### PR TITLE
Small improvements of the dev environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,7 @@
                 "files.watcherExclude": {
                     "**/target/**": true
                 },
-                "rust-analyzer.checkOnSave.command": "clippy",
-                "crates.compatibleDecorator": "🗹",
-                "crates.incompatibleDecorator": "☒ ${version}"
+                "rust-analyzer.checkOnSave.command": "clippy"
             },
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,27 +5,28 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
-   "mounts": [
-   ],
-   "runArgs": ["--privileged"],
-   "customizations": {
-       "vscode": {
-           // Set *default* container specific settings.json values on container create.
-           "settings": {
-               "lldb.executable": "/usr/bin/lldb",
-               // VS Code don't watch files under ./target
-               "files.watcherExclude": {
-                   "**/target/**": true
-               },
-               "rust-analyzer.checkOnSave.command": "clippy"
-           },
-           // Add the IDs of extensions you want installed when the container is created.
-           "extensions": [
+    "mounts": [
+    ],
+    "runArgs": ["--privileged"],
+    "customizations": {
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {
+                "lldb.executable": "/usr/bin/lldb",
+                // VS Code don't watch files under ./target
+                "files.watcherExclude": {
+                    "**/target/**": true
+                },
+                "rust-analyzer.checkOnSave.command": "clippy",
+                "crates.compatibleDecorator": "🗹",
+                "crates.incompatibleDecorator": "☒ ${version}"
+            },
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
                 "vadimcn.vscode-lldb",
                 "mutantdino.resourcemonitor",
                 "rust-lang.rust-analyzer",
                 "tamasfe.even-better-toml",
-                "serayuzgur.crates",
                 "timonwong.shellcheck",
                 "eamodio.gitlens",
                 "streetsidesoftware.code-spell-checker",
@@ -41,11 +42,14 @@
                 "d-biehl.robotcode",
                 "bianxianyang.htmlplay",
                 "DavidAnson.vscode-markdownlint",
-                "EditorConfig.EditorConfig"
-        ]
-       }
-   },
-   "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/ankaios/,type=bind",
-   "workspaceFolder": "/workspaces/ankaios/",
-   "remoteUser": "vscode"
+                "EditorConfig.EditorConfig",
+                "ms-vsliveshare.vsliveshare",
+                "BarbossHack.crates-io",
+                "PKief.material-icon-theme"
+            ]
+        }
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/ankaios/,type=bind",
+    "workspaceFolder": "/workspaces/ankaios/",
+    "remoteUser": "vscode"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,6 @@ version = "0.4.0-pre"
 dependencies = [
  "api",
  "async-trait",
- "common",
  "log",
  "serde",
  "serde_yaml",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -24,9 +24,6 @@ serde_yaml = "0.9"
 log = "0.4"
 sha256 = "1.5"
 
-[dev-dependencies]
-common = { features = ["test_utils"], path = "." }
-
 [features]
 default = []
 test_utils = []

--- a/common/src/state_manipulation/object.rs
+++ b/common/src/state_manipulation/object.rs
@@ -665,7 +665,7 @@ mod tests {
         use crate::objects::generate_test_runtime_config;
 
         pub fn generate_test_complete_state() -> Mapping {
-            let config_hash: &dyn common::objects::ConfigHash = &generate_test_runtime_config();
+            let config_hash: &dyn crate::objects::ConfigHash = &generate_test_runtime_config();
             Mapping::default()
                 .entry("desiredState", generate_test_state())
                 .entry(


### PR DESCRIPTION
Small improvements of the dev environment:
* removed cargo self dependency from common that caused error in the rust-analyzer
* switching to crates-io extension (old one is deprecated and the suggested dependi has an incompatible license)
* adding vsliveshare and material-icon-theme

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
