### PR TITLE
Remove successfully deleted workloads from delete graph

### DIFF
--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -685,9 +685,7 @@ Needs:
 
 Status: approved
 
-When the Ankaios Server receives new workload states, then the Ankaios Server shall:
-* provide the new workload states to the ServerState
-* trigger the ServerState to cleanup its state
+When the Ankaios Server receives new workload states, then the Ankaios Server shall trigger the ServerState to cleanup its internal state providing it the new workload states.
 
 Rationale:
 The server state should not have any obsolete entries.

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -680,22 +680,43 @@ Needs:
 - impl
 - utest
 
-#### Server removes obsolete delete conditions from delete graph
-`swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1`
+#### Server cleans up state
+`swdd~server-cleans-up-state~1`
 
 Status: approved
 
-When the Ankaios server receives an `UpdateWorkloadState` message
-and the message contains the WorkloadState `Removed` for a workload
-and the workload has an entry inside the delete graph,
-then the server shall delete the entry from the delete graph.
+When the Ankaios Server receives new workload states, then the Ankaios Server shall:
+* provide the new workload states to the ServerState
+* trigger the ServerState to cleanup its state
 
-Comment: The server ignores WorkloadStates from workloads that do not have an entry in the delete graph.
-
-Rationale: The entry should not exist after the workload has actually been deleted.
+Rationale:
+The server state should not have any obsolete entries.
 
 Tags:
 - AnkaiosServer
+- ServerState
+
+Needs:
+- impl
+- utest
+
+#### Server removes obsolete entries from delete graph
+`swdd~server-removes-obsolete-delete-graph-entires~1`
+
+Status: approved
+
+When the ServerState receives a trigger to cleanup its state, the ServerState shall:
+
+* provide the new workload states to the DeleteGraph
+* request the DeleteGraph to delete all entries for which there is a WorkloadState `Removed` in the list of new workload states
+
+Comment:
+The DeleteGraph ignores WorkloadStates from workloads that do not have an entry in the delete graph.
+
+Rationale:
+The entry should not exist after the workload has actually been deleted.
+
+Tags:
 - ServerState
 - DeleteGraph
 

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -703,10 +703,7 @@ Needs:
 
 Status: approved
 
-When the ServerState receives a trigger to cleanup its state, the ServerState shall:
-
-* provide the new workload states to the DeleteGraph
-* request the DeleteGraph to delete all entries for which there is a WorkloadState `Removed` in the list of new workload states
+When the ServerState receives a trigger to cleanup its state, the ServerState shall request the DeleteGraph to delete all entries for which there is a WorkloadState `Removed` in the list of provided workload states.
 
 Comment:
 The DeleteGraph ignores WorkloadStates from workloads that do not have an entry in the delete graph.

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -680,6 +680,29 @@ Needs:
 - impl
 - utest
 
+#### Server removes obsolete delete conditions from delete graph
+`swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1`
+
+Status: approved
+
+When the Ankaios server receives an `UpdateWorkloadState` message
+and the message contains the WorkloadState `Removed` for a workload
+and the workload has an entry inside the delete graph,
+then the server shall delete the entry from the delete graph.
+
+Comment: The server ignores WorkloadStates from workloads that do not have an entry in the delete graph.
+
+Rationale: The entry should not exist after the workload has actually been deleted.
+
+Tags:
+- AnkaiosServer
+- ServerState
+- DeleteGraph
+
+Needs:
+- impl
+- utest
+
 ## Data view
 
 ## Error management view

--- a/server/src/ankaios_server.rs
+++ b/server/src/ankaios_server.rs
@@ -342,6 +342,9 @@ impl AnkaiosServer {
                     self.workload_state_db
                         .process_new_states(method_obj.workload_states.clone());
 
+                    self.server_state
+                        .remove_deleted_workloads_from_delete_graph(&method_obj.workload_states);
+
                     // [impl->swdd~server-forwards-workload-state~1]
                     self.to_agents
                         .update_workload_state(method_obj.workload_states)

--- a/server/src/ankaios_server.rs
+++ b/server/src/ankaios_server.rs
@@ -342,9 +342,8 @@ impl AnkaiosServer {
                     self.workload_state_db
                         .process_new_states(method_obj.workload_states.clone());
 
-                    // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
-                    self.server_state
-                        .remove_deleted_workloads_from_delete_graph(&method_obj.workload_states);
+                    // [impl->swdd~server-cleans-up-state~1]
+                    self.server_state.cleanup_state(&method_obj.workload_states);
 
                     // [impl->swdd~server-forwards-workload-state~1]
                     self.to_agents
@@ -668,9 +667,7 @@ mod tests {
 
         let mut mock_server_state = MockServerState::new();
 
-        mock_server_state
-            .expect_remove_deleted_workloads_from_delete_graph()
-            .return_const(());
+        mock_server_state.expect_cleanup_state().return_const(());
 
         let mut seq = mockall::Sequence::new();
         mock_server_state
@@ -1143,7 +1140,7 @@ mod tests {
         let mut server = AnkaiosServer::new(server_receiver, to_agents);
         let mut mock_server_state = MockServerState::new();
         mock_server_state
-            .expect_remove_deleted_workloads_from_delete_graph()
+            .expect_cleanup_state()
             .once()
             .return_const(());
 
@@ -1456,7 +1453,7 @@ mod tests {
         assert!(comm_middle_ware_receiver.try_recv().is_err());
     }
 
-    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [utest->swdd~server-cleans-up-state~1]
     #[tokio::test]
     async fn utest_server_triggers_delete_of_actually_removed_workloads_from_delete_graph() {
         let _ = env_logger::builder().is_test(true).try_init();
@@ -1474,7 +1471,7 @@ mod tests {
         )];
 
         mock_server_state
-            .expect_remove_deleted_workloads_from_delete_graph()
+            .expect_cleanup_state()
             .with(mockall::predicate::eq(workload_states.clone()))
             .return_const(());
         server.server_state = mock_server_state;

--- a/server/src/ankaios_server.rs
+++ b/server/src/ankaios_server.rs
@@ -342,6 +342,7 @@ impl AnkaiosServer {
                     self.workload_state_db
                         .process_new_states(method_obj.workload_states.clone());
 
+                    // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
                     self.server_state
                         .remove_deleted_workloads_from_delete_graph(&method_obj.workload_states);
 
@@ -1455,6 +1456,7 @@ mod tests {
         assert!(comm_middle_ware_receiver.try_recv().is_err());
     }
 
+    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     #[tokio::test]
     async fn utest_server_triggers_delete_of_actually_removed_workloads_from_delete_graph() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/server/src/ankaios_server/delete_graph.rs
+++ b/server/src/ankaios_server/delete_graph.rs
@@ -55,6 +55,7 @@ impl DeleteGraph {
         }
     }
 
+    // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     pub fn remove_deleted_workloads_from_delete_graph(
         &mut self,
         workload_states: &[WorkloadState],
@@ -303,6 +304,7 @@ mod tests {
         );
     }
 
+    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_delete_entries() {
         let mut delete_graph = DeleteGraph::default();
@@ -326,6 +328,7 @@ mod tests {
         assert!(delete_graph.delete_graph.is_empty());
     }
 
+    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_keep_entries() {
         let mut delete_graph = DeleteGraph::default();
@@ -349,6 +352,7 @@ mod tests {
         assert!(delete_graph.delete_graph.contains_key(WORKLOAD_NAME_1));
     }
 
+    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_ignore_not_relevant_workload_states() {
         let mut delete_graph = DeleteGraph::default();

--- a/server/src/ankaios_server/delete_graph.rs
+++ b/server/src/ankaios_server/delete_graph.rs
@@ -52,6 +52,10 @@ impl DeleteGraph {
             }
         }
     }
+
+    pub fn remove_entry(&mut self, workload_name: &str) -> bool {
+        self.delete_graph.remove(workload_name).is_some()
+    }
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/server/src/ankaios_server/delete_graph.rs
+++ b/server/src/ankaios_server/delete_graph.rs
@@ -55,7 +55,7 @@ impl DeleteGraph {
         }
     }
 
-    // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [impl->swdd~server-removes-obsolete-delete-graph-entires~1]
     pub fn remove_deleted_workloads_from_delete_graph(
         &mut self,
         workload_states: &[WorkloadState],
@@ -304,7 +304,7 @@ mod tests {
         );
     }
 
-    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [utest->swdd~server-removes-obsolete-delete-graph-entires~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_delete_entries() {
         let mut delete_graph = DeleteGraph::default();
@@ -328,7 +328,7 @@ mod tests {
         assert!(delete_graph.delete_graph.is_empty());
     }
 
-    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [utest->swdd~server-removes-obsolete-delete-graph-entires~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_keep_entries() {
         let mut delete_graph = DeleteGraph::default();
@@ -352,7 +352,7 @@ mod tests {
         assert!(delete_graph.delete_graph.contains_key(WORKLOAD_NAME_1));
     }
 
-    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [utest->swdd~server-removes-obsolete-delete-graph-entires~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph_ignore_not_relevant_workload_states() {
         let mut delete_graph = DeleteGraph::default();

--- a/server/src/ankaios_server/delete_graph.rs
+++ b/server/src/ankaios_server/delete_graph.rs
@@ -287,4 +287,20 @@ mod tests {
             deleted_workloads[1]
         );
     }
+
+    #[test]
+    fn utest_remove_entry() {
+        let mut delete_graph = DeleteGraph::default();
+
+        delete_graph.delete_graph.insert(
+            WORKLOAD_NAME_1.to_owned(),
+            HashMap::from([(
+                WORKLOAD_NAME_2.to_owned(),
+                DeleteCondition::DelCondNotPendingNorRunning,
+            )]),
+        );
+
+        assert!(delete_graph.remove_entry(WORKLOAD_NAME_1));
+        assert!(!delete_graph.remove_entry("not existing workload"));
+    }
 }

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -235,11 +235,9 @@ impl ServerState {
         }
     }
 
-    pub fn remove_deleted_workloads_from_delete_graph(
-        &mut self,
-        new_workload_states: &[WorkloadState],
-    ) {
-        // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [impl->swdd~server-cleans-up-state~1]
+    pub fn cleanup_state(&mut self, new_workload_states: &[WorkloadState]) {
+        // [impl->swdd~server-removes-obsolete-delete-graph-entires~1]
         self.delete_graph
             .remove_deleted_workloads_from_delete_graph(new_workload_states);
     }
@@ -930,7 +928,7 @@ mod tests {
         assert!(added_deleted_workloads.is_some());
     }
 
-    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
+    // [utest->swdd~server-removes-obsolete-delete-graph-entires~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph() {
         let mut mock_delete_graph = MockDeleteGraph::default();
@@ -946,7 +944,7 @@ mod tests {
 
         let workload_states = vec![];
 
-        server_state.remove_deleted_workloads_from_delete_graph(&workload_states);
+        server_state.cleanup_state(&workload_states);
     }
 
     fn generate_test_old_state() -> CompleteState {

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -239,15 +239,8 @@ impl ServerState {
         &mut self,
         new_workload_states: &[WorkloadState],
     ) {
-        for wl_state in new_workload_states {
-            if wl_state.execution_state.is_removed()
-                && self
-                    .delete_graph
-                    .remove_entry(wl_state.instance_name.workload_name())
-            {
-                log::debug!("Removed '{}' from delete graph.", wl_state.instance_name);
-            }
-        }
+        self.delete_graph
+            .remove_deleted_workloads_from_delete_graph(new_workload_states);
     }
 }
 
@@ -934,6 +927,24 @@ mod tests {
             .update(new_complete_state.clone(), update_mask)
             .unwrap();
         assert!(added_deleted_workloads.is_some());
+    }
+
+    #[test]
+    fn utest_remove_deleted_workloads_from_delete_graph() {
+        let mut mock_delete_graph = MockDeleteGraph::default();
+        mock_delete_graph
+            .expect_remove_deleted_workloads_from_delete_graph()
+            .once()
+            .return_const(());
+
+        let mut server_state = ServerState {
+            delete_graph: mock_delete_graph,
+            ..Default::default()
+        };
+
+        let workload_states = vec![];
+
+        server_state.remove_deleted_workloads_from_delete_graph(&workload_states);
     }
 
     fn generate_test_old_state() -> CompleteState {

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -239,6 +239,7 @@ impl ServerState {
         &mut self,
         new_workload_states: &[WorkloadState],
     ) {
+        // [impl->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
         self.delete_graph
             .remove_deleted_workloads_from_delete_graph(new_workload_states);
     }
@@ -929,6 +930,7 @@ mod tests {
         assert!(added_deleted_workloads.is_some());
     }
 
+    // [utest->swdd~server-removes-obsolete-delete-conditions-from-delete-graph~1]
     #[test]
     fn utest_remove_deleted_workloads_from_delete_graph() {
         let mut mock_delete_graph = MockDeleteGraph::default();

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -16,7 +16,7 @@ use super::cycle_check;
 #[cfg_attr(test, mockall_double::double)]
 use super::delete_graph::DeleteGraph;
 use crate::workload_state_db::WorkloadStateDB;
-use common::objects::WorkloadInstanceName;
+use common::objects::{WorkloadInstanceName, WorkloadState};
 use common::{
     commands::CompleteStateRequest,
     objects::{CompleteState, DeletedWorkload, State, WorkloadSpec},
@@ -232,6 +232,21 @@ impl ServerState {
                 }
             }
             Err(error) => Err(error),
+        }
+    }
+
+    pub fn remove_deleted_workloads_from_delete_graph(
+        &mut self,
+        new_workload_states: &[WorkloadState],
+    ) {
+        for wl_state in new_workload_states {
+            if wl_state.execution_state.is_removed()
+                && self
+                    .delete_graph
+                    .remove_entry(wl_state.instance_name.workload_name())
+            {
+                log::debug!("Removed '{}' from delete graph.", wl_state.instance_name);
+            }
         }
     }
 }


### PR DESCRIPTION
Issues: #48 

The PR implements the maintaining of the delete graph.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
