### PR TITLE
Add tool to run Ankaios in docker

### DIFF
--- a/tools/ankaios-docker/README.md
+++ b/tools/ankaios-docker/README.md
@@ -5,7 +5,15 @@ This includes quick evaluation without installation, or running Ankaios on non-L
 
 ## Pre-conditions
 
-Docker Desktop or docker engine with `docker compose` must be available.
+Docker Desktop or docker engine with the compose plugin must be available.
+
+On Manjaro the compose plugin can be installed with:
+
+```shell
+sudo pacman -S docker-compose
+```
+
+Afterwards the plugin is avilable as sub command `docker compose`.
 
 ## Startup
 

--- a/tools/ankaios-docker/README.md
+++ b/tools/ankaios-docker/README.md
@@ -20,7 +20,7 @@ Just call:
 docker compose up -d
 ```
 
-Aftewards the `ank` CLI can be used to interact with Ankaios.
+Afterwards the `ank` CLI can be used to interact with Ankaios.
 Please make sure that the version of the `ank` CLI fits to the version of the Ankaios server and agent (see `compose.yaml`).
 
 ```shell

--- a/tools/ankaios-docker/README.md
+++ b/tools/ankaios-docker/README.md
@@ -1,0 +1,51 @@
+# Ankaios in docker
+
+For some scenarios it might be useful to run Ankaios in containers itself.
+This includes quick evaluation without installation, or running Ankaios on non-Linux platforms like Windows or MacOS.
+
+## Pre-conditions
+
+Docker Desktop or docker engine with `docker compose` must be available.
+
+## Startup
+
+The setup includes
+
+* One container running Ankaios server
+* An other container running Ankaios agent and podman
+
+Just call:
+
+```shell
+docker compose up -d
+```
+
+Aftewards the `ank` CLI can be used to interact with Ankaios.
+Please make sure that the version of the `ank` CLI fits to the version of the Ankaios server and agent (see `compose.yaml`).
+
+```shell
+ank get workloads
+```
+
+## Shutdown
+
+To stop Ankaios just call:
+
+```shell
+docker compose down
+```
+
+## Modify startup config
+
+The basic setup includes an empty startup config.
+In case workloads shall started at startup of the Ankaios server just modify the `server/state.yaml` and call:
+
+```shell
+docker compose build
+```
+
+Afterwards Ankaios can be started again using:
+
+```shell
+docker compose up -d
+```

--- a/tools/ankaios-docker/agent/Dockerfile
+++ b/tools/ankaios-docker/agent/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+ARG VERSION=v0.3.1
+
+RUN apt update && \
+    apt install -y curl podman
+
+COPY containers.conf /etc/containers/containers.conf
+
+RUN curl -sfL https://github.com/eclipse-ankaios/ankaios/releases/download/${VERSION}/ankaios-linux-${TARGETARCH}.tar.gz | tar xz -C /usr/local/bin
+
+CMD ["/usr/local/bin/ank-agent", "--name", "agent_A", "--server-url", "http://ank-server:25551"]

--- a/tools/ankaios-docker/agent/containers.conf
+++ b/tools/ankaios-docker/agent/containers.conf
@@ -1,0 +1,12 @@
+[containers]
+netns="private"
+userns="host"
+ipcns="host"
+utsns="host"
+cgroupns="host"
+cgroups="disabled"
+log_driver = "k8s-file"
+[engine]
+cgroup_manager = "cgroupfs"
+events_logger="file"
+runtime="crun"

--- a/tools/ankaios-docker/compose.yaml
+++ b/tools/ankaios-docker/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  ank-server:
+    build: 
+      context: ./server
+      args:
+        - VERSION=v0.3.1
+    ports:
+      - "25551:25551"
+  
+  ank-agent:
+    build:
+      context: ./agent
+      args:
+        - VERSION=v0.3.1
+    privileged: true
+
+
+

--- a/tools/ankaios-docker/server/Dockerfile
+++ b/tools/ankaios-docker/server/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+ARG VERSION=v0.3.1
+
+RUN apt update && \
+    apt install -y curl
+
+RUN curl -sfL https://github.com/eclipse-ankaios/ankaios/releases/download/${VERSION}/ankaios-linux-${TARGETARCH}.tar.gz | tar xz -C /usr/local/bin
+
+COPY state.yaml /etc/ankaios/state.yaml
+
+CMD ["/usr/local/bin/ank-server", "--address", "0.0.0.0:25551", "--startup-config", "/etc/ankaios/state.yaml"]

--- a/tools/ankaios-docker/server/state.yaml
+++ b/tools/ankaios-docker/server/state.yaml
@@ -1,0 +1,13 @@
+# Per default no workload is started. Adapt the file according to your needs.
+apiVersion: v0.1
+workloads:
+#   nginx:
+#     runtime: podman
+#     agent: agent_A
+#     restartPolicy: NEVER
+#     tags:
+#       - key: owner
+#         value: Ankaios team
+#     runtimeConfig: |
+#       image: docker.io/nginx:latest
+#       commandOptions: ["-p", "8081:80"]


### PR DESCRIPTION
For some scenarios it might be useful to run Ankaios in containers itself.
This includes quick evaluation without installation, or running Ankaios on non-Linux platforms like Windows or MacOS.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
