### PR TITLE
Fix link in protocol documentation

### DIFF
--- a/api/proto/ankaios.proto
+++ b/api/proto/ankaios.proto
@@ -23,9 +23,9 @@
 *
 * The protocol consists of the following top-level message types:
 *
-* 1. [ToServer](#ToServer): agent/cli -> server
+* 1. [ToServer](#toserver): agent/cli -> server
 *
-* 2. [FromServer](#FromServer): server -> agent/cli
+* 2. [FromServer](#fromserver): server -> agent/cli
 *
 */
 syntax = "proto3";


### PR DESCRIPTION
The links in the paragraph `#ankaiosproto`, pointing to `ToServer` and `FromServer` are not working.
This PR fixes these links.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
