### PR TITLE
Add instructions for private vulnerability reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you want to report a vulnerability in Ankaios or one of the SDKs, you can create a [private vulnerability report using Github](https://github.com/eclipse-ankaios/ankaios/security/advisories/new).
+In this case the Ankaios committers will be informed and only you and the committers will have access to this vulnerability report and you will get feedback there once the report has been analyzed.
+In the form to fill out, only the title and description are required, the rest of the fields are optional.


### PR DESCRIPTION
Currently the project misses a `SECURITY.md` which is added with this PR.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
