### PR TITLE
Add fix for system tests to dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -60,6 +60,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     # Cleanup
     && rm -rf /var/lib/apt/lists/*
 
+# Workaround for podman not being able to stop containers, see https://bugs.launchpad.net/ubuntu/noble/+source/libpod/+bug/2040483
+RUN mkdir -p /etc/containers/containers.conf.d \
+    && printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
+
 # User management
 RUN (userdel -r ubuntu || true) \
     && groupadd rustlang \
@@ -94,6 +98,19 @@ VOLUME /var/lib/containers
 COPY containers.conf /etc/containers/containers.conf
 RUN chmod 644 /etc/containers/containers.conf
 
+# install just
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        ITEMARCH="x86_64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        ITEMARCH="aarch64"; \
+    else \
+        exit 1; \
+    fi; \
+    curl -sL https://github.com/casey/just/releases/download/1.35.0/just-1.35.0-${ITEMARCH}-unknown-linux-musl.tar.gz | \
+    tar xz --directory=/usr/local/bin just \
+    && echo 'source <(just --completions bash)' >> /home/${USERNAME}/.bashrc \
+    && echo 'source <(just --completions zsh)' >> /home/${USERNAME}/.zshrc
+
 # install grpcurl
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
         ITEMARCH="x86_64"; \
@@ -113,7 +130,7 @@ RUN curl -sL https://github.com/plantuml/plantuml/releases/download/v1.2024.0/pl
 COPY plantuml /usr/local/bin
 
 # MkDocs Material
-RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip install mkdocs-material pillow cairosvg mike robotframework
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip install mkdocs-material pillow cairosvg mike robotframework==7.0.1
 
 # protoc-gen-doc
 RUN curl -sL https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_${TARGETARCH}.tar.gz | tar xz --directory=/usr/local/bin protoc-gen-doc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,8 @@
                 "EditorConfig.EditorConfig",
                 "ms-vsliveshare.vsliveshare",
                 "BarbossHack.crates-io",
-                "PKief.material-icon-theme"
+                "PKief.material-icon-theme",
+                "nefrob.vscode-just-syntax"
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,8 +43,7 @@
                 "EditorConfig.EditorConfig",
                 "ms-vsliveshare.vsliveshare",
                 "BarbossHack.crates-io",
-                "PKief.material-icon-theme",
-                "nefrob.vscode-just-syntax"
+                "PKief.material-icon-theme"
             ]
         }
     },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build and run system tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -51,7 +51,7 @@ jobs:
     name: Run unit tests Linux amd64
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -80,7 +80,7 @@ jobs:
     name: Create code coverage report
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -98,7 +98,7 @@ jobs:
     name: Build Linux amd64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
@@ -129,7 +129,7 @@ jobs:
     name: Build Linux arm64 debian package
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1
@@ -156,7 +156,7 @@ jobs:
     name: Build requirements tracing
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
     if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.2
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Prepare commit to branch gh-pages


### PR DESCRIPTION
This PR disables app armor for Podman to prevent the issue, that Podman cannot stop containers. In addition [just](https://just.systems) is added which might replace `make`.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
