### PR TITLE
Add Slack workspace to documentation

### DIFF
--- a/doc/docs/support.md
+++ b/doc/docs/support.md
@@ -14,3 +14,7 @@ the [discussion forum](https://github.com/eclipse-ankaios/ankaios/discussions) m
 For reporting bugs or suggesting enhancements a new
 [issue](https://github.com/eclipse-ankaios/ankaios/issues) should be created
 using one of the templates if possible.
+
+## Slack
+
+Join the conversion with the community in the [Ankaios Slack workspace](https://github.com/eclipse-ankaios/ankaios/wiki#slack).


### PR DESCRIPTION
The documentation links to a wiki page as the link for joining needs to be updated every 30 days.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
