### PR TITLE
Add a hint about a required summary comment in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,5 +36,6 @@ assignees: ''
 <!-- Please provide any additional information that may be helpful in understanding the issue. -->
 
 ## Final result
+<!-- Before filling in the final result, summarize the use-case and/or workflow in a comment and discuss it with the committers -->
 
 **To be filled by the one closing the issue.**

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -16,6 +16,7 @@ assignees: ''
 <!-- describe the goals you want to achieve with this enhancement -->
 
 ## Final result
+<!-- Before filling in the final result, summarize the use-case and/or workflow in a comment and discuss it with the committers -->
 
 ### Summary
 


### PR DESCRIPTION
Issues: #

As agreed, we would like to have a summary of the planned changes in every issue before actually starting the work. This PR adds a hint in the templates as a reminder to the contributors.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
