### PR TITLE
Improve the error message when entering wrong kube down options

### DIFF
--- a/agent/src/runtime_connectors/cli_command.rs
+++ b/agent/src/runtime_connectors/cli_command.rs
@@ -36,10 +36,10 @@ impl<'a> CliCommand<'a> {
     pub async fn exec(&mut self) -> Result<String, String> {
         let mut child = self.command.spawn().map_err(|err| {
             format!(
-                "Could not spawn command '{:?}'. Error: {}",
+                "Could not spawn command '{:?}'. Error: '{}'",
                 self.command, err
             )
-        })?
+        })?;
 
         if let Some(stdin) = self.stdin {
             child
@@ -48,18 +48,18 @@ impl<'a> CliCommand<'a> {
                 .ok_or_else(|| "Could not access commands stdin".to_string())?
                 .write_all(stdin)
                 .await
-                .map_err(|err| format!("Could write stdin data to command: {}", err))?;
+                .map_err(|err| format!("Could write stdin data to command: '{}'", err))?;
         }
         let result = child.wait_with_output().await.unwrap();
         if result.status.success() {
             String::from_utf8(result.stdout)
-                .map_err(|err| format!("Could not decode command's output as UTF8: {}", err))
+                .map_err(|err| format!("Could not decode command's output as UTF8: '{}'", err))
         } else {
             let stderr = String::from_utf8(result.stderr).unwrap_or_else(|err| {
-                format!("Could not decode command's stderr as UTF8: {}", err)
+                format!("Could not decode command's stderr as UTF8: '{}'", err)
             });
             Err(format!(
-                "Execution of '{:?}' failed: {}",
+                "Execution of '{:?}' failed: '{}'",
                 self.command,
                 stderr.trim()
             ))

--- a/agent/src/runtime_connectors/cli_command.rs
+++ b/agent/src/runtime_connectors/cli_command.rs
@@ -105,7 +105,7 @@ mod tests {
     #[tokio::test]
     async fn utest_cli_command_fail_on_not_existing_command() {
         let result = CliCommand::new("non_existing_command").exec().await;
-        assert!(matches!(result, Err(x) if x.starts_with("Could not execute command")));
+        assert!(matches!(result, Err(x) if x.starts_with("Could not spawn command")));
     }
 
     #[tokio::test]
@@ -135,7 +135,7 @@ mod tests {
             .exec()
             .await;
 
-        assert!(matches!(result, Err(x) if x== "Execution of command failed: error"));
+        assert_eq!(result, Err("Execution of 'Command { std: \"bash\" \"-c\" \"echo output;echo error >&2; false\", kill_on_drop: false }' failed: 'error'".to_string()));
     }
 
     #[tokio::test]
@@ -157,7 +157,7 @@ mod tests {
             .await;
 
         assert!(
-            matches!(result, Err(x) if x.starts_with("Execution of command failed: Could not decode command's stderr as UTF8"))
+            matches!(result, Err(x) if x.contains("Could not decode command's stderr as UTF8"))
         );
     }
 

--- a/agent/src/runtime_connectors/cli_command.rs
+++ b/agent/src/runtime_connectors/cli_command.rs
@@ -34,10 +34,12 @@ impl<'a> CliCommand<'a> {
     }
 
     pub async fn exec(&mut self) -> Result<String, String> {
-        let mut child = self
-            .command
-            .spawn()
-            .map_err(|err| format!("Could not execute command: {}", err))?;
+        let mut child = self.command.spawn().map_err(|err| {
+            format!(
+                "Could not spawn command '{:?}'. Error: {}",
+                self.command, err
+            )
+        })?
 
         if let Some(stdin) = self.stdin {
             child
@@ -46,7 +48,7 @@ impl<'a> CliCommand<'a> {
                 .ok_or_else(|| "Could not access commands stdin".to_string())?
                 .write_all(stdin)
                 .await
-                .map_err(|err| format!("Could write data to command: {}", err))?;
+                .map_err(|err| format!("Could write stdin data to command: {}", err))?;
         }
         let result = child.wait_with_output().await.unwrap();
         if result.status.success() {
@@ -56,7 +58,11 @@ impl<'a> CliCommand<'a> {
             let stderr = String::from_utf8(result.stderr).unwrap_or_else(|err| {
                 format!("Could not decode command's stderr as UTF8: {}", err)
             });
-            Err(format!("Execution of command failed: {}", stderr.trim()))
+            Err(format!(
+                "Execution of '{:?}' failed: {}",
+                self.command,
+                stderr.trim()
+            ))
         }
     }
 }


### PR DESCRIPTION
This problem was reported by @sboett-dev.

It is not possible to delete a podman-kube workload anymore when specifying the podman-kube downOptions as an array with an empty string:
downOptions: [""]

We cannot actually reject the config before creating the workload as we do not have control over the options which will be added to Podman in future. The also should not make a restriction there to keep all doors open for changes on Podman without having to update Ankaios to support them.

The only solution to the problem is to enhance the error message in order to give the reason to the user. As such misconfiguration errors should be easy to discover during development, this should be sufficient.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
