### PR TITLE
Fix rootless ports not being freed 

### DIFF
--- a/tests/stests/mtls/mtls_communication.robot
+++ b/tests/stests/mtls/mtls_communication.robot
@@ -48,7 +48,7 @@ Test Ankaios MTLS by providing PEM files via command line arguments
     # Preconditions
     # This test assumes that all containers in the podman have been created with this test -> clean it up first
     Given Podman has deleted all existing containers
-    And Ankaios server is started with config "${CONFIGS_DIR}/default.yaml" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/server.pem" "${CERTS_DIR}/server-key.pem"
+    And Ankaios server is started with config "${CONFIGS_DIR}/simple.yaml" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/server.pem" "${CERTS_DIR}/server-key.pem"
     And Ankaios agent is started with name "agent_B" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/agent.pem" "${CERTS_DIR}/agent-key.pem"
     And Ankaios agent is started with name "agent_A" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/agent.pem" "${CERTS_DIR}/agent-key.pem"
     # Actions
@@ -65,7 +65,7 @@ Test Ankaios MTLS by providing wrong PEM config via command line arguments
     # Preconditions
     # This test assumes that all containers in the podman have been created with this test -> clean it up first
     Given Podman has deleted all existing containers
-    And Ankaios server is started with config "${CONFIGS_DIR}/default.yaml" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/server.pem" "${CERTS_DIR}/server-key.pem"
+    And Ankaios server is started with config "${CONFIGS_DIR}/simple.yaml" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/server.pem" "${CERTS_DIR}/server-key.pem"
     And Ankaios agent is started with name "agent_B" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/agent.pem" "${CERTS_DIR}/agent-key.pem"
     And Ankaios agent is started with name "agent_A" and PEM files: "${CERTS_DIR}/ca.pem" "${CERTS_DIR}/agent.pem" "${CERTS_DIR}/agent-key.pem"
     # Actions


### PR DESCRIPTION
In this changes we switch to use a config that does not require port forwarding for tests that do not wait for a proper workload state.
It seems like Podman is instable when deleting containers with port forwarding when the container is not running yet.

Issues: #363

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
