### PR TITLE
Change default port

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -13,13 +13,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub const CHANNEL_CAPACITY: usize = 20;
-pub const DEFAULT_SOCKET_ADDRESS: &str = "127.0.0.1:50051";
-pub const DEFAULT_SERVER_ADDRESS: &str = "http://127.0.0.1:50051";
+pub const DEFAULT_SOCKET_ADDRESS: &str = "127.0.0.1:25551";
+pub const DEFAULT_SERVER_ADDRESS: &str = "http://127.0.0.1:25551";
 
 pub mod commands;
 pub mod communications_client;
-pub mod communications_server;
 pub mod communications_error;
+pub mod communications_server;
 pub mod execution_interface;
 pub mod helpers;
 pub mod objects;

--- a/grpc/tests/grpc_test.rs
+++ b/grpc/tests/grpc_test.rs
@@ -6,9 +6,10 @@ mod grpc_tests {
     use common::{
         commands::{self, CompleteState, RequestCompleteState},
         communications_client::CommunicationsClient,
+        communications_error::CommunicationMiddlewareError,
         communications_server::CommunicationsServer,
         execution_interface::ExecutionCommand,
-        state_change_interface::{StateChangeCommand, StateChangeInterface}, communications_error::CommunicationMiddlewareError,
+        state_change_interface::{StateChangeCommand, StateChangeInterface},
     };
     use grpc::{client::GRPCCommunicationsClient, server::GRPCCommunicationsServer};
 
@@ -112,7 +113,7 @@ mod grpc_tests {
     ) {
         let test_request_id = "test_request_id";
         let (to_grpc_client, mut server_receiver, _, _) =
-            generate_test_grpc_communication_setup(50051, CommunicationType::Cli, test_request_id)
+            generate_test_grpc_communication_setup(25551, CommunicationType::Cli, test_request_id)
                 .await;
 
         // send request to grpc client


### PR DESCRIPTION
Issues: #64 

Changes:
- changed port to 25551

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [x] documentation of all modules `/*/doc/swdesign` is up-to-date
- [x] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [x] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/main/development/unit-verification/)

