### PR TITLE
Simplify ank cli set state command

### DIFF
--- a/ank/src/cli_commands/set_state.rs
+++ b/ank/src/cli_commands/set_state.rs
@@ -12,10 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use common::{
-    objects::{CompleteState, StoredWorkloadSpec},
-    state_manipulation::{Object, Path},
-};
+use common::state_manipulation::Object;
 use std::io::{self, Read};
 
 #[cfg(not(test))]
@@ -27,30 +24,6 @@ use crate::{cli_error::CliError, output_debug};
 use tests::read_to_string_mock as read_file_to_string;
 
 use super::CliCommands;
-
-fn create_state_with_default_workload_specs(update_mask: &[String]) -> CompleteState {
-    let mut complete_state = CompleteState::default();
-    const WORKLOAD_ATTRIBUTE_LEVEL: usize = 4;
-    let workload_level_mask_parts = ["desiredState".to_string(), "workloads".to_string()];
-    const WORKLOAD_NAME_POSITION: usize = 2;
-
-    for field_mask in update_mask {
-        let path: Path = field_mask.into();
-
-        // if we want to set an attribute of a workload create a default object for the workload
-        let mask_parts = path.parts();
-        if mask_parts.len() >= WORKLOAD_ATTRIBUTE_LEVEL
-            && mask_parts.starts_with(&workload_level_mask_parts)
-        {
-            complete_state.desired_state.workloads.insert(
-                mask_parts[WORKLOAD_NAME_POSITION].to_string(),
-                StoredWorkloadSpec::default(),
-            );
-        }
-    }
-
-    complete_state
-}
 
 // [impl->swdd~cli-supports-yaml-to-set-desired-state~1]
 async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<Object, CliError> {
@@ -90,30 +63,6 @@ async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<O
     }
 }
 
-fn overwrite_using_field_mask(
-    mut complete_state_object: Object,
-    object_field_mask: &Vec<String>,
-    temp_obj: &Object,
-) -> Result<Object, CliError> {
-    for field_mask in object_field_mask {
-        let path: Path = field_mask.into();
-
-        complete_state_object
-            .set(
-                &path,
-                temp_obj
-                    .get(&path)
-                    .ok_or(CliError::ExecutionError(format!(
-                        "Specified update mask '{field_mask}' not found in the input config.",
-                    )))?
-                    .clone(),
-            )
-            .map_err(|err| CliError::ExecutionError(err.to_string()))?;
-    }
-
-    Ok(complete_state_object)
-}
-
 impl CliCommands {
     // [impl->swdd~cli-provides-set-desired-state~1]
     pub async fn set_state(
@@ -127,22 +76,17 @@ impl CliCommands {
             state_object_file
         );
 
-        let temp_obj = process_inputs(io::stdin(), &state_object_file).await?;
-        let default_complete_state = create_state_with_default_workload_specs(&object_field_mask);
-
-        // now overwrite with the values from the field mask
-        let mut complete_state_object: Object = default_complete_state.try_into()?;
-        complete_state_object =
-            overwrite_using_field_mask(complete_state_object, &object_field_mask, &temp_obj)?;
-        let new_complete_state = complete_state_object.try_into()?;
+        let complete_state = process_inputs(io::stdin(), &state_object_file)
+            .await?
+            .try_into()?;
 
         output_debug!(
             "Send UpdateState request with the CompleteState {:?}",
-            new_complete_state
+            complete_state
         );
 
         // [impl->swdd~cli-blocks-until-ankaios-server-responds-set-desired-state~2]
-        self.update_state_and_wait_for_complete(new_complete_state, object_field_mask)
+        self.update_state_and_wait_for_complete(complete_state, object_field_mask)
             .await
     }
 }
@@ -156,14 +100,11 @@ impl CliCommands {
 //////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
-    use super::{
-        create_state_with_default_workload_specs, io, overwrite_using_field_mask, process_inputs,
-        CliCommands, StoredWorkloadSpec,
-    };
+    use super::{io, process_inputs, CliCommands};
     use crate::cli_commands::server_connection::MockServerConnection;
     use api::ank_base::UpdateStateSuccess;
     use common::{
-        objects::{CompleteState, RestartPolicy, State},
+        objects::{CompleteState, RestartPolicy, State, StoredWorkloadSpec, Tag},
         state_manipulation::Object,
     };
     use mockall::predicate::eq;
@@ -177,6 +118,7 @@ mod tests {
     const RESPONSE_TIMEOUT_MS: u64 = 3000;
 
     const SAMPLE_CONFIG: &str = r#"desiredState:
+        apiVersion: api_version
         workloads:
           nginx:
             agent: agent_A
@@ -189,85 +131,6 @@ mod tests {
             runtimeConfig: |
               image: docker.io/nginx:latest
               commandOptions: ["-p", "8081:80"]"#;
-
-    // [utest->swdd~cli-provides-set-desired-state~1]
-    #[test]
-    fn utest_create_state_with_default_workload_specs_empty_update_mask() {
-        let update_mask = vec![];
-
-        let complete_state = create_state_with_default_workload_specs(&update_mask);
-
-        assert!(complete_state.desired_state.workloads.is_empty());
-    }
-
-    // [utest->swdd~cli-provides-set-desired-state~1]
-    #[test]
-    fn utest_create_state_with_default_workload_specs_with_update_mask() {
-        let update_mask = vec![
-            "desiredState.workloads.nginx.restartPolicy".to_string(),
-            "desiredState.workloads.nginx2.restartPolicy".to_string(),
-            "desiredState.workloads.nginx3".to_string(),
-        ];
-
-        let complete_state = create_state_with_default_workload_specs(&update_mask);
-
-        assert_eq!(
-            complete_state.desired_state.workloads.get("nginx"),
-            Some(&StoredWorkloadSpec::default())
-        );
-
-        assert_eq!(
-            complete_state.desired_state.workloads.get("nginx2"),
-            Some(&StoredWorkloadSpec::default())
-        );
-        assert!(!complete_state
-            .desired_state
-            .workloads
-            .contains_key("nginx3"));
-    }
-
-    // [utest->swdd~cli-provides-set-desired-state~1]
-    #[test]
-    fn utest_create_state_with_default_workload_specs_invalid_path() {
-        let update_mask = vec!["invalid.path".to_string()];
-
-        let complete_state = create_state_with_default_workload_specs(&update_mask);
-
-        assert!(complete_state.desired_state.workloads.is_empty());
-    }
-
-    // [utest->swdd~cli-provides-set-desired-state~1]
-    #[test]
-    fn utest_overwrite_using_field_mask() {
-        let workload_spec = StoredWorkloadSpec::default();
-        let mut complete_state = CompleteState {
-            desired_state: State {
-                workloads: HashMap::from([("nginx".to_string(), workload_spec)]),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let mut complete_state_object: Object = complete_state.try_into().unwrap();
-        let value: serde_yaml::Value = serde_yaml::from_str(SAMPLE_CONFIG).unwrap();
-        let temp_object = Object::try_from(&value).unwrap();
-        let update_mask = vec!["desiredState.workloads.nginx".to_string()];
-
-        complete_state_object =
-            overwrite_using_field_mask(complete_state_object, &update_mask, &temp_object).unwrap();
-
-        complete_state = complete_state_object.try_into().unwrap();
-
-        assert!(complete_state.desired_state.workloads.contains_key("nginx"));
-        assert_eq!(
-            complete_state
-                .desired_state
-                .workloads
-                .get("nginx")
-                .unwrap()
-                .restart_policy,
-            RestartPolicy::Always
-        )
-    }
 
     // [utest->swdd~cli-supports-yaml-to-set-desired-state~1]
     #[tokio::test]
@@ -318,13 +181,21 @@ mod tests {
         let state_object_file = SAMPLE_CONFIG.to_owned();
 
         let workload_spec = StoredWorkloadSpec {
+            agent: "agent_A".into(),
+            tags: vec![Tag {
+                key: "owner".into(),
+                value: "Ankaios team".into(),
+            }],
             restart_policy: RestartPolicy::Always,
+            runtime: "podman".into(),
+            runtime_config: "image: docker.io/nginx:latest\ncommandOptions: [\"-p\", \"8081:80\"]"
+                .into(),
             ..Default::default()
         };
         let updated_state = CompleteState {
             desired_state: State {
                 workloads: HashMap::from([("nginx".to_string(), workload_spec)]),
-                ..Default::default()
+                api_version: "api_version".into(),
             },
             ..Default::default()
         };
@@ -342,25 +213,5 @@ mod tests {
 
         let set_state_result = cmd.set_state(update_mask, state_object_file).await;
         assert!(set_state_result.is_ok());
-    }
-
-    // [utest->swdd~cli-provides-set-desired-state~1]
-    #[tokio::test]
-    async fn utest_set_state_failed() {
-        let wrong_update_mask = vec!["desiredState.workloads.notExistingWorkload".to_string()];
-        let state_object_file = SAMPLE_CONFIG.to_owned();
-        let mut mock_server_connection = MockServerConnection::default();
-        mock_server_connection
-            .expect_update_state()
-            .return_once(|_, _| Ok(UpdateStateSuccess::default()));
-
-        let mut cmd = CliCommands {
-            _response_timeout_ms: RESPONSE_TIMEOUT_MS,
-            no_wait: true,
-            server_connection: mock_server_connection,
-        };
-
-        let set_state_result = cmd.set_state(wrong_update_mask, state_object_file).await;
-        assert!(set_state_result.is_err());
     }
 }

--- a/tests/resources/configs/minimal_set_state.yaml
+++ b/tests/resources/configs/minimal_set_state.yaml
@@ -1,4 +1,7 @@
 desiredState:
+  apiVersion: "v0.1"
   workloads:
     simple:
       agent: ""
+      runtime: ""
+      runtimeConfig: ""

--- a/tests/resources/configs/update_state_create_one_workload.yaml
+++ b/tests/resources/configs/update_state_create_one_workload.yaml
@@ -1,4 +1,5 @@
 desiredState:
+  apiVersion: v0.1
   workloads:
     nginx:
       runtime: podman

--- a/tests/resources/configs/update_state_pending_create.yaml
+++ b/tests/resources/configs/update_state_pending_create.yaml
@@ -24,4 +24,3 @@ desiredState:
       runtimeConfig: |
         image: ghcr.io/eclipse-ankaios/tests/alpine:latest
         commandArgs: ["echo", "backend succeeded"]
-workloadStates: []


### PR DESCRIPTION
Before the ank cli, when executing a "set state" command, only send the parts of the state which have be changed by the update mask. This was probably done for previous problems with optional fields. This is now been removed and ank cli sends the whole state provided by the users, as:

* the implementation did not allow to delete objects from the desired state
* the ank cli should not have to much knowledge about the implementation. E.g. if we would introduce wildcards in the mask, this would needed to be implemented in the server and the ank cli.


# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
