### PR TITLE
Improve config file handling

### DIFF
--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -26,7 +26,7 @@ pub fn parse() -> Arguments {
         about="Ankaios - your friendly automotive workload orchestrator.\nWhat can the server do for you?")]
 pub struct Arguments {
     #[clap(short = 'c', long = "startup-config")]
-    /// The path to the startup config yaml.
+    /// The path to the startup configuration file in yaml format.
     pub path: String,
     #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap())]
     /// The address, including the port, the server shall listen at.


### PR DESCRIPTION
<!--  Description of the change in case no issue is mentioned -->
- In case the startup configuration file cannot be read/parsed, print out an error and return without `panic`ing as this is a handled error
- Write more clear error message for most common failure: file not found (and wrong file type)
- Write message to `log`
- Slightly rephrase description of "--startup-config" option


# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [x] documentation of all modules `/*/doc/swdesign` is up-to-date
- [x] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [x] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/development/unit-verification/)

