### PR TITLE
Upgrade app devcontainer base to newer tooling

### DIFF
--- a/doc/docs/development/extending-dev-container.md
+++ b/doc/docs/development/extending-dev-container.md
@@ -25,7 +25,7 @@ Build the base container by running the following commands outside of the dev co
 ```shell
 # Prepare the build with buildx. Depending on you environment
 # the following steps might be necessary:
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes  --credential yes
 
 # Create and use a new builder. This needs to be called only once:
 docker buildx create --name mybuilder --driver docker-container --bootstrap

--- a/tools/app_dev_container_base/Dockerfile
+++ b/tools/app_dev_container_base/Dockerfile
@@ -1,10 +1,14 @@
-FROM docker.io/ubuntu:22.04
+FROM ubuntu:24.04
 
 # example version: ANKAIOS_VERSION=0.1.0, if not provided latest is used
 ARG ANKAIOS_VERSION
 ARG TARGETARCH
+ARG USERNAME=ankaios
 
-RUN apt-get update && apt-get -y install \
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
+    && apt -y install \
+    sudo \
     # Protobuf
     protobuf-compiler \
     protobuf-compiler-grpc \
@@ -12,12 +16,35 @@ RUN apt-get update && apt-get -y install \
     gpg \
     curl \
     libssl-dev \
-    # install podman 4
-    && echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04 /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list \
-    && curl -fsSL https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null \
-    && apt update \
-    && apt install -y podman \
+    tmux \
+    vim \
+    uidmap \
+    fuse3 \
+    fuse-overlayfs \
+    slirp4netns \
+    # podman
+    podman \
     && rm -rf /var/lib/apt/lists/*
+
+# Workaround for podman not being able to stop containers, see https://bugs.launchpad.net/ubuntu/noble/+source/libpod/+bug/2040483
+RUN mkdir -p /etc/containers/containers.conf.d \
+    && printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
+
+# User management
+RUN (userdel -r ubuntu || true) \
+    && useradd -s /bin/bash -d /home/${USERNAME} -m ${USERNAME} \
+    && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
+
+# Prepare shells
+USER ${USERNAME}
+COPY --chown=${USERNAME}:${USERNAME} dot_bashrc /home/${USERNAME}/.bashrc
+COPY --chown=${USERNAME}:${USERNAME} dot_zshrc /home/${USERNAME}/.zshrc
+COPY --chown=${USERNAME}:${USERNAME} dot_tmux.conf /home/${USERNAME}/.tmux.conf
+RUN curl -sS https://starship.rs/install.sh | sh -s -- -y \
+    && echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
+    && echo 'eval "$(starship init zsh)"' >> /home/${USERNAME}/.zshrc
+COPY --chown=${USERNAME}:${USERNAME} starship.toml /home/${USERNAME}/.config/
+USER root
 
 # install grpcurl for debugging purposes
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
@@ -31,44 +58,19 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
         && curl -sSL https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_${ITEMARCH}.tar.gz | tar -xvz --directory /usr/bin/grpcurl.d \
         && ln /usr/bin/grpcurl.d/grpcurl /usr/bin/grpcurl
 
-RUN useradd ankaios; \
-echo -e "ankaios:1:999\nankaios:1001:64535" > /etc/subuid; \
-echo -e "ankaios:1:999\nankaios:1001:64535" > /etc/subgid;
-
 COPY containers.conf /etc/containers/containers.conf
-COPY podman-containers.conf /home/ankaios/.config/containers/containers.conf
+COPY podman-containers.conf /home/${USERNAME}/.config/containers/containers.conf
 
-RUN mkdir -p /home/ankaios/.local/share/containers && \
-    chown ankaios:ankaios -R /home/ankaios && \
+RUN mkdir -p /home/${USERNAME}/.local/share/containers && \
+    chown ${USERNAME}:${USERNAME} -R /home/${USERNAME} && \
     chmod 644 /etc/containers/containers.conf
-
-# Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-           -e '/additionalimage.*/a "/var/lib/shared",' \
-           -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
-           /usr/share/containers/storage.conf \
-           > /etc/containers/storage.conf
-
-# Setup internal Podman to pass subscriptions down from host to internal container
-RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
 # Note VOLUME options must always happen after the chown call above
 # RUN commands can not modify existing volumes
 VOLUME /var/lib/containers
 VOLUME /home/ankaios/.local/share/containers
 
-RUN mkdir -p /var/lib/shared/overlay-images \
-             /var/lib/shared/overlay-layers \
-             /var/lib/shared/vfs-images \
-             /var/lib/shared/vfs-layers && \
-    touch /var/lib/shared/overlay-images/images.lock && \
-    touch /var/lib/shared/overlay-layers/layers.lock && \
-    touch /var/lib/shared/vfs-images/images.lock && \
-    touch /var/lib/shared/vfs-layers/layers.lock
-
 RUN mkdir -p /workspaces/
 
 # Download and install latest Ankaios release
 RUN if [ -n "$ANKAIOS_VERSION" ] ; then curl -sfL https://github.com/eclipse-ankaios/ankaios/releases/download/${ANKAIOS_VERSION}/install.sh | bash -s -- -v ${ANKAIOS_VERSION} ; curl -sL https://github.com/eclipse-ankaios/ankaios/releases/download/${ANKAIOS_VERSION}/{ank_base,control_api}.proto --create-dirs -O --output-dir /usr/local/lib/ankaios/proto ; else curl -sfL https://github.com/eclipse-ankaios/ankaios/releases/latest/download/install.sh | bash -; curl -sL https://github.com/eclipse-ankaios/ankaios/releases/latest/download/{ank_base,control_api}.proto --create-dirs -O --output-dir /usr/local/lib/ankaios/proto ; fi
-

--- a/tools/app_dev_container_base/Dockerfile
+++ b/tools/app_dev_container_base/Dockerfile
@@ -36,12 +36,13 @@ RUN (userdel -r ubuntu || true) \
     && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
 
 # Prepare shells
+RUN curl -sS https://starship.rs/install.sh | sh -s -- -y
 USER ${USERNAME}
 COPY --chown=${USERNAME}:${USERNAME} dot_bashrc /home/${USERNAME}/.bashrc
 COPY --chown=${USERNAME}:${USERNAME} dot_zshrc /home/${USERNAME}/.zshrc
 COPY --chown=${USERNAME}:${USERNAME} dot_tmux.conf /home/${USERNAME}/.tmux.conf
-RUN curl -sS https://starship.rs/install.sh | sh -s -- -y \
-    && echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
+
+RUN echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
     && echo 'eval "$(starship init zsh)"' >> /home/${USERNAME}/.zshrc
 COPY --chown=${USERNAME}:${USERNAME} starship.toml /home/${USERNAME}/.config/
 USER root

--- a/tools/app_dev_container_base/Dockerfile
+++ b/tools/app_dev_container_base/Dockerfile
@@ -36,13 +36,12 @@ RUN (userdel -r ubuntu || true) \
     && echo "${USERNAME} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/${USERNAME}
 
 # Prepare shells
-RUN curl -sS https://starship.rs/install.sh | sh -s -- -y
 USER ${USERNAME}
 COPY --chown=${USERNAME}:${USERNAME} dot_bashrc /home/${USERNAME}/.bashrc
 COPY --chown=${USERNAME}:${USERNAME} dot_zshrc /home/${USERNAME}/.zshrc
 COPY --chown=${USERNAME}:${USERNAME} dot_tmux.conf /home/${USERNAME}/.tmux.conf
-
-RUN echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
+RUN curl -sS https://starship.rs/install.sh | sh -s -- -y \
+    && echo 'eval "$(starship init bash)"' >> /home/${USERNAME}/.bashrc \
     && echo 'eval "$(starship init zsh)"' >> /home/${USERNAME}/.zshrc
 COPY --chown=${USERNAME}:${USERNAME} starship.toml /home/${USERNAME}/.config/
 USER root

--- a/tools/app_dev_container_base/README.md
+++ b/tools/app_dev_container_base/README.md
@@ -46,7 +46,7 @@ Use the container with rootless podman inside (recommended):
 docker run --privileged -it --rm --user ankaios ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> /bin/bash
 ```
 
-**Note:** The ankaios user has activated the starship shell, which contains a command prompt and tools more suited to development tasks.
+**Note:** The ankaios user has the starship shell activated, which contains a command prompt and tools more suited for development tasks.
 
 Use the container with rootful podman inside:
 

--- a/tools/app_dev_container_base/README.md
+++ b/tools/app_dev_container_base/README.md
@@ -14,7 +14,7 @@ FROM ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version>
 RUN ... # customize the image with your dev dependencies
 ```
 
-**NOTE:** Replace the `<ankaios_version>` with a tag that points to an Ankaios release, e.g. 0.1.0.
+**NOTE:** Replace the `<ankaios_version>` with a tag that points to an Ankaios release, e.g. 0.5.0.
 
 The devcontainer contains the following:
 

--- a/tools/app_dev_container_base/README.md
+++ b/tools/app_dev_container_base/README.md
@@ -2,9 +2,9 @@
 
 This subfolder contains configurations for a devcontainer image that can be used to develop applications to be managed by Ankaios.
 
-The devcontainer image simplyfies the start of developing workloads by using Ankaios as your orchestrator and minimizes efforts to get started with the development.
+The devcontainer image makes it easy to start developing workloads using Ankaios as your orchestrator and minimizes the effort required to get started.
 
-You can just use the prebuilt public devcontainer as base image in your specific devcontainer setup:
+You can simply use the pre-built public devcontainer as a base image in your specific devcontainer setup:
 
 Example devcontainer Dockerfile:
 
@@ -14,11 +14,11 @@ FROM ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version>
 RUN ... # customize the image with your dev dependencies
 ```
 
-**NOTE:** Replace the `<ankaios_version>` with a tag pointing to an Ankaios release, e.g. 0.1.0.
+**NOTE:** Replace the `<ankaios_version>` with a tag that points to an Ankaios release, e.g. 0.1.0.
 
 The devcontainer contains the following:
 
-- Prebult Ankaios executables:
+- Pre-built Ankaios executables:
     - Ankaios server
     - Ankaios agent
     - Ankaios CLI
@@ -30,9 +30,9 @@ The devcontainer contains the following:
 
 - Podman 4 (daemonless container orchestrator)
 
-The control interface dependencies are essentially needed for use cases in which your app shall use the [Ankaios Control Interface](https://eclipse-ankaios.github.io/ankaios/main/reference/control-interface/) to be able to communicate with the Ankaios orchestrator. An example use case would be to write a workload that shall request Ankaios to dynamically start another workload.
+The control interface dependencies are essentially needed for use cases where your app needs to use the [Ankaios Control Interface](https://eclipse-ankaios.github.io/ankaios/main/reference/control-interface/) to communicate with the Ankaios orchestrator. An example use case would be to write a workload that requests Ankaios to dynamically start another workload.
 
-The prebuilt public container can be downloaded with the following command:
+The pre-built public container can be downloaded using the following command:
 
 ```shell
 docker pull ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version>
@@ -40,16 +40,18 @@ docker pull ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version>
 
 ## Run
 
+Use the container with rootless podman inside (recommended):
+
+```shell
+docker run --privileged -it --rm --user ankaios ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> /bin/bash
+```
+
+**Note:** The ankaios user has activated the starship shell, which contains a command prompt and tools more suited to development tasks.
+
 Use the container with rootful podman inside:
 
 ```shell
 docker run --privileged -it --rm ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> /bin/bash
-```
-
-Use the container with rootless podman inside:
-
-```shell
-docker run --privileged -it --rm --user ankaios ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> /bin/bash
 ```
 
 Next, follow the steps in the [Quickstart guide](https://eclipse-ankaios.github.io/ankaios/main/usage/quickstart/) to try Ankaios out within the devcontainer.
@@ -63,7 +65,7 @@ docker buildx use mybuilder
 docker buildx build -t ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> --platform linux/amd64,linux/arm64 .
 ```
 
-**NOTE:** If you are committer to Eclipse Ankaios project you are allowed to push the image to the public package repository of the organization. Just add `--push` to the command above.
+**NOTE:** If you are committer to the Eclipse Ankaios project you can push the image to the organization's public repository. Just add `--push` to the above command.
 
 ## Build for local usage
 

--- a/tools/app_dev_container_base/README.md
+++ b/tools/app_dev_container_base/README.md
@@ -28,7 +28,7 @@ The devcontainer contains the following:
     - protobuf-compiler
     - grpcurl
 
-- Podman 4 (daemonless container orchestrator)
+- Podman 4 (daemonless container engine)
 
 The control interface dependencies are essentially needed for use cases where your app needs to use the [Ankaios Control Interface](https://eclipse-ankaios.github.io/ankaios/main/reference/control-interface/) to communicate with the Ankaios orchestrator. An example use case would be to write a workload that requests Ankaios to dynamically start another workload.
 

--- a/tools/app_dev_container_base/README.md
+++ b/tools/app_dev_container_base/README.md
@@ -59,7 +59,7 @@ Next, follow the steps in the [Quickstart guide](https://eclipse-ankaios.github.
 ## Build for multi-platform
 
 ```shell
-docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes  --credential yes
 docker buildx create --name mybuilder --driver docker-container --bootstrap
 docker buildx use mybuilder
 docker buildx build -t ghcr.io/eclipse-ankaios/app-ankaios-dev:<ankaios_version> --platform linux/amd64,linux/arm64 .

--- a/tools/app_dev_container_base/containers.conf
+++ b/tools/app_dev_container_base/containers.conf
@@ -10,3 +10,4 @@ log_driver = "k8s-file"
 cgroup_manager = "cgroupfs"
 events_logger="file"
 runtime="crun"
+

--- a/tools/app_dev_container_base/containers.conf
+++ b/tools/app_dev_container_base/containers.conf
@@ -4,7 +4,7 @@ userns="host"
 ipcns="shareable"
 utsns="private"
 cgroupns="private"
-cgroups="enabled"
+cgroups="disabled"
 log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"

--- a/tools/app_dev_container_base/containers.conf
+++ b/tools/app_dev_container_base/containers.conf
@@ -1,10 +1,10 @@
 [containers]
 netns="private"
 userns="host"
-ipcns="host"
-utsns="host"
-cgroupns="host"
-cgroups="disabled"
+ipcns="shareable"
+utsns="private"
+cgroupns="private"
+cgroups="enabled"
 log_driver = "k8s-file"
 [engine]
 cgroup_manager = "cgroupfs"

--- a/tools/app_dev_container_base/dot_bashrc
+++ b/tools/app_dev_container_base/dot_bashrc
@@ -1,0 +1,118 @@
+# ~/.bashrc: executed by bash(1) for non-login shells.
+# see /usr/share/doc/bash/examples/startup-files (in the package bash-doc)
+# for examples
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# don't put duplicate lines or lines starting with space in the history.
+# See bash(1) for more options
+HISTCONTROL=ignoreboth
+
+# append to the history file, don't overwrite it
+shopt -s histappend
+
+# for setting history length see HISTSIZE and HISTFILESIZE in bash(1)
+HISTSIZE=1000
+HISTFILESIZE=2000
+
+# check the window size after each command and, if necessary,
+# update the values of LINES and COLUMNS.
+shopt -s checkwinsize
+
+# If set, the pattern "**" used in a pathname expansion context will
+# match all files and zero or more directories and subdirectories.
+#shopt -s globstar
+
+# make less more friendly for non-text input files, see lesspipe(1)
+[ -x /usr/bin/lesspipe ] && eval "$(SHELL=/bin/sh lesspipe)"
+
+# set variable identifying the chroot you work in (used in the prompt below)
+if [ -z "${debian_chroot:-}" ] && [ -r /etc/debian_chroot ]; then
+    debian_chroot=$(cat /etc/debian_chroot)
+fi
+
+# set a fancy prompt (non-color, unless we know we "want" color)
+case "$TERM" in
+    xterm-color|*-256color) color_prompt=yes;;
+esac
+
+# uncomment for a colored prompt, if the terminal has the capability; turned
+# off by default to not distract the user: the focus in a terminal window
+# should be on the output of commands, not on the prompt
+#force_color_prompt=yes
+
+if [ -n "$force_color_prompt" ]; then
+    if [ -x /usr/bin/tput ] && tput setaf 1 >&/dev/null; then
+	# We have color support; assume it's compliant with Ecma-48
+	# (ISO/IEC-6429). (Lack of such support is extremely rare, and such
+	# a case would tend to support setf rather than setaf.)
+	color_prompt=yes
+    else
+	color_prompt=
+    fi
+fi
+
+if [ "$color_prompt" = yes ]; then
+    PS1='${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
+else
+    PS1='${debian_chroot:+($debian_chroot)}\u@\h:\w\$ '
+fi
+unset color_prompt force_color_prompt
+
+# If this is an xterm set the title to user@host:dir
+case "$TERM" in
+xterm*|rxvt*)
+    PS1="\[\e]0;${debian_chroot:+($debian_chroot)}\u@\h: \w\a\]$PS1"
+    ;;
+*)
+    ;;
+esac
+
+# enable color support of ls and also add handy aliases
+if [ -x /usr/bin/dircolors ]; then
+    test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
+    alias ls='ls --color=auto'
+    #alias dir='dir --color=auto'
+    #alias vdir='vdir --color=auto'
+
+    alias grep='grep --color=auto'
+    alias fgrep='fgrep --color=auto'
+    alias egrep='egrep --color=auto'
+fi
+
+# colored GCC warnings and errors
+#export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
+
+# some more ls aliases
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Add an "alert" alias for long running commands.  Use like so:
+#   sleep 10; alert
+alias alert='notify-send --urgency=low -i "$([ $? = 0 ] && echo terminal || echo error)" "$(history|tail -n1|sed -e '\''s/^\s*[0-9]\+\s*//;s/[;&|]\s*alert$//'\'')"'
+
+# Alias definitions.
+# You may want to put all your additions into a separate file like
+# ~/.bash_aliases, instead of adding them here directly.
+# See /usr/share/doc/bash-doc/examples in the bash-doc package.
+
+if [ -f ~/.bash_aliases ]; then
+    . ~/.bash_aliases
+fi
+
+# enable programmable completion features (you don't need to enable
+# this, if it's already enabled in /etc/bash.bashrc and /etc/profile
+# sources /etc/bash.bashrc).
+if ! shopt -oq posix; then
+  if [ -f /usr/share/bash-completion/bash_completion ]; then
+    . /usr/share/bash-completion/bash_completion
+  elif [ -f /etc/bash_completion ]; then
+    . /etc/bash_completion
+  fi
+fi
+

--- a/tools/app_dev_container_base/dot_tmux.conf
+++ b/tools/app_dev_container_base/dot_tmux.conf
@@ -1,0 +1,2 @@
+set -g mouse on
+set-option -g default-shell /bin/zsh

--- a/tools/app_dev_container_base/dot_zshrc
+++ b/tools/app_dev_container_base/dot_zshrc
@@ -1,0 +1,40 @@
+# Set up the prompt
+
+#autoload -Uz promptinit
+#promptinit
+#prompt adam1
+
+setopt histignorealldups sharehistory
+
+# Use emacs keybindings even if our EDITOR is set to vi
+bindkey -e
+
+# Keep 1000 lines of history within the shell and save it to ~/.zsh_history:
+HISTSIZE=1000
+SAVEHIST=1000
+HISTFILE=~/.zsh_history
+
+# Use modern completion system
+autoload -Uz compinit
+compinit
+
+#zstyle ':completion:*' auto-description 'specify: %d'
+#zstyle ':completion:*' completer _expand _complete _correct _approximate
+#zstyle ':completion:*' format 'Completing %d'
+#zstyle ':completion:*' group-name ''
+#zstyle ':completion:*' menu select=2
+#eval "$(dircolors -b)"
+#zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+#zstyle ':completion:*' list-colors ''
+#zstyle ':completion:*' list-prompt %SAt %p: Hit TAB for more, or the character to insert%s
+#zstyle ':completion:*' matcher-list '' 'm:{a-z}={A-Z}' 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=* l:|=*'
+#zstyle ':completion:*' menu select=long
+#zstyle ':completion:*' select-prompt %SScrolling active: current selection at %p%s
+#zstyle ':completion:*' use-compctl false
+#zstyle ':completion:*' verbose true
+
+#zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+#zstyle ':completion:*:kill:*' command 'ps -u $USER -o pid,%cpu,tty,cputime,cmd'
+
+export EDITOR=/usr/bin/vim
+

--- a/tools/app_dev_container_base/starship.toml
+++ b/tools/app_dev_container_base/starship.toml
@@ -1,0 +1,10 @@
+add_newline = true
+command_timeout = 2000
+
+[container]
+disabled = true
+
+# We need to replace the first character to fix https://github.com/microsoft/vscode/issues/143103
+[character]
+success_symbol = '[>](bold green)'
+error_symbol = '[>](bold red)'


### PR DESCRIPTION
The PR upgrades the app devcontainer base to `Ubuntu-24.04` image including fixes for podman. It also includes the starship shell for non-root users and a tmux setup.

The changes took over parts from the Ankaios devcontainer base (`.devcontainer/Dockerfile.base`), but merged it with the portable configuration of the devcontainer to also run containers in Docker Desktop when developing on MacOS.

The readme has also been updated.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
