### PR TITLE
Add URL to connection error message

### DIFF
--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -92,7 +92,7 @@ impl CommunicationsClient for GRPCCommunicationsClient {
                         Err(GrpcMiddlewareError::ServerNotAvailable(err)) => {
                             log::debug!("No connection to the server: '{err}'");
                             return Err(CommunicationMiddlewareError(format!(
-                                "Could not connect to server on {}.",
+                                "Could not connect to Ankaios server on {}.",
                                 self.server_address
                             )));
                         }

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -91,7 +91,10 @@ impl CommunicationsClient for GRPCCommunicationsClient {
                         // [impl->swdd~grpc-client-outputs-error-server-unavailability-for-cli-connection~1]
                         Err(GrpcMiddlewareError::ServerNotAvailable(err)) => {
                             log::debug!("No connection to the server: '{err}'");
-                            return Err(CommunicationMiddlewareError("No connection to the server! Make sure that Ankaios Server is running.".to_string()));
+                            return Err(CommunicationMiddlewareError(format!(
+                                "Could not connect to server on {}.",
+                                self.server_address
+                            )));
                         }
                         // [impl->swdd~grpc-client-outputs-error-server-connection-loss-for-cli-connection~1]
                         Err(GrpcMiddlewareError::ConnectionInterrupted(err)) => {

--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -92,7 +92,7 @@ impl CommunicationsClient for GRPCCommunicationsClient {
                         Err(GrpcMiddlewareError::ServerNotAvailable(err)) => {
                             log::debug!("No connection to the server: '{err}'");
                             return Err(CommunicationMiddlewareError(format!(
-                                "Could not connect to Ankaios server on {}.",
+                                "Could not connect to Ankaios server on '{}'.",
                                 self.server_address
                             )));
                         }


### PR DESCRIPTION
This PR adds the server URL to the error message which is printed by e.g. the `ank` command when no connection the server can be established. This helps the user as a wrong URL might have been provided.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
