### PR TITLE
Use Vagrant for provisioning test VMs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,6 @@ Issues: #
 
 # Definition of Done
 
-The PR shall be merged only if all items mentioned in 
-[CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute)
-have been followed. In case an item is not applicable as described, please provide a short explanation in the description.
+The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.
 
 - [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
-

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist
 
 # ignore python data
 __pycache__
+
+# Vgarant
+**/.vagrant

--- a/tools/vagrant/README.md
+++ b/tools/vagrant/README.md
@@ -1,0 +1,54 @@
+# Vagrant VMs
+
+This folder contains different [Vagrant](https://developer.hashicorp.com/vagrant)
+setups for virtual machines which are intended for testing Ankaios. And thus they
+already come with Podman pre-installed.
+
+## Setup
+
+In order to use these virtual machines, Vagrant needs to be installed and also
+VirtualBox, which is used by Vagrant to create the VMs. Vagrant should be
+installed on the same host OS as VirtualBox, eg. on Windows.
+
+For Vagrant installation see <https://developer.hashicorp.com/vagrant/install>.
+
+## Creating and running a VM
+
+Make sure to have this repo cloned on the host and then enter one of the
+sub-folders (eg. `ubuntu22.04`) with the desired setup. 
+
+Create the VM using:
+
+```
+vagrant up
+```
+
+When called for the first time, this might take some time as the base box (i.e. base VM) needs to be downloaded.
+
+Login with:
+
+```
+vagrant ssh
+```
+
+Now you are in the VM and can execute any command like installing Ankaios and starting it.
+
+## Destroy VM
+
+To destroy the VM call:
+
+```
+vagrant destroy
+```
+
+## FAQ
+
+**Question:** Where do I find other boxes (i.e. base images)?
+
+**Answer:** Goto <https://app.vagrantup.com/boxes/search> and there you will find existing Vagrant boxes to start from.
+
+**Q:** How can I share files between host and VM?
+
+**A:** The folder keeping the `Vagrantfile` on the host is available as `/vagrant` in the VM. Other
+[folders can be synced as well](https://developer.hashicorp.com/vagrant/docs/synced-folders/basic_usage).
+

--- a/tools/vagrant/ubuntu20.04/Vagrantfile
+++ b/tools/vagrant/ubuntu20.04/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     #vb.gui = true
-    vb.memory = "1024"
+    vb.memory = "4096"
     vb.cpus = "2"
   end
 

--- a/tools/vagrant/ubuntu20.04/Vagrantfile
+++ b/tools/vagrant/ubuntu20.04/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  #config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu2004"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  #config.vm.synced_folder ".", "/vagrant_data"
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant", disabled: false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    #vb.gui = true
+    vb.memory = "1024"
+    vb.cpus = "2"
+  end
+
+  config.vm.provision "shell", path: "init.sh"
+end

--- a/tools/vagrant/ubuntu20.04/init.sh
+++ b/tools/vagrant/ubuntu20.04/init.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+apt update
+apt install -y software-properties-common uidmap tmux
+sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_20.04/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4D64390375060AA4
+apt update
+apt install -y podman

--- a/tools/vagrant/ubuntu22.04/Vagrantfile
+++ b/tools/vagrant/ubuntu22.04/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     #vb.gui = true
-    vb.memory = "1024"
+    vb.memory = "4096"
     vb.cpus = "2"
   end
 

--- a/tools/vagrant/ubuntu22.04/Vagrantfile
+++ b/tools/vagrant/ubuntu22.04/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  #config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu2204"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  #config.vm.synced_folder ".", "/vagrant_data"
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant", disabled: false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    #vb.gui = true
+    vb.memory = "1024"
+    vb.cpus = "2"
+  end
+
+  config.vm.provision "shell", path: "init.sh"
+end

--- a/tools/vagrant/ubuntu22.04/init.sh
+++ b/tools/vagrant/ubuntu22.04/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt update
+apt install -y podman tmux

--- a/tools/vagrant/ubuntu23.04/Vagrantfile
+++ b/tools/vagrant/ubuntu23.04/Vagrantfile
@@ -72,7 +72,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     #vb.gui = true
-    vb.memory = "1024"
+    vb.memory = "4096"
     vb.cpus = "2"
   end
 

--- a/tools/vagrant/ubuntu23.04/Vagrantfile
+++ b/tools/vagrant/ubuntu23.04/Vagrantfile
@@ -1,0 +1,80 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  #config.vm.box = "ubuntu/focal64"
+  config.vm.box = "generic/ubuntu2304"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  #config.vm.synced_folder ".", "/vagrant_data"
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant", disabled: false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    #vb.gui = true
+    vb.memory = "1024"
+    vb.cpus = "2"
+  end
+
+  config.vm.provision "shell", path: "init.sh"
+end

--- a/tools/vagrant/ubuntu23.04/init.sh
+++ b/tools/vagrant/ubuntu23.04/init.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt update
+apt install -y podman tmux


### PR DESCRIPTION
When testing Ankaios on different Linux distributions, a VM for VirtualBox with the specific distribution like Ubuntu 22.04 had to be created so far. This was a lot of manual work and not so easy to re-create.

This PR adds [Vagrant](https://www.vagrantup.com) setups for the distributions which are supported by Ankaios in order to automate the creation of VMs for VirtualBox.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled

