### PR TITLE
Allow command entry in Podman RuntimeConfig to overrides image's entrypoint - preparations

### DIFF
--- a/agent/src/podman/mod.rs
+++ b/agent/src/podman/mod.rs
@@ -13,8 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod podman_adapter;
-mod workload;
+mod podman_runtime_config;
 mod podman_utils;
+mod workload;
 pub use podman_adapter::PodmanAdapter;
 
 #[cfg(test)]

--- a/agent/src/podman/podman_runtime_config.rs
+++ b/agent/src/podman/podman_runtime_config.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use common::objects::WorkloadSpec;
-use podman_api::models::PortMapping;
 
 use crate::workload_trait::WorkloadError;
 
@@ -23,20 +22,8 @@ pub struct PodmanRuntimeConfig {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Mapping {
-    container_port: String,
-    host_port: String,
-}
-
-pub fn convert_to_port_mapping(item: &[Mapping]) -> Vec<PortMapping> {
-    item.iter()
-        .map(|value| PortMapping {
-            container_port: value.container_port.parse::<u16>().ok(),
-            host_port: value.host_port.parse::<u16>().ok(),
-            host_ip: None,
-            protocol: None,
-            range: None,
-        })
-        .collect()
+    pub container_port: String,
+    pub host_port: String,
 }
 
 impl PodmanRuntimeConfig {

--- a/agent/src/podman/podman_runtime_config.rs
+++ b/agent/src/podman/podman_runtime_config.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use common::objects::WorkloadSpec;
+use podman_api::models::PortMapping;
+
+use crate::workload_trait::WorkloadError;
+
+#[derive(Debug, serde::Deserialize)]
+pub struct PodmanRuntimeConfig {
+    pub image: String,
+    #[serde(default)]
+    command: Vec<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    #[serde(default)]
+    pub ports: Vec<Mapping>,
+    #[serde(default)]
+    pub remove: bool,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Mapping {
+    container_port: String,
+    host_port: String,
+}
+
+pub fn convert_to_port_mapping(item: &[Mapping]) -> Vec<PortMapping> {
+    item.iter()
+        .map(|value| PortMapping {
+            container_port: value.container_port.parse::<u16>().ok(),
+            host_port: value.host_port.parse::<u16>().ok(),
+            host_ip: None,
+            protocol: None,
+            range: None,
+        })
+        .collect()
+}
+
+impl PodmanRuntimeConfig {
+    pub fn get_command_with_args(&self) -> Vec<String> {
+        let mut command = vec![];
+        command.extend(self.command.iter().cloned());
+        command.extend(self.args.iter().cloned());
+        command
+    }
+}
+
+#[derive(Debug)]
+pub struct TryFromWorkloadSpecError(String);
+
+impl TryFrom<&WorkloadSpec> for PodmanRuntimeConfig {
+    type Error = TryFromWorkloadSpecError;
+    fn try_from(workload_spec: &WorkloadSpec) -> Result<Self, Self::Error> {
+        match serde_yaml::from_str(workload_spec.workload.runtime_config.as_str()) {
+            Ok(workload_cfg) => Ok(workload_cfg),
+            Err(e) => Err(TryFromWorkloadSpecError(e.to_string())),
+        }
+    }
+}
+
+impl From<TryFromWorkloadSpecError> for WorkloadError {
+    fn from(value: TryFromWorkloadSpecError) -> Self {
+        WorkloadError::StartError(value.0)
+    }
+}

--- a/agent/src/podman/podman_utils.rs
+++ b/agent/src/podman/podman_utils.rs
@@ -14,7 +14,6 @@
 
 use common::state_change_interface::StateChangeInterface;
 use common::state_change_interface::StateChangeSender;
-use podman_api::models;
 use podman_api::models::ContainerMount;
 use podman_api::models::ListContainer;
 use podman_api::opts::ContainerCreateOpts;
@@ -50,13 +49,22 @@ const STATUS_CHECK_INTERVAL_MS: u64 = 1000;
 const API_PIPES_MOUNT_POINT: &str = "/run/ankaios/control_interface";
 const BIND_MOUNT: &str = "bind";
 
-pub struct PodmanUtils {}
+#[derive(Debug)]
+pub struct PodmanUtils {
+    podman: Podman,
+}
 
 #[cfg_attr(test, automock)]
 impl PodmanUtils {
+    pub fn new(socket_path: String) -> Self {
+        Self {
+            podman: Podman::unix(socket_path.as_str()),
+        }
+    }
+
     pub async fn check_status(
+        &self,
         manager_interface: StateChangeSender,
-        podman: Podman,
         agent_name: String,
         workload_name: String,
         container_id: String,
@@ -66,7 +74,7 @@ impl PodmanUtils {
         let mut interval = time::interval(Duration::from_millis(STATUS_CHECK_INTERVAL_MS));
         loop {
             interval.tick().await;
-            let current_state = PodmanUtils::get_status(&podman, &container_id).await;
+            let current_state = self.get_status(&container_id).await;
 
             if current_state != last_state {
                 log::info!(
@@ -94,10 +102,11 @@ impl PodmanUtils {
 
     // [impl->swdd~podman-workload-state~1]
     // [impl->swdd~podman-workload-maps-state~1]
-    async fn get_status(podman: &Podman, container_id: &str) -> ExecutionState {
+    async fn get_status(&self, container_id: &str) -> ExecutionState {
         let mut ret_state = ExecutionState::ExecUnknown;
 
-        match podman
+        match self
+            .podman
             .containers()
             .list(
                 &ContainerListOpts::builder()
@@ -163,25 +172,21 @@ impl PodmanUtils {
         }
     }
 
-    pub async fn list_images(
-        podman: &Podman,
-        image_name: &str,
-    ) -> podman_api::Result<Vec<models::LibpodImageSummary>> {
-        podman
+    pub async fn has_image(&self, image_name: &str) -> podman_api::Result<bool> {
+        let list = self
+            .podman
             .images()
             .list(
                 &ImageListOpts::builder()
                     .filter(vec![ImageListFilter::Reference(image_name.into(), None)])
                     .build(),
             )
-            .await
+            .await?;
+        Ok(!list.is_empty())
     }
 
-    pub async fn list_containers(
-        podman: &Podman,
-        name_filter: &str,
-    ) -> podman_api::Result<Vec<ListContainer>> {
-        podman
+    async fn list_containers(&self, name_filter: &str) -> podman_api::Result<Vec<ListContainer>> {
+        self.podman
             .containers()
             .list(
                 &ContainerListOpts::builder()
@@ -192,32 +197,30 @@ impl PodmanUtils {
             .await
     }
 
-    pub async fn pull_image(
-        podman: &Podman,
-        image: &String,
-    ) -> Result<Vec<podman_api::models::LibpodImagesPullReport>, Error> {
+    pub async fn pull_image(&self, image: &String) -> Result<(), Error> {
         use futures_util::{StreamExt, TryStreamExt};
 
-        podman
+        self.podman
             .images()
             .pull(&PullOpts::builder().reference(image).build())
             .map(|report| {
                 report.and_then(|report| match report.error {
                     Some(error) => Err(Error::InvalidResponse(error)),
-                    None => Ok(report),
+                    None => Ok(()),
                 })
             })
-            .try_collect::<Vec<_>>()
+            .try_collect()
             .await
     }
 
     pub async fn create_container(
-        podman: &Podman,
+        &self,
         workload_cfg: PodmanRuntimeConfig,
         container_name: String,
         api_pipes_location: String,
-    ) -> podman_api::Result<models::ContainerCreateCreatedBody> {
-        podman
+    ) -> podman_api::Result<String> {
+        let result = self
+            .podman
             .containers()
             .create(
                 &ContainerCreateOpts::builder()
@@ -237,19 +240,24 @@ impl PodmanUtils {
                     .remove(workload_cfg.remove)
                     .build(),
             )
-            .await
+            .await?;
+        Ok(result.id)
     }
 
-    pub async fn stop_container(podman: &Podman, container_id: &str) -> podman_api::Result<()> {
-        podman
+    pub async fn start_container(&self, container_id: &str) -> podman_api::Result<()> {
+        self.podman.containers().get(container_id).start(None).await
+    }
+
+    pub async fn stop_container(&self, container_id: &str) -> podman_api::Result<()> {
+        self.podman
             .containers()
             .get(container_id)
             .stop(&ContainerStopOpts::default())
             .await
     }
 
-    pub async fn delete_container(podman: &Podman, container_id: &str) -> podman_api::Result<()> {
-        podman
+    pub async fn delete_container(&self, container_id: &str) -> podman_api::Result<()> {
+        self.podman
             .containers()
             .get(container_id)
             .delete(&ContainerDeleteOpts::builder().volumes(true).build())
@@ -257,15 +265,15 @@ impl PodmanUtils {
     }
 
     pub fn remove_containers(
-        podman: &Podman,
+        socket_path: &str,
         instance_map: HashMap<String, (WorkloadExecutionInstanceName, String)>,
     ) {
         for (_, (_, container_id)) in instance_map {
-            let podman = podman.clone();
+            let podman_utils = PodmanUtils::new(socket_path.to_string());
             tokio::spawn(async move {
                 if let Err(err) = (|| async {
-                    PodmanUtils::stop_container(&podman, &container_id).await?;
-                    PodmanUtils::delete_container(&podman, &container_id).await?;
+                    podman_utils.stop_container(&container_id).await?;
+                    podman_utils.delete_container(&container_id).await?;
                     podman_api::Result::Ok(())
                 })()
                 .await
@@ -280,14 +288,16 @@ impl PodmanUtils {
 
     // [impl->swdd~agent-adapter-start-finds-existing-workloads~1]
     pub async fn list_running_workloads(
-        podman: &Podman,
+        socket_path: &str,
         agent_name: &str,
     ) -> HashMap<String, (WorkloadExecutionInstanceName, String)> {
         let mut running_workloads = HashMap::new();
 
         let name_filter = WorkloadExecutionInstanceName::get_agent_filter_regex(agent_name);
 
-        match PodmanUtils::list_containers(podman, &name_filter).await {
+        let podman_utils = PodmanUtils::new(socket_path.to_string());
+
+        match podman_utils.list_containers(&name_filter).await {
             Ok(container_list) => {
                 for container in container_list {
                     if let Some(instance_name) =
@@ -375,7 +385,6 @@ mod tests {
 
     use common::objects::ExecutionState;
     use hyper::StatusCode;
-    use podman_api::Podman;
 
     use crate::podman::{
         podman_utils::{
@@ -386,8 +395,8 @@ mod tests {
         },
         test_utils::{
             request_handlers::{
-                handler_helpers::*, ErrorResponseRequestHandler, ListContainerRequestHandler,
-                RequestHandler, WithRequestHandlerParameter,
+                handler_helpers::*, BasicRequestHandler, ErrorResponseRequestHandler,
+                ListContainerRequestHandler, RequestHandler, WithRequestHandlerParameter,
             },
             server_models::ServerListContainer,
             test_daemon::PodmanTestDaemon,
@@ -417,11 +426,9 @@ mod tests {
         let request_handlers = vec![Box::new(handler) as Box<dyn RequestHandler + Sync + Send>];
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
 
-        let result = PodmanUtils::list_containers(&podman, ".agent_1")
-            .await
-            .unwrap();
+        let result = podman_utils.list_containers(".agent_1").await.unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].names, Some(container_names));
 
@@ -443,8 +450,10 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        let status = PodmanUtils::get_status(&podman, &String::from("test_workload")).await;
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
+        let status = podman_utils
+            .get_status(&String::from("test_workload"))
+            .await;
         assert_eq!(status, ExecutionState::ExecUnknown);
 
         test_daemon.check_calls_and_stop();
@@ -463,9 +472,11 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
         assert_eq!(
-            PodmanUtils::get_status(&podman, &String::from("test_workload")).await,
+            podman_utils
+                .get_status(&String::from("test_workload"))
+                .await,
             ExecutionState::ExecUnknown
         );
 
@@ -482,9 +493,11 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
         assert_eq!(
-            PodmanUtils::get_status(&podman, &String::from("test_workload")).await,
+            podman_utils
+                .get_status(&String::from("test_workload"))
+                .await,
             ExecutionState::ExecRemoved
         );
 
@@ -504,9 +517,11 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
         assert_eq!(
-            PodmanUtils::get_status(&podman, &String::from("test_workload")).await,
+            podman_utils
+                .get_status(&String::from("test_workload"))
+                .await,
             ExecutionState::ExecUnknown
         );
 
@@ -528,9 +543,11 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
         assert_eq!(
-            PodmanUtils::get_status(&podman, &String::from("test_workload")).await,
+            podman_utils
+                .get_status(&String::from("test_workload"))
+                .await,
             ExecutionState::ExecUnknown
         );
 
@@ -541,9 +558,11 @@ mod tests {
     async fn utest_status_get_no_connetion_to_socket() {
         let _ = env_logger::builder().is_test(true).try_init();
 
-        let podman = Podman::unix(String::from("/not/running/socket"));
+        let podman_utils = PodmanUtils::new(String::from("/not/running/socket"));
         assert_eq!(
-            PodmanUtils::get_status(&podman, &String::from("test_workload")).await,
+            podman_utils
+                .get_status(&String::from("test_workload"))
+                .await,
             ExecutionState::ExecUnknown
         );
     }
@@ -554,10 +573,8 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(vec![stop_success_handler(CONTAINER_ID)]).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        assert!(PodmanUtils::stop_container(&podman, CONTAINER_ID)
-            .await
-            .is_ok());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
+        assert!(podman_utils.stop_container(CONTAINER_ID).await.is_ok());
 
         test_daemon.check_calls_and_stop();
     }
@@ -568,10 +585,8 @@ mod tests {
 
         let test_daemon = PodmanTestDaemon::create(vec![stop_error_handler(CONTAINER_ID)]).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        assert!(PodmanUtils::stop_container(&podman, CONTAINER_ID)
-            .await
-            .is_err());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
+        assert!(podman_utils.stop_container(CONTAINER_ID).await.is_err());
 
         test_daemon.check_calls_and_stop();
     }
@@ -583,10 +598,8 @@ mod tests {
         let mut test_daemon =
             PodmanTestDaemon::create(vec![delete_success_handler(CONTAINER_ID)]).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        assert!(PodmanUtils::delete_container(&podman, CONTAINER_ID)
-            .await
-            .is_ok());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
+        assert!(podman_utils.delete_container(CONTAINER_ID).await.is_ok());
 
         test_daemon.wait_expected_requests_done().await;
 
@@ -600,10 +613,8 @@ mod tests {
         let mut test_daemon =
             PodmanTestDaemon::create(vec![delete_error_handler(CONTAINER_ID)]).await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        assert!(PodmanUtils::delete_container(&podman, CONTAINER_ID)
-            .await
-            .is_err());
+        let podman_utils = PodmanUtils::new(test_daemon.socket_path.clone());
+        assert!(podman_utils.delete_container(CONTAINER_ID).await.is_err());
 
         test_daemon.wait_expected_requests_done().await;
 
@@ -636,8 +647,7 @@ mod tests {
         ])
         .await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        PodmanUtils::remove_containers(&podman, unneeded_workloads);
+        PodmanUtils::remove_containers(test_daemon.socket_path.as_str(), unneeded_workloads);
 
         test_daemon.wait_expected_requests_done().await;
 
@@ -670,8 +680,7 @@ mod tests {
         ])
         .await;
 
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
-        PodmanUtils::remove_containers(&podman, unneeded_workloads);
+        PodmanUtils::remove_containers(test_daemon.socket_path.as_str(), unneeded_workloads);
 
         test_daemon.wait_expected_requests_done().await;
 
@@ -838,10 +847,12 @@ mod tests {
         let request_handlers = vec![Box::new(handler) as Box<dyn RequestHandler + Sync + Send>];
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
 
-        let running_workloads =
-            PodmanUtils::list_running_workloads(&podman, expected_agent.as_str()).await;
+        let running_workloads = PodmanUtils::list_running_workloads(
+            test_daemon.socket_path.as_str(),
+            expected_agent.as_str(),
+        )
+        .await;
 
         assert_eq!(running_workloads.len(), 1);
         let (workload_instance_name, container_id) =
@@ -869,10 +880,12 @@ mod tests {
         let request_handlers = vec![Box::new(handler) as Box<dyn RequestHandler + Sync + Send>];
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
 
-        let running_workloads =
-            PodmanUtils::list_running_workloads(&podman, expected_agent.as_str()).await;
+        let running_workloads = PodmanUtils::list_running_workloads(
+            test_daemon.socket_path.as_str(),
+            expected_agent.as_str(),
+        )
+        .await;
         assert!(running_workloads.is_empty());
         test_daemon.check_calls_and_stop();
     }
@@ -894,11 +907,13 @@ mod tests {
         let request_handlers = vec![Box::new(handler) as Box<dyn RequestHandler + Sync + Send>];
 
         let test_daemon = PodmanTestDaemon::create(request_handlers).await;
-        let podman = Podman::unix(test_daemon.socket_path.as_str());
 
         let expected_agent = "agent_1".to_string();
-        let running_workloads =
-            PodmanUtils::list_running_workloads(&podman, expected_agent.as_str()).await;
+        let running_workloads = PodmanUtils::list_running_workloads(
+            test_daemon.socket_path.as_str(),
+            expected_agent.as_str(),
+        )
+        .await;
         assert!(running_workloads.is_empty());
         test_daemon.check_calls_and_stop();
     }

--- a/agent/src/podman/podman_utils.rs
+++ b/agent/src/podman/podman_utils.rs
@@ -395,8 +395,8 @@ mod tests {
         },
         test_utils::{
             request_handlers::{
-                handler_helpers::*, BasicRequestHandler, ErrorResponseRequestHandler,
-                ListContainerRequestHandler, RequestHandler, WithRequestHandlerParameter,
+                handler_helpers::*, ErrorResponseRequestHandler, ListContainerRequestHandler,
+                RequestHandler, WithRequestHandlerParameter,
             },
             server_models::ServerListContainer,
             test_daemon::PodmanTestDaemon,

--- a/agent/src/podman/workload.rs
+++ b/agent/src/podman/workload.rs
@@ -26,9 +26,6 @@ use crate::podman::podman_runtime_config::PodmanRuntimeConfig;
 use crate::workload_trait::{Workload, WorkloadError};
 use common::objects::{WorkloadExecutionInstanceName, WorkloadInstanceName};
 
-#[cfg(test)]
-use crate::podman::podman_utils::MockPodmanUtils as PodmanUtils;
-#[cfg(not(test))]
 use crate::podman::podman_utils::PodmanUtils;
 
 #[cfg(test)]

--- a/agent/src/podman/workload.rs
+++ b/agent/src/podman/workload.rs
@@ -22,25 +22,25 @@ use podman_api::Error;
 use std::path::{Path, PathBuf};
 use tokio::task::JoinHandle;
 
-use podman_api::Podman;
-
 use crate::podman::podman_runtime_config::PodmanRuntimeConfig;
-use crate::podman::podman_utils::PodmanUtils;
 use crate::workload_trait::{Workload, WorkloadError};
 use common::objects::{WorkloadExecutionInstanceName, WorkloadInstanceName};
 
 #[cfg(test)]
-use mockall::automock;
+use crate::podman::podman_utils::MockPodmanUtils as PodmanUtils;
+#[cfg(not(test))]
+use crate::podman::podman_utils::PodmanUtils;
 
-const API_PIPES_MOUNT_POINT: &str = "/run/ankaios/control_interface";
-const BIND_MOUNT: &str = "bind";
+#[cfg(test)]
+use mockall::automock;
 
 #[derive(Debug)]
 pub struct PodmanWorkload {
     manager_interface: StateChangeSender,
-    podman: Podman,
     workload_spec: WorkloadSpec,
     api_pipes_location: PathBuf,
+    podman_utils: PodmanUtils,
+    socket_path: String,
 }
 
 #[derive(Debug)]
@@ -64,10 +64,10 @@ impl PodmanWorkload {
     ) -> Self {
         Self {
             manager_interface,
-            podman: Podman::unix(socket_path.as_str()),
-
             api_pipes_location: workload_spec.instance_name().pipes_folder_name(run_folder),
             workload_spec,
+            podman_utils: PodmanUtils::new(socket_path.clone()),
+            socket_path,
         }
     }
 
@@ -106,27 +106,32 @@ impl PodmanWorkload {
         })?;
 
         if !has_image {
-            self.pull_image(&workload_cfg.image).await.map_err(|e| {
-                WorkloadError::StartError(format!(
-                    "Could not pull the podman image '{}': {}",
-                    workload_cfg.image, e
-                ))
-            })?;
+            // [impl->swdd~podman-workload-pulls-container~2]]
+            self.podman_utils
+                .pull_image(&workload_cfg.image)
+                .await
+                .map_err(|e| {
+                    WorkloadError::StartError(format!(
+                        "Could not pull the podman image '{}': {}",
+                        workload_cfg.image, e
+                    ))
+                })?;
         }
 
         // [impl->swdd~podman-workload-creates-container~1]
         // [impl->swdd~podman-adapt-mount-interface-pipes-into-workload~2]
-        match PodmanUtils::create_container(
-            &self.podman,
-            workload_cfg,
-            self.workload_spec.instance_name().to_string(),
-            self.api_pipes_location.to_string_lossy().to_string(),
-        )
-        .await
+        match self
+            .podman_utils
+            .create_container(
+                workload_cfg,
+                self.workload_spec.instance_name().to_string(),
+                self.api_pipes_location.to_string_lossy().to_string(),
+            )
+            .await
         {
-            Ok(result) => {
+            Ok(id) => {
                 // [impl->swdd~podman-workload-stores-container-id~1]
-                Ok(result.id)
+                Ok(id)
             }
             Err(e) => Err(WorkloadError::StartError(format!(
                 "Could not create the podman container. Error: '{}'",
@@ -136,22 +141,13 @@ impl PodmanWorkload {
     }
 
     async fn has_image(&self, image: &str) -> Result<bool, Error> {
-        let list = PodmanUtils::list_images(&self.podman, image).await?;
-        Ok(!list.is_empty())
-    }
-
-    // [impl->swdd~podman-workload-pulls-container~2]]
-    async fn pull_image(
-        &self,
-        image: &String,
-    ) -> Result<Vec<podman_api::models::LibpodImagesPullReport>, Error> {
-        PodmanUtils::pull_image(&self.podman, image).await
+        self.podman_utils.has_image(image).await
     }
 
     // [impl->swdd~podman-workload-monitors-workload-state~1]
     // [impl->swdd~podman-workload-starts-container~1]
     async fn start_container(&self, container_id: &str) -> Result<JoinHandle<()>, WorkloadError> {
-        if let Err(e) = self.podman.containers().get(container_id).start(None).await {
+        if let Err(e) = self.podman_utils.start_container(container_id).await {
             Err(WorkloadError::StartError(format!(
                 "Error starting the container '{}': '{}'",
                 self.workload_spec.instance_name(),
@@ -164,7 +160,6 @@ impl PodmanWorkload {
 
     fn watch_container(&self, container_id: String) -> JoinHandle<()> {
         let manager_interface_clone = self.manager_interface.clone();
-        let podman_clone = self.podman.clone();
         let agent_name_clone = self.workload_spec.instance_name().agent_name().to_string();
         let workload_name_clone = self
             .workload_spec
@@ -172,25 +167,26 @@ impl PodmanWorkload {
             .workload_name()
             .to_string();
 
+        let podman_utils = PodmanUtils::new(self.socket_path.to_string());
         tokio::spawn(async move {
-            PodmanUtils::check_status(
-                manager_interface_clone,
-                podman_clone,
-                agent_name_clone,
-                workload_name_clone,
-                container_id,
-            )
-            .await
+            podman_utils
+                .check_status(
+                    manager_interface_clone,
+                    agent_name_clone,
+                    workload_name_clone,
+                    container_id,
+                )
+                .await
         })
     }
 
     // [impl->swdd~podman-workload-stops-container~1]
     async fn stop_container(
-        podman: &Podman,
+        &self,
         instance_name: &WorkloadExecutionInstanceName,
         container_id: &str,
     ) -> Result<(), WorkloadError> {
-        match PodmanUtils::stop_container(podman, container_id).await {
+        match self.podman_utils.stop_container(container_id).await {
             Ok(()) => {
                 log::debug!("Successfully stopped container '{}'.", instance_name);
                 Ok(())
@@ -226,12 +222,12 @@ impl PodmanWorkload {
 
     // [impl->swdd~podman-workload-deletes-container~1]
     async fn delete_container(
-        podman: &Podman,
+        &self,
         instance_name: &WorkloadExecutionInstanceName,
         container_id: &str,
         manager_interface: &StateChangeSender,
     ) -> Result<(), WorkloadError> {
-        match PodmanUtils::delete_container(podman, container_id).await {
+        match self.podman_utils.delete_container(container_id).await {
             Ok(()) => {
                 log::debug!("Successfully deleted container '{}'.", instance_name);
                 manager_interface
@@ -284,9 +280,9 @@ impl Workload for PodmanWorkload {
         existing_instance_name: WorkloadExecutionInstanceName,
         existing_id: Self::Id,
     ) -> Result<Self::State, WorkloadError> {
-        Self::stop_container(&self.podman, &existing_instance_name, &existing_id).await?;
-        Self::delete_container(
-            &self.podman,
+        self.stop_container(&existing_instance_name, &existing_id)
+            .await?;
+        self.delete_container(
             &existing_instance_name,
             &existing_id,
             &self.manager_interface,
@@ -297,14 +293,12 @@ impl Workload for PodmanWorkload {
     }
 
     async fn delete(&mut self, running_state: PodmanWorkloadState) -> Result<(), WorkloadError> {
-        Self::stop_container(
-            &self.podman,
+        self.stop_container(
             &self.workload_spec.instance_name(),
             &running_state.container_id,
         )
         .await?;
-        Self::delete_container(
-            &self.podman,
+        self.delete_container(
             &self.workload_spec.instance_name(),
             &running_state.container_id,
             &self.manager_interface,
@@ -402,6 +396,8 @@ mod tests {
     const API_PIPES_LOCATION: &str = "/api/pipes/location/workload_name.29b6a7ccff50ffc4dac58ad64c837888584fb121d7ef72c059205e5d29b9c901";
     const CONTAINER_ID: &str = "testid";
     const TEST_TIMEOUT: u64 = 100;
+    const API_PIPES_MOUNT_POINT: &str = "/run/ankaios/control_interface";
+    const BIND_MOUNT: &str = "bind";
 
     #[tokio::test()]
     async fn utest_workload_name() {
@@ -957,11 +953,9 @@ mod tests {
                         let mount_type = mount.get("type")?.as_str()?;
 
                         assert_eq!(
-                            destination,
-                            super::API_PIPES_MOUNT_POINT,
+                            destination, API_PIPES_MOUNT_POINT,
                             "Expected destination to be \"{}\", got \"{}\"",
-                            super::API_PIPES_MOUNT_POINT,
-                            destination
+                            API_PIPES_MOUNT_POINT, destination
                         );
                         assert_eq!(
                             source, API_PIPES_LOCATION,
@@ -969,11 +963,9 @@ mod tests {
                             API_PIPES_LOCATION, source
                         );
                         assert_eq!(
-                            mount_type,
-                            super::BIND_MOUNT,
+                            mount_type, BIND_MOUNT,
                             "Expected type to be \"{}\", got \"{}\"",
-                            super::BIND_MOUNT,
-                            mount_type
+                            BIND_MOUNT, mount_type
                         );
 
                         Some(())


### PR DESCRIPTION
Issues: #24 

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [x] documentation of all modules `/*/doc/swdesign` is up-to-date
- [x] requirements are up-to-date and requirements for new features have been added and mapped to source and test - This will be fixed in the issue #1 
- [x] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/development/unit-verification/) - This will be fixed in the issue #1 

