### PR TITLE
Update devcontainer to Rust 1.80.1

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ target = "x86_64-unknown-linux-musl"
 
 [target.aarch64-unknown-linux-musl]
 linker="aarch64-linux-gnu-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker="x86_64-linux-gnu-gcc"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -12,8 +12,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:1-debian-12 AS src
-
 FROM ubuntu:24.04
 
 ARG TARGETARCH
@@ -59,20 +57,23 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     podman \
     # TLS
     musl-tools \
+    # Cleanup
     && rm -rf /var/lib/apt/lists/*
 
 # User management
-COPY --from=src /home/vscode/.bashrc /etc/skel/
 RUN (userdel -r ubuntu || true) \
     && groupadd rustlang \
     && useradd -s /bin/bash -d /home/${USERNAME} -m -G rustlang ${USERNAME} \
     && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
 
-# Install oh-my-zsh
+# Prepare shells
 USER ${USERNAME}
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \
-    && sed -i 's/ZSH_THEME="[^"]*"/ZSH_THEME="devcontainers"/' /home/${USERNAME}/.zshrc
-COPY --from=src /home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme /home/${USERNAME}/.oh-my-zsh/custom/themes/
+COPY --chown=${USERNAME}:${USERNAME} dot_bashrc /home/${USERNAME}/.bashrc
+COPY --chown=${USERNAME}:${USERNAME} dot_zshrc /home/${USERNAME}/.zshrc
+RUN curl -sS https://starship.rs/install.sh | sh -s -- -y \
+    && echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
+    && echo 'eval "$(starship init zsh)"' >> /home/${USERNAME}/.zshrc
+COPY --chown=${USERNAME}:${USERNAME} starship.toml /home/${USERNAME}/.config/
 USER root
 
 # Rust

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -70,6 +70,7 @@ RUN (userdel -r ubuntu || true) \
 USER ${USERNAME}
 COPY --chown=${USERNAME}:${USERNAME} dot_bashrc /home/${USERNAME}/.bashrc
 COPY --chown=${USERNAME}:${USERNAME} dot_zshrc /home/${USERNAME}/.zshrc
+COPY --chown=${USERNAME}:${USERNAME} dot_tmux.conf /home/${USERNAME}/.tmux.conf
 RUN curl -sS https://starship.rs/install.sh | sh -s -- -y \
     && echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
     && echo 'eval "$(starship init zsh)"' >> /home/${USERNAME}/.zshrc

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -14,20 +14,18 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/base:1-debian-12 AS src
 
-FROM debian:12
+FROM ubuntu:24.04
 
 ARG TARGETARCH
 ARG USERNAME=vscode
 
 # All the packages we need
-RUN export DEBIAN_FRONTEND=noninteractive; \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt update && \
     if [ "$TARGETARCH" = "amd64" ]; then \
-        dpkg --add-architecture arm64 && \
-        apt update && \
-        apt install -y gcc-aarch64-linux-gnu musl-tools libc6-dev:arm64; \
+        apt install -y gcc-aarch64-linux-gnu; \
     elif [ "$TARGETARCH" = "arm64" ]; then \
-        apt update && \
-        apt install -y gcc-x86-64-linux-gnu musl-tools; \
+        apt install -y gcc-x86-64-linux-gnu; \
     fi \
     && apt -y install \
     # Basics
@@ -65,7 +63,8 @@ RUN export DEBIAN_FRONTEND=noninteractive; \
 
 # User management
 COPY --from=src /home/vscode/.bashrc /etc/skel/
-RUN groupadd rustlang \
+RUN (userdel -r ubuntu || true) \
+    && groupadd rustlang \
     && useradd -s /bin/bash -d /home/${USERNAME} -m -G rustlang ${USERNAME} \
     && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
 
@@ -85,7 +84,7 @@ RUN mkdir -p -m 2777 $RUSTUP_HOME \
     && mkdir -p -m 2777 $CARGO_HOME \
     && chgrp rustlang $CARGO_HOME \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-       sh -s -- -y --default-toolchain 1.80.1 --target x86_64-unknown-linux-musl aarch64-linux-gnu-gcc --no-modify-path \
+       sh -s -- -y --default-toolchain 1.80.1 --target x86_64-unknown-linux-musl aarch64-unknown-linux-musl --no-modify-path \
     && chmod -R ag+w $RUSTUP_HOME $CARGO_HOME
 
 VOLUME /var/lib/containers
@@ -129,9 +128,5 @@ RUN cargo install cargo-llvm-cov --locked; \
     cargo install cargo-nextest --locked; \
     cargo install cargo-deny --locked; \
     cargo install cargo-about --locked
-
-# Install required cargo targets and toolchains
-RUN rustup target add x86_64-unknown-linux-musl \
-    && rustup target add aarch64-unknown-linux-musl
 
 USER root

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -12,13 +12,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/base:1-debian-12 AS src
 
-ARG USERNAME=vscode
+FROM debian:12
+
 ARG TARGETARCH
+ARG USERNAME=vscode
 
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install \
+# All the packages we need
+RUN export DEBIAN_FRONTEND=noninteractive; \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+        dpkg --add-architecture arm64 && \
+        apt update && \
+        apt install -y gcc-aarch64-linux-gnu musl-tools libc6-dev:arm64; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        apt update && \
+        apt install -y gcc-x86-64-linux-gnu musl-tools; \
+    fi \
+    && apt -y install \
+    # Basics
+    git \
+    zsh \
+    curl \
+    iputils-ping \
+    sudo \
     # java for plantuml
     default-jre \
     graphviz \
@@ -35,7 +52,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Others
     protobuf-compiler \
     protobuf-compiler-grpc \
-    gcc-aarch64-linux-gnu \
     tmux \
     vim \
     uidmap \
@@ -45,8 +61,32 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     podman \
     # TLS
     musl-tools \
-    && \
-    rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
+
+# User management
+COPY --from=src /home/vscode/.bashrc /etc/skel/
+RUN groupadd rustlang \
+    && useradd -s /bin/bash -d /home/${USERNAME} -m -G rustlang ${USERNAME} \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
+
+# Install oh-my-zsh
+USER ${USERNAME}
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended \
+    && sed -i 's/ZSH_THEME="[^"]*"/ZSH_THEME="devcontainers"/' /home/${USERNAME}/.zshrc
+COPY --from=src /home/vscode/.oh-my-zsh/custom/themes/devcontainers.zsh-theme /home/${USERNAME}/.oh-my-zsh/custom/themes/
+USER root
+
+# Rust
+ENV RUSTUP_HOME=/usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo
+ENV PATH=/usr/local/cargo/bin:$PATH
+RUN mkdir -p -m 2777 $RUSTUP_HOME \
+    && chgrp rustlang $RUSTUP_HOME \
+    && mkdir -p -m 2777 $CARGO_HOME \
+    && chgrp rustlang $CARGO_HOME \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+       sh -s -- -y --default-toolchain 1.80.1 --target x86_64-unknown-linux-musl aarch64-linux-gnu-gcc --no-modify-path \
+    && chmod -R ag+w $RUSTUP_HOME $CARGO_HOME
 
 VOLUME /var/lib/containers
 

--- a/.devcontainer/dot_bashrc
+++ b/.devcontainer/dot_bashrc
@@ -1,0 +1,118 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# don't put duplicate lines or lines starting with space in the history.
+# See bash(1) for more options
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# If set, the pattern "**" used in a pathname expansion context will
+# match all files and zero or more directories and subdirectories.
+#shopt -s globstar
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# colored GCC warnings and errors
+#export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi
+

--- a/.devcontainer/dot_tmux.conf
+++ b/.devcontainer/dot_tmux.conf
@@ -1,0 +1,2 @@
+set -g mouse on
+set-option -g default-shell /bin/zsh

--- a/.devcontainer/dot_zshrc
+++ b/.devcontainer/dot_zshrc
@@ -1,0 +1,39 @@
+# Set up the prompt
+
+#autoload -Uz promptinit
+#promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+zstyle ':completion:*' auto-description 'specify: %d'
+zstyle ':completion:*' completer _expand _complete _correct _approximate
+zstyle ':completion:*' format 'Completing %d'
+zstyle ':completion:*' group-name ''
+zstyle ':completion:*' menu select=2
+eval "$(dircolors -b)"
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+zstyle ':completion:*' menu select=long
+zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+zstyle ':completion:*' use-compctl false
+zstyle ':completion:*' verbose true
+
+zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+export EDITOR=/usr/bin/vim

--- a/.devcontainer/dot_zshrc
+++ b/.devcontainer/dot_zshrc
@@ -18,22 +18,23 @@ HISTFILE=~/.zsh_history
 autoload -Uz compinit
 compinit
 
-zstyle ':completion:*' auto-description 'specify: %d'
-zstyle ':completion:*' completer _expand _complete _correct _approximate
-zstyle ':completion:*' format 'Completing %d'
-zstyle ':completion:*' group-name ''
-zstyle ':completion:*' menu select=2
-eval "$(dircolors -b)"
-zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
-zstyle ':completion:*' list-colors ''
-zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
-zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
-zstyle ':completion:*' menu select=long
-zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
-zstyle ':completion:*' use-compctl false
-zstyle ':completion:*' verbose true
+#zstyle ':completion:*' auto-description 'specify: %d'
+#zstyle ':completion:*' completer _expand _complete _correct _approximate
+#zstyle ':completion:*' format 'Completing %d'
+#zstyle ':completion:*' group-name ''
+#zstyle ':completion:*' menu select=2
+#eval "$(dircolors -b)"
+#zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+#zstyle ':completion:*' list-colors ''
+#zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+#zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+#zstyle ':completion:*' menu select=long
+#zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+#zstyle ':completion:*' use-compctl false
+#zstyle ':completion:*' verbose true
 
-zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
-zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+#zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+#zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
 
 export EDITOR=/usr/bin/vim
+

--- a/.devcontainer/starship.toml
+++ b/.devcontainer/starship.toml
@@ -1,0 +1,4 @@
+add_newline = true
+
+[container]
+disabled = true

--- a/.devcontainer/starship.toml
+++ b/.devcontainer/starship.toml
@@ -1,4 +1,10 @@
 add_newline = true
+command_timeout = 2000
 
 [container]
 disabled = true
+
+# We need to replace the first character to fix https://github.com/microsoft/vscode/issues/143103
+[character]
+success_symbol = '[>](bold green)'
+error_symbol = '[>](bold red)'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and run system tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -50,7 +50,7 @@ jobs:
     name: Run unit tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -78,7 +78,7 @@ jobs:
     name: Create code coverage report
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -96,7 +96,7 @@ jobs:
     name: Build Linux amd64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -127,7 +127,7 @@ jobs:
     name: Build Linux arm64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1
@@ -154,7 +154,7 @@ jobs:
     name: Build requirements tracing
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build and run system tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -50,7 +50,7 @@ jobs:
     name: Run unit tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -78,7 +78,7 @@ jobs:
     name: Create code coverage report
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -96,7 +96,7 @@ jobs:
     name: Build Linux amd64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -127,7 +127,7 @@ jobs:
     name: Build Linux arm64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1
@@ -154,7 +154,7 @@ jobs:
     name: Build requirements tracing
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Prepare commit to branch gh-pages

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.9.2
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.0
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Prepare commit to branch gh-pages


### PR DESCRIPTION
For #348 we need to update to Rust 1.80.1. The previous base container image `mcr.microsoft.com/devcontainers/rust` does not provide that Rust version. For that reason I have also changed the base image version to `ubuntu:24.04` and used `rustup` to install Rust.

Issues: #89

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
