### PR TITLE
Add release preparation steps for releases

### DIFF
--- a/doc/docs/development/ci-cd-release.md
+++ b/doc/docs/development/ci-cd-release.md
@@ -113,7 +113,20 @@ The release notes are generated automatically if a release is created via the Gi
 
 The procedure uses the filters for pull request labels configured inside `.github/release.yml`.
 
+## Preparing a release
+
+The following steps shall be done before the actual release build is triggered.
+
+1. Create an isssue containing tasks for getting the main branch ready:
+    1. Update the versions in the project packages (Cargo.toml files) to the new version.
+    2. Execute tests on the supported targets.
+    3. Make sure there are no security warnings of Github dependabot.
+2. Finish all tasks inside the issue.
+3. Build the release according to the steps described [here](#building-a-release).
+
 ## Building a release
+
+Before building the release, all [preparation steps](#preparing-a-release) shall be finished before.
 
 The release shall be created directly via the GitHub web frontend.
 


### PR DESCRIPTION
In our last retrospective we decided to add preparation steps to the release description in the user documentation.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
