### PR TITLE
Fix unstable apply manifest stest

### DIFF
--- a/tests/stests/manifests/apply_manifests.robot
+++ b/tests/stests/manifests/apply_manifests.robot
@@ -36,7 +36,7 @@ Test Ankaios apply workload specifications showing progress via spinner
 
     # Preconditions
     Given Podman has deleted all existing containers
-    Given Ankaios server is started with config "${simple_yaml_file}"
+    And Ankaios server is started with config "${simple_yaml_file}"
     And Ankaios agent is started with name "agent_A"
     And all workloads of agent "agent_A" have an initial execution state
     # Actions

--- a/tests/stests/manifests/apply_manifests.robot
+++ b/tests/stests/manifests/apply_manifests.robot
@@ -36,8 +36,9 @@ Test Ankaios apply workload specifications showing progress via spinner
 
     # Preconditions
     Given Podman has deleted all existing containers
-    And Ankaios server is started without config
+    Given Ankaios server is started with config "${simple_yaml_file}"
     And Ankaios agent is started with name "agent_A"
+    And all workloads of agent "agent_A" have an initial execution state
     # Actions
     When user triggers "ank apply ${manifest12_yaml_file}"
     # Asserts


### PR DESCRIPTION
The changes here ensure that the agent is started by waiting on the an initial state of a workload.

This is just a workaround for now to ensure that we don't start sampling states before agent and server are actually running.
A proper fix would be to provide functionality to ensure server and agent are running also without waiting for distinct execution states.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
