### PR TITLE
Add final result to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,3 +34,7 @@ assignees: ''
 
 ## Additional Information
 <!-- Please provide any additional information that may be helpful in understanding the issue. -->
+
+## Final result
+
+**To be filled by the one closing the issue.**

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -19,7 +19,7 @@ assignees: ''
 
 ### Summary
 
-**To be filled when final solution is sketched.**
+**To be filled when the final solution is sketched.**
 
 ### Tasks
 

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -15,7 +15,13 @@ assignees: ''
 
 <!-- describe the goals you want to achieve with this enhancement -->
 
-## Tasks
+## Final result
+
+### Summary
+
+**To be filled when final solution is sketched.**
+
+### Tasks
 
 <!--
 An optional lists of tasks that need to be executed


### PR DESCRIPTION
When reading issues with a lof of comments it is hard to find the final result. This change adds a "Final result"  to the description field which has to be filled when the issues is closed or the solution is clear.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [x] documentation of all modules `/*/doc/swdesign` is up-to-date
- [x] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [x] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/development/unit-verification/)

