### PR TITLE
Use static release of podman for Vagrant Ubuntu 22.04

### DIFF
--- a/tools/vagrant/ubuntu22.04/init.sh
+++ b/tools/vagrant/ubuntu22.04/init.sh
@@ -1,4 +1,15 @@
 #!/bin/bash
 
 apt update
-apt install -y podman tmux
+apt install -y curl tmux vim uidmap
+
+# This would install podman 3.4.4
+#apt install podman
+
+# We want a newer podman and thus install static binaries
+cd /tmp
+VERSION=v4.9.4
+curl -fsSL -o podman-linux-amd64.tar.gz https://github.com/mgoltzsche/podman-static/releases/download/$VERSION/podman-linux-amd64.tar.gz
+tar -xzf podman-linux-amd64.tar.gz
+cp -r podman-linux-amd64/usr podman-linux-amd64/etc /
+rm -rf podman-linux-amd64 podman-linux-amd64.tar.gz


### PR DESCRIPTION
Before this change the podman ubuntu package has been used which is quite old in Ubuntu 22.04 (v3.4.4) and does not support pod specs. This change uses static images of podman and its dependencies and thus installs podman v4.9.4.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
