### PR TITLE
Set executable flag before tar command

### DIFF
--- a/tools/create_artifacts.sh
+++ b/tools/create_artifacts.sh
@@ -37,6 +37,7 @@ ANK_BIN_DIR="${DIST_DIR}/bin"
 RELEASE_FILE_NAME_BASE="ankaios-${RELEASE_ARCHITECTURE}"
 
 echo "Creating the archive for '$RELEASE_FILE_NAME_BASE'"
+chmod +x "${ANK_BIN_DIR}"/ank{,-server,-agent}
 cd "${DIST_DIR}"
 tar -cvzf "${RELEASE_FILE_NAME_BASE}".tar.gz --directory=${ANK_BIN_DIR} $(ls "${ANK_BIN_DIR}")
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -126,6 +126,5 @@ fi
 
 echo "Extracting the binaries into install folder: '${BIN_DESTINATION}'"
 ${PREFIX} tar -xvzf "${RELEASE_FILE_NAME}" -C "${BIN_DESTINATION}"
-${PREFIX} chmod +x "${BIN_DESTINATION}"/ank{,-agent,-server}
 
 echo "Installation has finished."


### PR DESCRIPTION
Set the executable flag with chmod before binaries are placed into the tar.gz.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [ ] documentation of all modules `/*/doc/swdesign` is up-to-date
- [ ] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [ ] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/development/unit-verification/)

