### PR TITLE
Add report with licenses of dependencies to release

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.7.0
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -83,7 +83,8 @@ USER ${USERNAME}
 RUN cargo install cargo-llvm-cov --locked; \
     cargo install cargo-deb --locked; \
     cargo install cargo-nextest --locked; \
-    cargo install cargo-deny --locked
+    cargo install cargo-deny --locked; \
+    cargo install cargo-about --locked
 
 # Install required cargo targets and toolchains
 RUN rustup target add x86_64-unknown-linux-musl \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Test and build Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.7.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --privileged
     steps:
       - uses: actions/checkout@v3.5.3
@@ -92,7 +92,7 @@ jobs:
     name: Build Linux arm64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.7.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --user root
     steps:
       - uses: actions/checkout@v3.5.3
@@ -119,7 +119,7 @@ jobs:
     name: Build requirements tracing
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.7.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --user root
     steps:
       - uses: actions/checkout@v3.5.3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,15 @@ jobs:
       - name: Check licenses
         run: cargo deny check
 
+      - name: Create license report
+        run: |
+          mkdir -p build
+          cargo about generate about.hbs > build/licenses.html
+      - uses: actions/upload-artifact@v3.1.2
+        with:
+          name: licenses
+          path: build/licenses.html
+
       - name: Run tests
         run: RUST_LOG=debug cargo nextest run
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --privileged
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - uses: Swatinem/rust-cache@v2.6.2
 
         # If the next step fails, then a license used by a new dependency is currently
@@ -95,7 +95,7 @@ jobs:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --user root
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
 
       - name: Build linux-arm64 release-mode
         run: |
@@ -122,7 +122,7 @@ jobs:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
       options: --user root
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - run: |
           mkdir -p dist
           oft trace $(find . -type d -name "src" -o -name "doc") -a swdd,utest,itest,stest,impl -o html -f dist/req_tracing_report.html || true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.7.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
     steps:
       - uses: actions/checkout@v3.5.3
       - name: Prepare commit to branch gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,8 +23,8 @@ jobs:
     outputs:
       documentation: ${{ steps.filter.outputs.documentation }}
     steps:
-    - uses: actions/checkout@v3.5.3
-    - uses: dorny/paths-filter@v2.11.1
+    - uses: actions/checkout@v4.1.1
+    - uses: dorny/paths-filter@v3.0.0
       id: filter
       with:
         filters: |
@@ -40,7 +40,7 @@ jobs:
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.8.0
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - name: Prepare commit to branch gh-pages
         run: |
             git config --global --add safe.directory $PWD
@@ -70,11 +70,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           show-progress: ''
       - name: markdownlint-cli2-action
-        uses: DavidAnson/markdownlint-cli2-action@v9
+        uses: DavidAnson/markdownlint-cli2-action@v15.0.0
         with:
           globs: |
             **/*.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           name: code-coverage
           path: dist/coverage
+      - name: Download license report
+        uses: actions/download-artifact@v3.0.2
+        with:
+          name: licenses
+          path: dist/
       - name: Package release artifacts
         run: tools/create_release.sh
       - name: Upload release artifacts
@@ -59,4 +64,5 @@ jobs:
           linux-amd64/ankaios-linux-amd64.tar.gz \
           linux-amd64/ankaios-linux-amd64.tar.gz.sha512sum.txt \
           linux-arm64/ankaios-linux-arm64.tar.gz \
-          linux-arm64/ankaios-linux-arm64.tar.gz.sha512sum.txt
+          linux-arm64/ankaios-linux-arm64.tar.gz.sha512sum.txt \
+          licenses.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.5.3
+      - uses: actions/checkout@v4.1.1
       - name: Download artifacts for ankaios-linux-amd64-bin
         uses: actions/download-artifact@v3.0.2
         with:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Community Code of Conduct
 
-**Version 2.0  
+**Version 2.0
 January 1, 2023**
 
 ## Our Pledge
@@ -49,7 +49,7 @@ This Code applies within all Project, Working Group, and Interest Group spaces a
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via conduct@eclipse-foundation.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via <conduct@eclipse-foundation>.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
 
 Staff, Committers and Project Leads have the right to report, remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code, or to block temporarily or permanently any Contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. Any such actions will be reported to the Conduct Committee for transparency and record keeping.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,9 +595,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",

--- a/about.hbs
+++ b/about.hbs
@@ -1,6 +1,11 @@
 <html>
 
 <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="description" content="This page lists the licenses of the projects used in Eclipse Ankaios." />
+	<meta name="author" content="Eclipse Ankaios committers" />
+	<meta name="viewport" content="user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, width=device-width" />
+	<title>Third Party Licenses</title>
     <style>
         @media (prefers-color-scheme: dark) {
             body {

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+    <main class="container">
+        <div class="intro">
+            <h1>Third Party Licenses</h1>
+            <p>This page lists the licenses of the projects used in Eclipse Ankaios.</p>
+        </div>
+
+        <h2>Overview of licenses:</h2>
+        <ul class="licenses-overview">
+            {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+            {{/each}}
+        </ul>
+
+        <h2>All license text:</h2>
+        <ul class="licenses-list">
+            {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                    <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+            {{/each}}
+        </ul>
+    </main>
+</body>
+
+</html>

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,20 @@
+# Config file for cargo about
+# For all options see https://embarkstudios.github.io/cargo-about/cli/generate/config.html
+
+accepted = [
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause"
+]
+
+targets = [
+    "x86_64-unknown-linux-musl",
+    "aarch64-unknown-linux-musl"
+]
+
+ignore-dev-dependencies = true
+
+[unicode-ident]
+accepted = ["Unicode-DFS-2016"]
+
+

--- a/about.toml
+++ b/about.toml
@@ -1,6 +1,7 @@
 # Config file for cargo about
 # For all options see https://embarkstudios.github.io/cargo-about/cli/generate/config.html
 
+# If you add a license in the following section also consider changing deny.toml
 accepted = [
     "Apache-2.0",
     "MIT",

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 # Config file for cargo deny
 # For all options see https://github.com/EmbarkStudios/cargo-deny/blob/main/deny.template.toml
 
+# If you add a license in the following section also consider changing about.toml
 [licenses]
 allow = [
     "MIT",

--- a/doc/docs/development/ci-cd-release.md
+++ b/doc/docs/development/ci-cd-release.md
@@ -29,7 +29,6 @@ The script calls another script `tools/create_artifacts.sh` for each platform th
 In addition, it exports the following:
 
 - Coverage report
-- Requirements tracing teport
 - ankaios.proto
 - install.sh (Ankaios installation script)
 

--- a/doc/docs/development/ci-cd.md
+++ b/doc/docs/development/ci-cd.md
@@ -61,7 +61,7 @@ Bad:
 
 ```yaml
 ...
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
 ...
 ```
 
@@ -69,7 +69,7 @@ Good:
 
 ```yaml
 ...
-  - uses: actions/checkout@v3.5.3
+  - uses: actions/checkout@v4.1.1
 ...
 ```
 


### PR DESCRIPTION
Some OSS licenses require the original license text to be included in a distribution. This PR uses [cargo about](https://github.com/EmbarkStudios/cargo-about) to generate an HTML with all the third party licenses used by Ankaios's dependencies. This report is generated with every CI build and also stored as asset in a release as `licenses.html`.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
