### PR TITLE
Add support for environment variables for server socket and server url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,13 +341,16 @@ version = "0.1.0"
 dependencies = [
  "api",
  "async-trait",
+ "clap",
  "common",
  "log",
+ "mockall",
  "serde",
  "serde_yaml",
  "sha256",
  "tokio",
  "tokio-stream",
+ "url",
 ]
 
 [[package]]

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1"
 podman-api = { version = "0.10", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 futures-util = "0.3"
 rand = "0.8"
 hyper = { version = "0.14", features = ["full"] }

--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -80,17 +80,48 @@ The following diagram shows the startup sequence of the Ankaios Agent:
 
 Status: approved
 
-The Ankaios Agent shall use the given interfaces and channels to communicate with the Server.
+The Ankaios agent shall use the given interfaces and channels to communicate with the server.
 
 Tags:
 - AgentManager
 
-Rationale: The Server is "only source of true" and ensures that Agents are in the consistent state.
+Rationale: The server is "only source of true" and ensures that Agents are in the consistent state.
 
 Needs:
 - impl
 - itest
 
+#### Agent supports environment variable for the server url
+`swdd~agent-shall-support-environment-variable-for-server-url~1`
+
+Status: approved
+
+When the environment variable with key `ANKAIOS_SERVER_URL` is set and the user has not provided the server url via cli argument,
+the Ankaios agent shall use the server url from the environment variable to connect to the Ankaios server.
+
+Tags:
+- AnkaiosAgent
+
+Needs:
+- impl
+- utest
+- stest
+
+#### Agent prioritizes cli argument over environment variable
+`swdd~agent-prioritizes-cli-argument-over-environment-variable~1`
+
+Status: approved
+
+When an environment variable is set and the user specifies a value for the corresponding cli argument,
+the Ankaios agent shall use the value from the cli argument.
+
+Tags:
+- AnkaiosAgent
+
+Needs:
+- impl
+- utest
+- stest
 
 #### Agent sends hello
 `swdd~agent-sends-hello~1`

--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -34,6 +34,7 @@ pub struct Arguments {
     #[clap(short = 'n', long = "name")]
     /// The name to use for the registration with the server. Every agent has to register with a unique name.
     pub agent_name: String,
+    // [impl->swdd~agent-shall-support-environment-variable-for-server-url~1]
     #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap(), env = SERVER_URL_ENV_KEY, value_parser = ServerUrlParser)]
     /// The server url.
     pub server_url: Url,

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -22,7 +22,7 @@ assets = [
 api = { package = "api", version = "0", path = "../api" }
 common = { package = "common", version = "0.1", path = "../common" }
 grpc = { package = "grpc", version = "0.1", path = "../grpc" }
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 tokio = { version = "1.28", features = [
     "macros",
     "rt-multi-thread",

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -125,6 +125,38 @@ Needs:
 - impl
 - itest
 
+#### CLI supports environment variable for the server url
+`swdd~cli-shall-support-environment-variable-for-server-url~1`
+
+Status: approved
+
+When the environment variable with key `ANKAIOS_SERVER_URL` is set and the user has not provided the server url via cli argument,
+the Ankaios CLI shall use the server url from the environment variable to connect to the Ankaios server.
+
+Tags:
+- CliStartup
+
+Needs:
+- impl
+- utest
+- stest
+
+#### CLI prioritizes cli argument over environment variable
+`swdd~cli-prioritizes-cli-argument-over-environment-variable~1`
+
+Status: approved
+
+When an environment variable is set and the user specifies a value for the corresponding cli argument,
+the Ankaios CLI shall use the value from the cli argument.
+
+Tags:
+- CliStartup
+
+Needs:
+- impl
+- utest
+- stest
+
 #### CLI is a standalone application
 `swdd~cli-standalone-application~1`
 

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -12,70 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{error::Error, str::FromStr};
+use std::error::Error;
 
-use clap::{
-    command,
-    error::{ContextKind, ContextValue, ErrorKind},
-    Parser, Subcommand,
-};
+use clap::{command, Parser, Subcommand};
 
-use common::{DEFAULT_SERVER_ADDRESS, SERVER_URL_ENV_KEY};
+use common::{cli_utils::ServerUrlParser, DEFAULT_SERVER_ADDRESS, SERVER_URL_ENV_KEY};
 use url::Url;
-
-#[derive(Clone, Default)]
-/// Custom url parser as a workaround to Clap's bug about
-/// outputting the wrong error message context
-/// when using the environment variable and not the cli argument.
-/// When using a wrong value inside environment variable
-/// Clap still outputs that the cli argument was wrongly set,
-/// but not the environment variable. This is poor use-ability.
-/// An issue for this bug is already opened (https://github.com/clap-rs/clap/issues/5202).
-/// The code will be removed if the bug in Clap is fixed.
-struct ServerUrlParser;
-
-impl clap::builder::TypedValueParser for ServerUrlParser {
-    type Value = Url;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-        if let Some(arg) = arg {
-            if let Ok(env_var) = std::env::var(SERVER_URL_ENV_KEY) {
-                if env_var == value.to_string_lossy() {
-                    err.insert(
-                        ContextKind::InvalidArg,
-                        ContextValue::String(format!(
-                            "environment variable '{}'",
-                            SERVER_URL_ENV_KEY
-                        )),
-                    );
-                } else {
-                    err.insert(
-                        ContextKind::InvalidArg,
-                        ContextValue::String(arg.to_string()),
-                    );
-                }
-            } else {
-                err.insert(
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                );
-            }
-        }
-
-        err.insert(
-            ContextKind::InvalidValue,
-            ContextValue::String(value.to_str().unwrap().to_owned()),
-        );
-        let url = Url::from_str(value.to_str().unwrap()).map_err(|_| err)?;
-        Ok(url)
-    }
-}
 
 #[derive(Parser)] // requires `derive` feature
 #[command(name = "ank")]
@@ -85,7 +27,7 @@ impl clap::builder::TypedValueParser for ServerUrlParser {
 pub struct AnkCli {
     #[command(subcommand)]
     pub command: Commands,
-    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap(), env = SERVER_URL_ENV_KEY, value_parser = ServerUrlParser::default() )]
+    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap(), env = SERVER_URL_ENV_KEY, value_parser = ServerUrlParser)]
     /// The url to Ankaios server.
     pub server_url: Url,
     #[clap(long = "response-timeout", default_value_t = 3000)]

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -27,6 +27,7 @@ use url::Url;
 pub struct AnkCli {
     #[command(subcommand)]
     pub command: Commands,
+    // [impl->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap(), env = SERVER_URL_ENV_KEY, value_parser = ServerUrlParser)]
     /// The url to Ankaios server.
     pub server_url: Url,

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -22,10 +22,13 @@ tokio-stream = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 sha256 = "1.1"
+clap = { version = "4.0" }
+url = "2.3"
 
 [dev-dependencies]
 common = { features = ["test_utils"], path = "." }
 serde_yaml = "0.9"
+mockall = "0.11"
 
 [features]
 default = []

--- a/common/src/cli_utils.rs
+++ b/common/src/cli_utils.rs
@@ -11,6 +11,9 @@ fn create_error_context(
 ) -> clap::Error {
     let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd); // the order in which the errors are inserted is important
     if let Some(arg) = arg {
+        // [impl->swdd~agent-prioritizes-cli-argument-over-environment-variable~1]
+        // [impl->swdd~cli-prioritizes-cli-argument-over-environment-variable~1]
+        // [impl->swdd~server-prioritizes-cli-argument-over-environment-variable~1]
         if let Ok(env_value) = env::var(env_key) {
             if env_value == *arg_value {
                 err.insert(
@@ -127,6 +130,8 @@ mod tests {
         }
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[test]
     fn utest_cli_argument_server_url_use_cli_arg() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -141,6 +146,8 @@ mod tests {
         assert_eq!(actual_url, expected_url);
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[test]
     fn utest_cli_argument_server_url_use_env_var() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -157,6 +164,10 @@ mod tests {
         assert_eq!(actual_url, expected_url);
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~agent-prioritizes-cli-argument-over-environment-variable~1]
+    // [utest->swdd~cli-prioritizes-cli-argument-over-environment-variable~1]
     #[test]
     fn utest_cli_argument_server_url_prioritize_cli_arg() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -173,6 +184,8 @@ mod tests {
         assert_eq!(actual_url, expected_url);
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[test]
     fn utest_cli_argument_server_url_use_env_var_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -190,6 +203,8 @@ mod tests {
             .contains("environment variable"));
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[test]
     fn utest_cli_argument_server_url_use_cli_arg_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -201,6 +216,8 @@ mod tests {
         assert!(parsing_result.err().unwrap().to_string().contains(ARG_NAME));
     }
 
+    // [utest->swdd~agent-shall-support-environment-variable-for-server-url~1]
+    // [utest->swdd~cli-shall-support-environment-variable-for-server-url~1]
     #[test]
     fn utest_cli_argument_server_url_none_arg_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -212,6 +229,7 @@ mod tests {
         assert!(err.contains("invalid value for one of the arguments"));
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[test]
     fn utest_cli_argument_server_address_use_cli_arg() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -226,6 +244,7 @@ mod tests {
         assert_eq!(actual_socket_addr, expected_socket_addr);
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[test]
     fn utest_cli_argument_server_address_use_env_var() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -242,6 +261,8 @@ mod tests {
         assert_eq!(actual_socket_addr, expected_socket_addr);
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
+    // [utest->swdd~server-prioritizes-cli-argument-over-environment-variable~1]
     #[test]
     fn utest_cli_argument_server_address_prioritize_cli_arg() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -258,6 +279,7 @@ mod tests {
         assert_eq!(actual_socket_addr, expected_socket_addr);
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[test]
     fn utest_cli_argument_server_address_use_env_var_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -275,6 +297,7 @@ mod tests {
             .contains("environment variable"));
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[test]
     fn utest_cli_argument_server_address_use_cli_arg_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
@@ -286,6 +309,7 @@ mod tests {
         assert!(parsing_result.err().unwrap().to_string().contains(ARG_NAME));
     }
 
+    // [utest->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[test]
     fn utest_cli_argument_server_address_none_arg_error_context() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock();

--- a/common/src/cli_utils.rs
+++ b/common/src/cli_utils.rs
@@ -1,0 +1,299 @@
+use crate::{SERVER_ADDRESS_ENV_KEY, SERVER_URL_ENV_KEY};
+use clap::error::{ContextKind, ContextValue, ErrorKind};
+use std::{env, net::SocketAddr, str::FromStr};
+use url::Url;
+
+fn create_error_context(
+    cmd: &clap::Command,
+    env_key: &str,
+    arg: Option<&clap::Arg>,
+    arg_value: &String,
+) -> clap::Error {
+    let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd); // the order in which the errors are inserted is important
+    if let Some(arg) = arg {
+        if let Ok(env_value) = env::var(env_key) {
+            if env_value == *arg_value {
+                err.insert(
+                    ContextKind::InvalidArg,
+                    ContextValue::String(format!("environment variable '{}'", env_key)),
+                );
+            } else {
+                err.insert(
+                    ContextKind::InvalidArg,
+                    ContextValue::String(arg.to_string()),
+                );
+            }
+        } else {
+            err.insert(
+                ContextKind::InvalidArg,
+                ContextValue::String(arg.to_string()),
+            );
+        }
+    }
+
+    err.insert(
+        ContextKind::InvalidValue,
+        ContextValue::String(arg_value.clone()),
+    );
+    err
+}
+
+#[derive(Clone)]
+/// Custom url parser as a workaround to Clap's bug about
+/// outputting the wrong error message context
+/// when using the environment variable and not the cli argument.
+/// When using a wrong value inside environment variable
+/// Clap still outputs that the cli argument was wrongly set,
+/// but not the environment variable. This is poor use-ability.
+/// An issue for this bug is already opened (https://github.com/clap-rs/clap/issues/5202).
+/// The code will be removed if the bug in Clap is fixed.
+pub struct ServerUrlParser;
+
+impl clap::builder::TypedValueParser for ServerUrlParser {
+    type Value = Url;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let arg_value = value.to_string_lossy().to_string();
+        let err = create_error_context(cmd, SERVER_URL_ENV_KEY, arg, &arg_value);
+        let url = Url::from_str(&arg_value).map_err(|_| err)?;
+        Ok(url)
+    }
+}
+
+#[derive(Clone)]
+/// Custom url parser as a workaround to Clap's bug about
+/// outputting the wrong error message context
+/// when using the environment variable and not the cli argument.
+/// When using a wrong value inside environment variable
+/// Clap still outputs that the cli argument was wrongly set,
+/// but not the environment variable. This is poor use-ability.
+/// An issue for this bug is already opened (https://github.com/clap-rs/clap/issues/5202).
+/// The code will be removed if the bug in Clap is fixed.
+pub struct ServerAddressParser;
+
+impl clap::builder::TypedValueParser for ServerAddressParser {
+    type Value = SocketAddr;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let arg_value = value.to_string_lossy().to_string();
+        let err = create_error_context(cmd, SERVER_ADDRESS_ENV_KEY, arg, &arg_value);
+        let url = SocketAddr::from_str(&arg_value).map_err(|_| err)?;
+        Ok(url)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::builder::TypedValueParser;
+    use mockall::lazy_static;
+    use std::env;
+    use std::ffi::OsStr;
+    const INVALID_VALUE: &str = "invalid-value";
+    const PROGRAM_NAME: &str = "some program";
+    const ARG_NAME: &str = "arg";
+    const EXAMPLE_URL: &str = "http://0.0.0.0:11111";
+    const EXAMPLE_SOCKET_ADDRESS: &str = "0.0.0.0:11111";
+
+    lazy_static! {
+        pub static ref MOCKALL_CONTEXT_SYNC: common::test_utils::MockAllContextSync =
+            common::test_utils::MockAllContextSync::new();
+    }
+
+    struct CleanupEnv;
+
+    impl Drop for CleanupEnv {
+        fn drop(&mut self) {
+            env::remove_var(common::SERVER_URL_ENV_KEY);
+            env::remove_var(common::SERVER_ADDRESS_ENV_KEY);
+        }
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_use_cli_arg() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        let actual_url = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(crate::DEFAULT_SERVER_ADDRESS))
+            .unwrap();
+        let expected_url = Url::from_str(crate::DEFAULT_SERVER_ADDRESS).unwrap();
+        assert_eq!(actual_url, expected_url);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_use_env_var() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_URL_ENV_KEY, EXAMPLE_URL);
+        let actual_url = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(EXAMPLE_URL))
+            .unwrap();
+
+        let expected_url = Url::from_str(EXAMPLE_URL).unwrap();
+        assert_eq!(actual_url, expected_url);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_prioritize_cli_arg() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_URL_ENV_KEY, EXAMPLE_URL);
+        let actual_url = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(crate::DEFAULT_SERVER_ADDRESS))
+            .unwrap();
+
+        let expected_url = Url::from_str(crate::DEFAULT_SERVER_ADDRESS).unwrap();
+        assert_eq!(actual_url, expected_url);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_use_env_var_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_URL_ENV_KEY, INVALID_VALUE);
+        let parsing_result = url_parser.parse_ref(&cmd, Some(&arg), OsStr::new(INVALID_VALUE));
+
+        assert!(parsing_result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("environment variable"));
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_use_cli_arg_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        let parsing_result = url_parser.parse_ref(&cmd, Some(&arg), OsStr::new(INVALID_VALUE));
+        assert!(parsing_result.err().unwrap().to_string().contains(ARG_NAME));
+    }
+
+    #[test]
+    fn utest_cli_argument_server_url_none_arg_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerUrlParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let parsing_result = url_parser.parse_ref(&cmd, None, OsStr::new(INVALID_VALUE));
+        let err: String = parsing_result.err().unwrap().to_string();
+        assert!(err.contains("invalid value for one of the arguments"));
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_use_cli_arg() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        let actual_socket_addr = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(crate::DEFAULT_SOCKET_ADDRESS))
+            .unwrap();
+        let expected_socket_addr = SocketAddr::from_str(crate::DEFAULT_SOCKET_ADDRESS).unwrap();
+        assert_eq!(actual_socket_addr, expected_socket_addr);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_use_env_var() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_ADDRESS_ENV_KEY, EXAMPLE_SOCKET_ADDRESS);
+        let actual_socket_addr = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(EXAMPLE_SOCKET_ADDRESS))
+            .unwrap();
+
+        let expected_socket_addr = SocketAddr::from_str(EXAMPLE_SOCKET_ADDRESS).unwrap();
+        assert_eq!(actual_socket_addr, expected_socket_addr);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_prioritize_cli_arg() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_ADDRESS_ENV_KEY, EXAMPLE_SOCKET_ADDRESS);
+        let actual_socket_addr = url_parser
+            .parse_ref(&cmd, Some(&arg), OsStr::new(crate::DEFAULT_SOCKET_ADDRESS))
+            .unwrap();
+
+        let expected_socket_addr = SocketAddr::from_str(crate::DEFAULT_SOCKET_ADDRESS).unwrap();
+        assert_eq!(actual_socket_addr, expected_socket_addr);
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_use_env_var_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        std::env::set_var(crate::SERVER_ADDRESS_ENV_KEY, INVALID_VALUE);
+        let parsing_result = url_parser.parse_ref(&cmd, Some(&arg), OsStr::new(INVALID_VALUE));
+
+        assert!(parsing_result
+            .err()
+            .unwrap()
+            .to_string()
+            .contains("environment variable"));
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_use_cli_arg_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let arg = clap::Arg::new(ARG_NAME);
+        let parsing_result = url_parser.parse_ref(&cmd, Some(&arg), OsStr::new(INVALID_VALUE));
+        assert!(parsing_result.err().unwrap().to_string().contains(ARG_NAME));
+    }
+
+    #[test]
+    fn utest_cli_argument_server_address_none_arg_error_context() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock();
+        let _cleanup = CleanupEnv;
+        let url_parser = ServerAddressParser;
+        let cmd = clap::Command::new(PROGRAM_NAME);
+        let parsing_result = url_parser.parse_ref(&cmd, None, OsStr::new(INVALID_VALUE));
+        let err: String = parsing_result.err().unwrap().to_string();
+        assert!(err.contains("invalid value for one of the arguments"));
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,6 +15,7 @@
 pub const CHANNEL_CAPACITY: usize = 20;
 pub const DEFAULT_SOCKET_ADDRESS: &str = "127.0.0.1:25551";
 pub const DEFAULT_SERVER_ADDRESS: &str = "http://127.0.0.1:25551";
+pub const SERVER_SOCKET_ENV_KEY: &str = "ANKAIOS_SERVER_SOCKET";
 
 pub mod commands;
 pub mod communications_client;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -18,6 +18,7 @@ pub const DEFAULT_SERVER_ADDRESS: &str = "http://127.0.0.1:25551";
 pub const SERVER_URL_ENV_KEY: &str = "ANKAIOS_SERVER_URL";
 pub const SERVER_ADDRESS_ENV_KEY: &str = "ANKAIOS_SERVER_SOCKET";
 
+pub mod cli_utils;
 pub mod commands;
 pub mod communications_client;
 pub mod communications_error;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,7 +15,8 @@
 pub const CHANNEL_CAPACITY: usize = 20;
 pub const DEFAULT_SOCKET_ADDRESS: &str = "127.0.0.1:25551";
 pub const DEFAULT_SERVER_ADDRESS: &str = "http://127.0.0.1:25551";
-pub const SERVER_SOCKET_ENV_KEY: &str = "ANKAIOS_SERVER_SOCKET";
+pub const SERVER_URL_ENV_KEY: &str = "ANKAIOS_SERVER_URL";
+pub const SERVER_ADDRESS_ENV_KEY: &str = "ANKAIOS_SERVER_SOCKET";
 
 pub mod commands;
 pub mod communications_client;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,7 @@ tonic = "0.9"
 async-stream = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.0", features = ["derive", "env"] }
 
 [dev-dependencies]
 common = { package = "common", path = "../common", features = ["test_utils"] }

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -59,6 +59,38 @@ The following diagram shows the startup sequence of the Ankaios Server:
 
 ![Startup](plantuml/seq_startup.svg)
 
+#### Server supports environment variable for server socket address
+`swdd~server-shall-support-environment-variable-for-server-socket-address~1`
+
+Status: approved
+
+When the environment variable with key `ANKAIOS_SERVER_SOCKET` is set and the user has not provided the server url via cli argument,
+the Ankaios agent shall use the server url from the environment variable to connect to the Ankaios server.
+
+Tags:
+- AnkaiosServer
+
+Needs:
+- impl
+- utest
+- stest
+
+#### Server prioritizes cli argument over environment variable
+`swdd~server-prioritizes-cli-argument-over-environment-variable~1`
+
+Status: approved
+
+When an environment variable is set and the user specifies a value for the corresponding cli argument,
+the Ankaios server shall use the value from the cli argument.
+
+Tags:
+- AnkaiosServer
+
+Needs:
+- impl
+- utest
+- stest
+
 #### Server holds Current State in memory
 `swdd~server-state-in-memory~1`
 

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -12,69 +12,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{
-    error::{ContextKind, ContextValue, ErrorKind},
-    Parser,
-};
-use common::{DEFAULT_SOCKET_ADDRESS, SERVER_ADDRESS_ENV_KEY};
-use std::{env, net::SocketAddr, str::FromStr};
+use clap::Parser;
+use common::{cli_utils::ServerAddressParser, DEFAULT_SOCKET_ADDRESS, SERVER_ADDRESS_ENV_KEY};
+use std::{env, net::SocketAddr};
 
 pub fn parse() -> Arguments {
     Arguments::parse()
-}
-
-#[derive(Clone, Default)]
-/// Custom url parser as a workaround to Clap's bug about
-/// outputting the wrong error message context
-/// when using the environment variable and not the cli argument.
-/// When using a wrong value inside environment variable
-/// Clap still outputs that the cli argument was wrongly set,
-/// but not the environment variable. This is poor use-ability.
-/// An issue for this bug is already opened (https://github.com/clap-rs/clap/issues/5202).
-/// The code will be removed if the bug in Clap is fixed.
-struct ServerAddressParser;
-
-impl clap::builder::TypedValueParser for ServerAddressParser {
-    type Value = SocketAddr;
-
-    fn parse_ref(
-        &self,
-        cmd: &clap::Command,
-        arg: Option<&clap::Arg>,
-        value: &std::ffi::OsStr,
-    ) -> Result<Self::Value, clap::Error> {
-        let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
-        if let Some(arg) = arg {
-            if let Ok(env_var) = std::env::var(SERVER_ADDRESS_ENV_KEY) {
-                if env_var == value.to_string_lossy() {
-                    err.insert(
-                        ContextKind::InvalidArg,
-                        ContextValue::String(format!(
-                            "environment variable '{}'",
-                            SERVER_ADDRESS_ENV_KEY
-                        )),
-                    );
-                } else {
-                    err.insert(
-                        ContextKind::InvalidArg,
-                        ContextValue::String(arg.to_string()),
-                    );
-                }
-            } else {
-                err.insert(
-                    ContextKind::InvalidArg,
-                    ContextValue::String(arg.to_string()),
-                );
-            }
-        }
-
-        err.insert(
-            ContextKind::InvalidValue,
-            ContextValue::String(value.to_str().unwrap().to_owned()),
-        );
-        let url = SocketAddr::from_str(value.to_str().unwrap()).map_err(|_| err)?;
-        Ok(url)
-    }
 }
 
 #[derive(Parser, Debug)]
@@ -85,7 +28,7 @@ pub struct Arguments {
     #[clap(short = 'c', long = "startup-config")]
     /// The path to the startup config yaml.
     pub path: String,
-    #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap(), env = SERVER_ADDRESS_ENV_KEY, value_parser = ServerAddressParser::default())]
+    #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap(), env = SERVER_ADDRESS_ENV_KEY, value_parser = ServerAddressParser)]
     /// The address, including the port, the server shall listen at.
     pub addr: SocketAddr,
 }

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -28,6 +28,7 @@ pub struct Arguments {
     #[clap(short = 'c', long = "startup-config")]
     /// The path to the startup config yaml.
     pub path: String,
+    // [impl->swdd~server-shall-support-environment-variable-for-server-socket-address~1]
     #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap(), env = SERVER_ADDRESS_ENV_KEY, value_parser = ServerAddressParser)]
     /// The address, including the port, the server shall listen at.
     pub addr: SocketAddr,

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -12,12 +12,69 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::Parser;
-use common::DEFAULT_SOCKET_ADDRESS;
-use std::{env, net::SocketAddr};
+use clap::{
+    error::{ContextKind, ContextValue, ErrorKind},
+    Parser,
+};
+use common::{DEFAULT_SOCKET_ADDRESS, SERVER_ADDRESS_ENV_KEY};
+use std::{env, net::SocketAddr, str::FromStr};
 
 pub fn parse() -> Arguments {
     Arguments::parse()
+}
+
+#[derive(Clone, Default)]
+/// Custom url parser as a workaround to Clap's bug about
+/// outputting the wrong error message context
+/// when using the environment variable and not the cli argument.
+/// When using a wrong value inside environment variable
+/// Clap still outputs that the cli argument was wrongly set,
+/// but not the environment variable. This is poor use-ability.
+/// An issue for this bug is already opened (https://github.com/clap-rs/clap/issues/5202).
+/// The code will be removed if the bug in Clap is fixed.
+struct ServerAddressParser;
+
+impl clap::builder::TypedValueParser for ServerAddressParser {
+    type Value = SocketAddr;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        let mut err = clap::Error::new(ErrorKind::ValueValidation).with_cmd(cmd);
+        if let Some(arg) = arg {
+            if let Ok(env_var) = std::env::var(SERVER_ADDRESS_ENV_KEY) {
+                if env_var == value.to_string_lossy() {
+                    err.insert(
+                        ContextKind::InvalidArg,
+                        ContextValue::String(format!(
+                            "environment variable '{}'",
+                            SERVER_ADDRESS_ENV_KEY
+                        )),
+                    );
+                } else {
+                    err.insert(
+                        ContextKind::InvalidArg,
+                        ContextValue::String(arg.to_string()),
+                    );
+                }
+            } else {
+                err.insert(
+                    ContextKind::InvalidArg,
+                    ContextValue::String(arg.to_string()),
+                );
+            }
+        }
+
+        err.insert(
+            ContextKind::InvalidValue,
+            ContextValue::String(value.to_str().unwrap().to_owned()),
+        );
+        let url = SocketAddr::from_str(value.to_str().unwrap()).map_err(|_| err)?;
+        Ok(url)
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -28,7 +85,7 @@ pub struct Arguments {
     #[clap(short = 'c', long = "startup-config")]
     /// The path to the startup config yaml.
     pub path: String,
-    #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap())]
+    #[clap(short = 'a', long = "address", default_value_t = DEFAULT_SOCKET_ADDRESS.parse().unwrap(), env = SERVER_ADDRESS_ENV_KEY, value_parser = ServerAddressParser::default())]
     /// The address, including the port, the server shall listen at.
     pub addr: SocketAddr,
 }


### PR DESCRIPTION
Issues: #75 

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged **only if all of following items were checked.** In case an item is not applicable as described, please provide a short explanation right after the item in question. Separate the explanation by a semicolon and write it as bold text like **; requirements are handled in issue #xyz**:

- [ ] documentation of all modules `/*/doc/swdesign` is up-to-date
- [ ] requirements are up-to-date and requirements for new features have been added and mapped to source and test
- [ ] conform to [unit verification strategy](https://eclipse-ankaios.github.io/ankaios/main/development/unit-verification/)

