### PR TITLE
Fix requirements version for optional control interface creation

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -690,7 +690,7 @@ Needs:
 - utest
 
 ##### RuntimeFacade creates workload
-`swdd~agent-create-workload~2`
+`swdd~agent-create-workload~3`
 
 Status: approved
 
@@ -897,7 +897,7 @@ Needs:
 - utest
 
 ##### Workload handles update command
-`swdd~agent-workload-obj-update-command~2`
+`swdd~agent-workload-obj-update-command~3`
 
 Status: approved
 

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -106,7 +106,7 @@ impl<
         self.runtime.get_reusable_workloads(agent_name).await
     }
 
-    // [impl->swdd~agent-create-workload~2]
+    // [impl->swdd~agent-create-workload~3]
     fn create_workload(
         &self,
         workload_spec: WorkloadSpec,
@@ -160,7 +160,7 @@ impl<
         StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     > GenericRuntimeFacade<WorkloadId, StChecker>
 {
-    // [impl->swdd~agent-create-workload~2]
+    // [impl->swdd~agent-create-workload~3]
     fn create_workload_non_blocking(
         &self,
         workload_spec: WorkloadSpec,
@@ -445,7 +445,7 @@ mod tests {
         runtime_mock.assert_all_expectations().await;
     }
 
-    // [utest->swdd~agent-create-workload~2]
+    // [utest->swdd~agent-create-workload~3]
     #[tokio::test]
     async fn utest_runtime_facade_create_workload() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/agent/src/workload.rs
+++ b/agent/src/workload.rs
@@ -130,7 +130,7 @@ impl Workload {
         }
     }
 
-    // [impl->swdd~agent-workload-obj-update-command~2]
+    // [impl->swdd~agent-workload-obj-update-command~3]
     pub async fn update(
         &mut self,
         spec: Option<WorkloadSpec>,
@@ -365,7 +365,7 @@ mod tests {
         assert!(test_workload.control_interface.is_none());
     }
 
-    // [utest->swdd~agent-workload-obj-update-command~2]
+    // [utest->swdd~agent-workload-obj-update-command~3]
     #[tokio::test]
     async fn utest_workload_obj_update_success() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
@@ -449,7 +449,7 @@ mod tests {
         );
     }
 
-    // [utest->swdd~agent-workload-obj-update-command~2]
+    // [utest->swdd~agent-workload-obj-update-command~3]
     #[tokio::test]
     async fn utest_workload_obj_update_error() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC


### PR DESCRIPTION
Issues: 

Requirement description got changed but the version was not incremented.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
