### PR TITLE
Fix new workload always having the state "removed"

### DIFF
--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -158,6 +158,8 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
         workload_spec: WorkloadSpec,
         update_state_tx: StateChangeSender,
     ) -> Result<GenericPollingStateChecker, RuntimeError> {
+        PodmanCli::reset_ps_cache().await;
+
         log::debug!(
             "Starting the checker for the workload '{}' with id '{}'",
             workload_spec.name,
@@ -289,8 +291,11 @@ mod tests {
     async fn utest_create_workload_success() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
 
-        let context = PodmanCli::podman_run_context();
-        context.expect().return_const(Ok("test_id".into()));
+        let run_context = PodmanCli::podman_run_context();
+        run_context.expect().return_const(Ok("test_id".into()));
+
+        let resest_cache_context = PodmanCli::reset_ps_cache_context();
+        resest_cache_context.expect().once().return_const(());
 
         let workload_spec = generate_test_workload_spec_with_param(
             AGENT_NAME.to_string(),

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -45,6 +45,8 @@ impl RuntimeStateGetter<PodmanWorkloadId> for PodmanStateGetter {
         log::trace!("Getting the state for the workload '{}'", workload_id.id);
 
         // [impl->swdd~podman-state-getter-returns-unknown-state~1]
+        // [impl->swdd~podman-state-getter-uses-podmancli~1]
+        // [impl->swdd~podman-state-getter-returns-removed-state~1]
         let exec_state = match PodmanCli::list_states_by_id(workload_id.id.as_str()).await {
             Ok(state) => {
                 if let Some(state) = state {
@@ -158,6 +160,7 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
         workload_spec: WorkloadSpec,
         update_state_tx: StateChangeSender,
     ) -> Result<GenericPollingStateChecker, RuntimeError> {
+        // [impl->swdd~podman-state-getter-reset-cache~1]
         PodmanCli::reset_ps_cache().await;
 
         log::debug!(
@@ -201,6 +204,8 @@ mod tests {
         state_change_interface::StateChangeCommand,
         test_utils::generate_test_workload_spec_with_param,
     };
+    use futures_util::task::Spawn;
+    use mockall::Sequence;
 
     use super::PodmanCli;
     use super::PodmanRuntime;
@@ -295,7 +300,7 @@ mod tests {
         run_context.expect().return_const(Ok("test_id".into()));
 
         let resest_cache_context = PodmanCli::reset_ps_cache_context();
-        resest_cache_context.expect().once().return_const(());
+        resest_cache_context.expect().return_const(());
 
         let workload_spec = generate_test_workload_spec_with_param(
             AGENT_NAME.to_string(),
@@ -314,6 +319,68 @@ mod tests {
 
         // [utest->swdd~podman-create-workload-returns-workload-id~1]
         assert_eq!(workload_id.id, "test_id".to_string());
+    }
+
+    // [utest->swdd~podman-state-getter-reset-cache~1]
+    #[tokio::test]
+    async fn utest_state_getter_resets_cache() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let run_context = PodmanCli::podman_run_context();
+        run_context.expect().return_const(Ok("test_id".into()));
+
+        let mut seq = Sequence::new();
+
+        let resest_cache_context = PodmanCli::reset_ps_cache_context();
+        resest_cache_context
+            .expect()
+            .once()
+            .return_const(())
+            .in_sequence(&mut seq);
+
+        let list_states_context = PodmanCli::list_states_by_id_context();
+        list_states_context
+            .expect()
+            .once()
+            .return_const(Ok(Some(ExecutionState::ExecRunning)))
+            .in_sequence(&mut seq);
+
+        let workload_spec = generate_test_workload_spec_with_param(
+            AGENT_NAME.to_string(),
+            WORKLOAD_1_NAME.to_string(),
+            PODMAN_RUNTIME_NAME.to_string(),
+        );
+        let (to_server, mut from_agent) =
+            tokio::sync::mpsc::channel::<StateChangeCommand>(BUFFER_SIZE);
+
+        let podman_runtime = PodmanRuntime {};
+        let res = podman_runtime
+            .create_workload(workload_spec, Some(PathBuf::from("run_folder")), to_server)
+            .await;
+
+        let (_workload_id, _checker) = res.unwrap();
+
+        from_agent.recv().await;
+    }
+
+    // [utest->swdd~podman-state-getter-uses-podmancli~1]
+    #[tokio::test]
+    async fn utest_state_getter_uses_podman_cli() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let list_states_context = PodmanCli::list_states_by_id_context();
+        list_states_context
+            .expect()
+            .return_const(Ok(Some(ExecutionState::ExecRunning)));
+
+        let state_getter = PodmanStateGetter {};
+        let execution_state = state_getter
+            .get_state(&PodmanWorkloadId {
+                id: "test_workload_id".into(),
+            })
+            .await;
+
+        assert_eq!(execution_state, ExecutionState::ExecRunning);
     }
 
     #[tokio::test]
@@ -424,6 +491,7 @@ mod tests {
         assert_eq!(res, Err(RuntimeError::List("simulated error".to_owned())))
     }
 
+    // [utest->podman-state-getter-uses-podmancli~1]
     #[tokio::test]
     async fn utest_get_state_returns_state() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;

--- a/agent/src/runtime_connectors/podman_cli.rs
+++ b/agent/src/runtime_connectors/podman_cli.rs
@@ -69,6 +69,10 @@ struct PodmanPsCache {
 struct TimedPodmanPsResult(Mutex<Option<PodmanPsCache>>);
 
 impl TimedPodmanPsResult {
+    async fn reset(&self) {
+        *self.lock().await = None;
+    }
+
     async fn get(&self) -> Arc<PodmanPsResult> {
         let mut guard = self.lock().await;
 
@@ -141,6 +145,10 @@ pub struct PodmanCli {}
 
 #[cfg_attr(test, automock)]
 impl PodmanCli {
+    pub async fn reset_ps_cache() {
+        LAST_PS_RESULT.reset().await;
+    }
+
     pub async fn play_kube(
         general_options: &[String],
         play_options: &[String],

--- a/agent/src/runtime_connectors/podman_cli.rs
+++ b/agent/src/runtime_connectors/podman_cli.rs
@@ -73,6 +73,7 @@ impl TimedPodmanPsResult {
         *self.lock().await = None;
     }
 
+    // [impl->swdd~podmancli-container-state-cache-refresh~1]
     async fn get(&self) -> Arc<PodmanPsResult> {
         let mut guard = self.lock().await;
 
@@ -105,6 +106,7 @@ impl Deref for TimedPodmanPsResult {
     }
 }
 
+// [impl->swdd~podmancli-container-state-cache-all-containers~1]
 #[derive(Debug)]
 struct PodmanPsResult {
     container_states: Result<HashMap<String, ExecutionState>, String>,
@@ -304,6 +306,7 @@ impl PodmanCli {
         Ok(id)
     }
 
+    // [impl->swdd~podmancli-uses-container-state-cache~1]
     pub async fn list_states_by_id(workload_id: &str) -> Result<Option<ExecutionState>, String> {
         let ps_result = LAST_PS_RESULT.get().await;
         let all_containers_states = ps_result
@@ -316,6 +319,7 @@ impl PodmanCli {
             .map(ToOwned::to_owned))
     }
 
+    // [impl->swdd~podmancli-uses-container-state-cache~1]
     // [impl->swdd~podman-kube-state-getter-treats-missing-pods-as-unknown~1]
     pub async fn list_states_from_pods(pods: &[String]) -> Result<Vec<ContainerState>, String> {
         let ps_result = LAST_PS_RESULT.get().await;
@@ -950,6 +954,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-state-getter-maps-state~1]
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_pending() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -973,6 +978,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-state-getter-maps-state~1]
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_succeeded() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -997,6 +1003,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-state-getter-maps-state~1]
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_failed() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -1021,6 +1028,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-state-getter-maps-state~1]
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_running() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -1044,6 +1052,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-state-getter-maps-state~1]
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_unknown() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -1083,6 +1092,7 @@ mod tests {
         assert_eq!(res, Err("simulated error".to_string()));
     }
 
+    // [utest->podmancli-uses-container-state-cache~1]
     #[tokio::test]
     async fn utest_list_states_by_id_podman_use_existing_ps_result() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -1102,6 +1112,7 @@ mod tests {
         assert_eq!(res, Ok(Some(ExecutionState::ExecRunning)));
     }
 
+    // [utest->swdd~podmancli-container-state-cache-refresh~1]
     #[tokio::test]
     async fn utest_list_states_by_id_podman_existing_ps_result_to_old() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
@@ -1291,6 +1302,46 @@ mod tests {
             .await
             .unwrap()
             .is_empty());
+    }
+
+    // [utest->swdd~podmancli-container-state-cache-all-containers~1]
+    // [utest->swdd~podmancli-uses-container-state-cache~1]
+    #[tokio::test]
+    async fn utest_list_states_uses_cache() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+        super::CliCommand::reset();
+        *super::LAST_PS_RESULT.lock().await = None;
+
+        super::CliCommand::new_expect(
+            "podman",
+            super::CliCommand::default()
+                .expect_args(&["ps", "--all", "--format=json"])
+                .exec_returns(Ok([
+                    TestPodmanContainerInfo {
+                        id: "id1",
+                        pod: "pod1",
+                        state: "running",
+                        ..Default::default()
+                    },
+                    TestPodmanContainerInfo {
+                        id: "id2",
+                        pod: "pod2",
+                        state: "exited",
+                        exit_code: 0,
+                        ..Default::default()
+                    },
+                ]
+                .to_json())),
+        );
+
+        let _ = PodmanCli::list_states_by_id("id1").await;
+
+        assert!(
+            matches!(PodmanCli::list_states_by_id("id2").await, Ok(Some(state)) if state == ExecutionState::ExecSucceeded )
+        );
+        assert!(
+            matches!(PodmanCli::list_states_from_pods(&["pod2".into()]).await, Ok(states) if states == [ContainerState::Exited(0)] )
+        );
     }
 
     #[tokio::test]

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -218,6 +218,7 @@ impl RuntimeConnector<PodmanKubeWorkloadId, GenericPollingStateChecker> for Podm
         workload_spec: WorkloadSpec,
         update_state_tx: StateChangeSender,
     ) -> Result<GenericPollingStateChecker, RuntimeError> {
+        PodmanCli::reset_ps_cache().await;
         log::debug!(
             "Starting the checker for the workload '{}' with workload execution instance name '{}'",
             workload_spec.name,
@@ -493,6 +494,8 @@ mod tests {
             )
             .returns(Ok(()));
 
+        mock_context.reset_ps_cache.expect().once().return_const(());
+
         let runtime = PodmanKubeRuntime {};
 
         let mut workload_spec = generate_test_workload_spec_with_param(
@@ -540,6 +543,8 @@ mod tests {
             )
             .returns(Ok(()));
 
+        mock_context.reset_ps_cache.expect().once().return_const(());
+
         let runtime = PodmanKubeRuntime {};
 
         let mut workload_spec = generate_test_workload_spec_with_param(
@@ -584,6 +589,8 @@ mod tests {
                 r#"["pod1","pod2"]"#,
             )
             .returns(Err(SAMPLE_ERROR.into()));
+
+        mock_context.reset_ps_cache.expect().once().return_const(());
 
         let runtime = PodmanKubeRuntime {};
 
@@ -967,6 +974,7 @@ mod tests {
         down_kube: podman_cli_mock::__down_kube::Context,
         remove_volume: podman_cli_mock::__remove_volume::Context,
         list_states_from_pods: podman_cli_mock::__list_states_from_pods::Context,
+        reset_ps_cache: podman_cli_mock::__reset_ps_cache::Context,
         _guard: tokio::sync::MutexGuard<'a, ()>, // The guard shall be dropped last
     }
 
@@ -980,6 +988,7 @@ mod tests {
                 down_kube: PodmanCli::down_kube_context(),
                 remove_volume: PodmanCli::remove_volume_context(),
                 list_states_from_pods: PodmanCli::list_states_from_pods_context(),
+                reset_ps_cache: PodmanCli::reset_ps_cache_context(),
                 _guard: MOCKALL_CONTEXT_SYNC.get_lock_async().await,
             }
         }


### PR DESCRIPTION
If the "podman ps" cache is not reset before starting the state checker, the state checker will get the old "podman ps" result, this result will not contain the new workload, the state checker will assume the workload has be removed and will stop immediately.

# Definition of Done

The PR shall be merged only if all items mentioned in 
[CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute)
have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled

