### PR TITLE
Fix markdown lint in CI builds

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,8 +66,7 @@ jobs:
             tools/generate_docs.sh build
   lint:
     name: Lint documentation
-    needs: documentation_changes
-    if: ${{ needs.documentation_changes.outputs.documentation == 'true' }}
+    # No dependencies as we have markdown files in a lot of places
     runs-on: ubuntu-latest
     steps:
       - name: git checkout


### PR DESCRIPTION
Prior to this change, we only triggered the markdown lint check in CI when the documentation had been changed. That could cause a situation when a lint violation exists in SW design which is not recognized immediately in CI but only many commits later when someone changes the documentation.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
