### PR TITLE
Remove dependencies to URL crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,6 @@ dependencies = [
  "serde_yaml",
  "tabled",
  "tokio",
- "url",
  "uuid",
 ]
 
@@ -76,7 +75,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "umask",
- "url",
  "uuid",
 ]
 
@@ -507,15 +505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,12 +601,12 @@ dependencies = [
  "mockall",
  "mockall_double",
  "prost",
+ "regex",
  "serde",
  "tokio",
  "tokio-stream",
  "tonic",
  "tonic-build",
- "url",
  "uuid",
 ]
 
@@ -772,16 +761,6 @@ dependencies = [
  "hyper",
  "pin-project",
  "tokio",
-]
-
-[[package]]
-name = "idna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -1574,21 +1553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,25 +1741,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"
@@ -1808,17 +1757,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "url"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "utf8parse"

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -35,7 +35,6 @@ futures-util = "0.3"
 rand = "0.8"
 hyper = { version = "0.14", features = ["full"] }
 hyperlocal = "0.8"
-url = "= 2.5.0"
 serde_json = "1.0"
 uuid = { version = "1.3", features = ["v4", "fast-rng"] }
 sha256 = "1.5"

--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -19,7 +19,6 @@ use crate::control_interface::Directory;
 use crate::control_interface::FileSystemError;
 use clap::Parser;
 use common::DEFAULT_SERVER_ADDRESS;
-use url::Url;
 
 const DEFAULT_RUN_FOLDER: &str = "/tmp/ankaios/";
 const RUNFOLDER_SUFFIX: &str = "_io";
@@ -33,10 +32,9 @@ pub struct Arguments {
     #[clap(short = 'n', long = "name")]
     /// The name to use for the registration with the server. Every agent has to register with a unique name.
     pub agent_name: String,
-    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap())]
+    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.to_string())]
     /// The server url.
-    pub server_url: Url,
-
+    pub server_url: String,
     /// An existing path where to manage the fifo files.
     #[clap(short = 'r', long = "run-folder", default_value_t = DEFAULT_RUN_FOLDER.into())]
     pub run_folder: String,

--- a/agent/src/cli.rs
+++ b/agent/src/cli.rs
@@ -79,7 +79,7 @@ mod tests {
 
         let args = Arguments {
             agent_name: "test_agent_name".to_owned(),
-            server_url: DEFAULT_SERVER_ADDRESS.parse().unwrap(),
+            server_url: DEFAULT_SERVER_ADDRESS.to_string(),
             run_folder: DEFAULT_RUN_FOLDER.to_owned(),
         };
 
@@ -95,7 +95,7 @@ mod tests {
 
         let args = Arguments {
             agent_name: "test_agent_name".to_owned(),
-            server_url: DEFAULT_SERVER_ADDRESS.parse().unwrap(),
+            server_url: DEFAULT_SERVER_ADDRESS.to_string(),
             run_folder: "/tmp/x".to_owned(),
         };
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -103,7 +103,8 @@ async fn main() {
     );
 
     let mut grpc_communications_client =
-        GRPCCommunicationsClient::new_agent_communication(args.agent_name.clone(), args.server_url);
+        GRPCCommunicationsClient::new_agent_communication(args.agent_name.clone(), args.server_url)
+            .unwrap_or_exit("Cannot connect to server");
 
     let mut agent_manager = AgentManager::new(
         args.agent_name,

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1.28", features = [
     "signal",
 ] }
 prost = "0.11"
-url = "= 2.5.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -17,7 +17,6 @@ use std::error::Error;
 use clap::{command, Parser, Subcommand};
 
 use common::DEFAULT_SERVER_ADDRESS;
-use url::Url;
 
 const ANK_SERVER_URL_ENV_KEY: &str = "ANK_SERVER_URL";
 
@@ -31,9 +30,9 @@ const ANK_SERVER_URL_ENV_KEY: &str = "ANK_SERVER_URL";
 pub struct AnkCli {
     #[command(subcommand)]
     pub command: Commands,
-    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.parse().unwrap(), env = ANK_SERVER_URL_ENV_KEY)]
+    #[clap(short = 's', long = "server-url", default_value_t = DEFAULT_SERVER_ADDRESS.to_string(), env = ANK_SERVER_URL_ENV_KEY)]
     /// The url to Ankaios server.
-    pub server_url: Url,
+    pub server_url: String,
     #[clap(long = "response-timeout", default_value_t = 3000)]
     /// The timeout in milliseconds to wait for a response.
     pub response_timeout_ms: u64,

--- a/ank/src/log.rs
+++ b/ank/src/log.rs
@@ -41,12 +41,12 @@ macro_rules! output_debug {
     ( $ ( $ arg : tt ) + ) => { $crate::log::output_debug_fn ( format_args ! ( $ ( $ arg ) + ) ) }
 }
 
-pub(crate) fn output_and_error_fn(args: fmt::Arguments<'_>) {
+pub(crate) fn output_and_error_fn(args: fmt::Arguments<'_>) -> ! {
     eprintln!("{} {}", "error:".bold().red(), args);
     exit(1);
 }
 
-pub(crate) fn output_and_exit_fn(args: fmt::Arguments<'_>) {
+pub(crate) fn output_and_exit_fn(args: fmt::Arguments<'_>) -> ! {
     std::println!("{}", args);
     exit(0);
 }

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -42,7 +42,10 @@ async fn main() {
         cli_name.to_string(),
         args.server_url,
         args.no_wait,
-    );
+    )
+    .unwrap_or_else(|err| {
+        output_and_error!("Cannot connect to server: '{}'", err);
+    });
 
     match args.command {
         cli::Commands::Get(get_args) => match get_args.command {

--- a/common/src/communications_error.rs
+++ b/common/src/communications_error.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use tokio::task::JoinError;
 
+#[derive(Debug, Clone)]
 pub struct CommunicationMiddlewareError(pub String);
 
 impl From<JoinError> for CommunicationMiddlewareError {

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -24,8 +24,8 @@ tokio = { version = "1.28", features = [
 tokio-stream = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-url = "= 2.5.0"
 uuid = { version = "1.3", features = ["v4", "fast-rng"] }
+regex = "1.10"
 
 [dev-dependencies]
 common = { path = "../common", features = ["test_utils"] }

--- a/grpc/tests/grpc_test.rs
+++ b/grpc/tests/grpc_test.rs
@@ -15,7 +15,6 @@ mod grpc_tests {
     use grpc::{client::GRPCCommunicationsClient, server::GRPCCommunicationsServer};
 
     use tokio::time::timeout;
-    use url::Url;
 
     enum CommunicationType {
         Cli,
@@ -32,7 +31,7 @@ mod grpc_tests {
         tokio::task::JoinHandle<Result<(), CommunicationMiddlewareError>>,
     ) {
         let (to_grpc_client, grpc_client_receiver) = tokio::sync::mpsc::channel::<ToServer>(20);
-        let url = Url::parse(&format!("http://{}", server_addr)).expect("error");
+        let url = format!("http://{}", server_addr);
         let mut grpc_communications_client = match comm_type {
             CommunicationType::Cli => {
                 GRPCCommunicationsClient::new_cli_communication(test_request_id.to_owned(), url)
@@ -40,7 +39,7 @@ mod grpc_tests {
             CommunicationType::Agent => {
                 GRPCCommunicationsClient::new_agent_communication(test_request_id.to_owned(), url)
             }
-        };
+        }.unwrap();
 
         let grpc_client_task = tokio::spawn(async move {
             grpc_communications_client


### PR DESCRIPTION
This PR removes the dependency to the URL crate as the functionality can be easily achieved also without pulling in 28 dependencies into Ankaios.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
