### PR TITLE
Add hint for automated parsing of workload states

### DIFF
--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -89,7 +89,8 @@ pub enum GetCommands {
         object_field_mask: Vec<String>,
     },
     /// Information about workloads of the Ankaios system
-    #[clap(visible_alias("workloads"))]
+    /// For automation use "ank get state -o json" and process the workloadStates
+    #[clap(visible_alias("workloads"), verbatim_doc_comment)]
     Workload {
         /// Only workloads of the given agent shall be output
         #[arg(short = 'a', long = "agent", required = false)]


### PR DESCRIPTION
With this pr `ank get workloads -h` will display an extended help for automation.

Issues: #119

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
