### PR TITLE
Add fix for stopping containers to documentation

### DIFF
--- a/doc/docs/usage/installation.md
+++ b/doc/docs/usage/installation.md
@@ -25,6 +25,16 @@ container runtime
 For using the `podman` runtime, Podman version 3.4.2 is sufficient but the
 `podman-kube` runtime requires at least Podman version 4.3.1.
 
+!!! note
+
+    On Ubuntu 24.04 there is a [known problem with Podman stopping containers](https://bugs.launchpad.net/ubuntu/+source/libpod/+bug/2040483).
+    The following workaround disables AppArmor for Podman. Run the following steps as root after installation of Podman:
+
+    ```shell
+    mkdir -p /etc/containers/containers.conf.d
+    printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
+    ```
+
 ## Installation methods
 
 There a different ways to install Ankaios.


### PR DESCRIPTION
Default installation of Podman on Ubuntu 24.04 has problems stopping containers. This PR adds a workaround to the documentation.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
