### PR TITLE
Fix table update in-place

### DIFF
--- a/ank/src/cli_commands/get_workloads.rs
+++ b/ank/src/cli_commands/get_workloads.rs
@@ -11,7 +11,6 @@
 // under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use crate::output_warn;
 use crate::{cli_error::CliError, output_debug};
 
 use super::cli_table::CliTable;
@@ -65,13 +64,7 @@ impl CliCommands {
             .table_with_wrapped_column_to_remaining_terminal_width(
                 WorkloadTableRow::ADDITIONAL_INFO_POS,
             )
-            .unwrap_or_else(|err| {
-                output_warn!(
-                    "Could not create wrapped table: '{}'. Continue with default table.",
-                    err
-                );
-                CliTable::new(&table_rows).create_default_table()
-            }))
+            .unwrap_or_else(|_err| CliTable::new(&table_rows).create_default_table()))
     }
 }
 

--- a/ank/src/cli_commands/wait_list_display.rs
+++ b/ank/src/cli_commands/wait_list_display.rs
@@ -19,7 +19,7 @@ use std::{
 
 use common::objects::WorkloadInstanceName;
 
-use crate::{cli_commands::workload_table_row::WorkloadTableRowWithSpinner, output_warn};
+use crate::cli_commands::workload_table_row::WorkloadTableRowWithSpinner;
 
 use super::cli_table::CliTable;
 use super::{wait_list::WaitListDisplayTrait, workload_table_row::WorkloadTableRow};
@@ -58,13 +58,7 @@ impl Display for WaitListDisplay {
             .table_with_truncated_column_to_remaining_terminal_width(
                 WorkloadTableRowWithSpinner::ADDITIONAL_INFO_POS,
             )
-            .unwrap_or_else(|err| {
-                output_warn!(
-                    "Could not create truncated table: '{}'. Continue with default table.",
-                    err
-                );
-                CliTable::new(&table_rows_with_spinner).create_default_table()
-            });
+            .unwrap_or_else(|_err| CliTable::new(&table_rows_with_spinner).create_default_table());
 
         write!(f, "{}", table)
     }


### PR DESCRIPTION
Before this fix, on narrow terminals the table printed by ank apply has not been updated in-place. Instead it has been repeated below the previous table. The reason for that has been the warning output which disturbed the logic of keeping the old table and replacing that in log.rs:104 fn output_update_fn().

Fixes #420


<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
