### PR TITLE
Remove unused Success response

### DIFF
--- a/api/proto/ankaios.proto
+++ b/api/proto/ankaios.proto
@@ -231,14 +231,11 @@ message UpdateWorkloadState {
 message Response {
   string requestId = 1;
   oneof ResponseContent {
-    Success success = 2;
     Error error = 3;
     CompleteState completeState = 4;
     UpdateStateSuccess UpdateStateSuccess = 5;
   }
 }
-
-message Success {}
 
 message Error {
   string message = 1;

--- a/common/src/commands.rs
+++ b/common/src/commands.rs
@@ -209,7 +209,6 @@ impl TryFrom<proto::Response> for Response {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum ResponseContent {
-    Success,
     Error(Error),
     CompleteState(Box<CompleteState>),
     UpdateStateSuccess(UpdateStateSuccess),
@@ -218,10 +217,6 @@ pub enum ResponseContent {
 impl From<ResponseContent> for proto::response::ResponseContent {
     fn from(value: ResponseContent) -> Self {
         match value {
-            ResponseContent::Success => {
-                proto::response::ResponseContent::Success(proto::Success {})
-            }
-
             ResponseContent::Error(error) => proto::response::ResponseContent::Error(error.into()),
             ResponseContent::CompleteState(complete_state) => {
                 proto::response::ResponseContent::CompleteState((*complete_state).into())
@@ -238,7 +233,6 @@ impl TryFrom<proto::response::ResponseContent> for ResponseContent {
 
     fn try_from(value: proto::response::ResponseContent) -> Result<Self, String> {
         match value {
-            proto::response::ResponseContent::Success(_) => Ok(ResponseContent::Success),
             proto::response::ResponseContent::Error(error) => {
                 Ok(ResponseContent::Error(error.into()))
             }
@@ -321,7 +315,7 @@ mod tests {
         pub use api::proto::{
             execution_state::ExecutionStateEnum, request::RequestContent,
             response::ResponseContent, ApiVersion, CompleteState, CompleteStateRequest, Error,
-            ExecutionState, Request, Response, Running, State, Success, UpdateStateRequest,
+            ExecutionState, Request, Response, Running, State, UpdateStateRequest,
             UpdateStateSuccess, UpdateWorkloadState, Workload, WorkloadInstanceName, WorkloadState,
         };
     }
@@ -392,21 +386,6 @@ mod tests {
                 state: complete_state!(ankaios),
                 update_mask: vec![FIELD_1.into(), FIELD_2.into()],
             }))
-        };
-    }
-
-    macro_rules! success_response {
-        (proto) => {
-            proto::Response {
-                request_id: REQUEST_ID.into(),
-                response_content: proto::ResponseContent::Success(proto::Success {}).into(),
-            }
-        };
-        (ankaios) => {
-            ankaios::Response {
-                request_id: REQUEST_ID.into(),
-                response_content: ankaios::ResponseContent::Success,
-            }
         };
     }
 
@@ -731,28 +710,6 @@ mod tests {
         assert_eq!(
             ankaios::Request::try_from(proto_request).unwrap_err(),
             "Request has no content"
-        );
-    }
-
-    #[test]
-    fn utest_converts_to_proto_success_response() {
-        let ankaios_success_response = success_response!(ankaios);
-        let proto_success_response = success_response!(proto);
-
-        assert_eq!(
-            proto::Response::from(ankaios_success_response),
-            proto_success_response
-        );
-    }
-
-    #[test]
-    fn utest_converts_from_proto_success_response() {
-        let proto_success_response = success_response!(proto);
-        let ankaios_success_response = success_response!(ankaios);
-
-        assert_eq!(
-            ankaios::Response::try_from(proto_success_response).unwrap(),
-            ankaios_success_response
         );
     }
 

--- a/common/src/from_server_interface.rs
+++ b/common/src/from_server_interface.rs
@@ -104,7 +104,6 @@ pub trait FromServerInterface {
         request_id: String,
         complete_state: CompleteState,
     ) -> Result<(), FromServerInterfaceError>;
-    async fn success(&self, request_id: String) -> Result<(), FromServerInterfaceError>;
     async fn update_state_success(
         &self,
         request_id: String,
@@ -163,15 +162,6 @@ impl FromServerInterface for FromServerSender {
                 response_content: commands::ResponseContent::CompleteState(Box::new(
                     complete_state,
                 )),
-            }))
-            .await?)
-    }
-
-    async fn success(&self, request_id: String) -> Result<(), FromServerInterfaceError> {
-        Ok(self
-            .send(FromServer::Response(commands::Response {
-                request_id,
-                response_content: commands::ResponseContent::Success,
             }))
             .await?)
     }


### PR DESCRIPTION
Issues: #13

The changes here remove the unused Success response. The IDs of the enum are not touched explicitly to allow a later reintroduction in case the response is indeed needed in future.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
