### PR TITLE
Add basic Makefile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+
 [workspace]
 
 members = [

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := build
+
+.PHONY:build
+release: check-env
+	cargo build -v --release
+
+build: check-env
+	cargo build
+
+test: check-env
+	cargo install cargo-nextest --locked
+	cargo nextest run
+
+check-env:
+	if [ ! -f /usr/bin/protoc ] ; \
+	then \
+	    echo "\nERROR: Protobuf compiler needs to be installed"; \
+	    echo "       Debian/Ubuntu: install \"protobuf-compiler\"\n"; \
+	    exit 1; \
+	fi;


### PR DESCRIPTION
Add Makefile for:
- Run tests with a faster and better runner
- Check required environment
- Better integration (future) with packaging routines