### PR TITLE
Improve ank error when server not available

### DIFF
--- a/common/src/communications_error.rs
+++ b/common/src/communications_error.rs
@@ -14,7 +14,7 @@ impl fmt::Display for CommunicationMiddlewareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             CommunicationMiddlewareError(message) => {
-                write!(f, "Communication middleware failure: '{}'", message)
+                write!(f, "{}", message)
             }
         }
     }


### PR DESCRIPTION
This removes unnecessary part of the display function for the middleware error.


# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
