### PR TITLE
Fix documentation workflow block of PRs and add names to jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:      
   test_and_build_linux_amd64:
+    name: Test and Build Linux amd64
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.6.3
@@ -19,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.3
       - uses: Swatinem/rust-cache@v2.6.2
-      
+
       - name: Run tests
         run: RUST_LOG=debug cargo nextest run
 
@@ -66,6 +67,7 @@ jobs:
     # requesting the support for arm64: https://github.com/actions/runner-images/issues/5631
     # if arm64 variants will be released we can switch to an arm64 image and save the longer built time for cross platform build
     # and in addition, tests for arm64 can be enabled in this job, too
+    name: Build Linux arm64
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.6.3
@@ -92,6 +94,7 @@ jobs:
           path: target/aarch64-unknown-linux-gnu/debian/ankaios*.deb
 
   requirements:
+    name: Build Requirements Tracing
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.6.3

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,28 +3,39 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'doc/**'
-      - 'api/proto/**'
-      - '.github/workflows/documentation.yml'
   pull_request:
-    paths:
-      - 'doc/**'
-      - 'api/proto/**'
-      - '.github/workflows/documentation.yml'
   workflow_dispatch:
   workflow_call:
 
 permissions:
   contents: write
 jobs:
+  documentation_changes:
+    name: Check If Documentation Changed
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      documentation: ${{ steps.filter.outputs.documentation }}
+    steps:
+    - uses: actions/checkout@v3.5.3
+    - uses: dorny/paths-filter@v2.11.1
+      id: filter
+      with:
+        filters: |
+          documentation:
+              - 'doc/**'
+              - 'api/proto/**'
+              - '.github/workflows/documentation.yml'
   deploy:
+    name: Deploy Documentation
+    needs: documentation_changes
+    if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.6.3
     steps:
       - uses: actions/checkout@v3.5.3
-
       - name: Prepare commit to branch gh-pages
         run: |
             git config --global --add safe.directory $PWD

--- a/.github/workflows/task-list-check.yml
+++ b/.github/workflows/task-list-check.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   verify:
-    name: verify_pr_task_list
+    name: Verify PR Task List
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Issues: #71 

<!--  Description of the change in case no issue is mentioned -->
- moves the path filter of the workflow trigger to a job conditional (because job conditionals do not mark a GH workflow as pending or failed if they skip the job)

- adds names to the GH action jobs

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [ ] documentation of all modules `/*/doc/swdesign` is up-to-date
- [ ] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [ ] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/main/development/unit-verification/)

