### PR TITLE
Avoid flickering of table output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,6 +77,11 @@ jobs:
         with:
           name: licenses
           path: build/licenses.html
+        # We check advisories only for PRs in order to have stable builds on main.
+        # Remember that new advisories can pop up every time without changing the code.
+      - name: Check advisories for pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        run: just check-advisories
 
   code_coverage_linux_amd64:
     name: Create code coverage report

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,6 @@ name = "ank"
 version = "0.5.0"
 dependencies = [
  "api",
- "atty",
  "clap",
  "clap_complete",
  "common",
@@ -244,17 +243,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -878,15 +866,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1149,7 +1128,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,7 @@ name = "ank"
 version = "0.5.0"
 dependencies = [
  "api",
+ "atty",
  "clap",
  "clap_complete",
  "common",
@@ -243,6 +244,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.85",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -866,6 +878,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1128,7 +1149,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -1001,7 +1001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,9 +1291,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "papergrid"
-version = "0.9.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
 dependencies = [
  "bytecount",
  "fnv",
@@ -1472,27 +1472,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1960,23 +1958,22 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.12.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
 dependencies = [
  "papergrid",
  "tabled_derive",
- "unicode-width",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2266,9 +2263,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -38,6 +38,7 @@ tabled = "0.12"
 uuid = { version = "1.7.0", features = ["v4"] }
 crossterm = "0.27.0"
 clap_complete = { version = "<=4.5.24", features = ["unstable-dynamic", "unstable-command"] }
+atty = "0.2.14"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1.41", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-tabled = "0.12"
+tabled = "0.17"
 uuid = { version = "1.7.0", features = ["v4"] }
 crossterm = "0.27.0"
 clap_complete = { version = "<=4.5.24", features = ["unstable-dynamic", "unstable-command"] }

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -38,7 +38,6 @@ tabled = "0.12"
 uuid = { version = "1.7.0", features = ["v4"] }
 crossterm = "0.27.0"
 clap_complete = { version = "<=4.5.24", features = ["unstable-dynamic", "unstable-command"] }
-atty = "0.2.14"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/ank/src/log.rs
+++ b/ank/src/log.rs
@@ -14,12 +14,17 @@
 
 use std::{env, fmt, process::exit, sync::Mutex};
 
-use crossterm::{cursor, style::Stylize, terminal};
+use atty::Stream;
+use crossterm::{
+    cursor,
+    style::Stylize,
+    terminal::{self, ClearType},
+};
 
 pub const VERBOSITY_KEY: &str = "VERBOSE";
 pub const QUIET_KEY: &str = "SILENT";
 
-static CLEANUP_STRING: Mutex<String> = Mutex::new(String::new());
+static ROWS_PREV_MSG: Mutex<u16> = Mutex::new(0);
 
 /// Prints the message, if the CLI command is not called with `--quiet` flag
 #[macro_export]
@@ -74,25 +79,33 @@ pub(crate) fn output_and_exit_fn(args: fmt::Arguments<'_>) -> ! {
 
 pub(crate) fn output_debug_fn(args: fmt::Arguments<'_>) {
     if is_verbose() {
-        std::println!("{} {}{}", "debug:".blue(), args, cursor::SavePosition);
-        *CLEANUP_STRING.lock().unwrap() = "".into();
+        std::println!("{} {}", "debug:".blue(), args);
+        *ROWS_PREV_MSG.lock().unwrap() = 0;
     }
 }
 
 pub(crate) fn output_warn_fn(args: fmt::Arguments<'_>) {
-    std::println!("{} {}{}", "warn:".yellow(), args, cursor::SavePosition);
-    *CLEANUP_STRING.lock().unwrap() = "".into();
+    std::println!("{} {}", "warn:".yellow(), args);
+    *ROWS_PREV_MSG.lock().unwrap() = 0;
 }
 
 pub(crate) fn output_fn(args: fmt::Arguments<'_>) {
     if !is_quiet() {
-        std::println!("{}{}", args, cursor::SavePosition);
-        *CLEANUP_STRING.lock().unwrap() = "".into();
+        std::println!("{}", args);
+        *ROWS_PREV_MSG.lock().unwrap() = 0;
     }
 }
 
+pub fn interactive() -> bool {
+    atty::is(Stream::Stdout)
+}
+
 pub fn terminal_width() -> usize {
-    let terminal_width = terminal::size().unwrap_or((80, 0)).0 as usize;
+    let terminal_width = if interactive() {
+        terminal::size().unwrap_or((80, 0)).0 as usize
+    } else {
+        u16::MAX as usize
+    };
 
     // This is a workaround for terminals that return a wrong width of 0 instead of None
     if 0 == terminal_width {
@@ -105,8 +118,15 @@ pub(crate) fn output_update_fn(args: fmt::Arguments<'_>) {
     if !is_quiet() {
         let args = args.to_string();
 
+        if !interactive() {
+            println!("{}\n", args);
+            return;
+        }
+
+        let lf = format!("{}\n", terminal::Clear(ClearType::UntilNewLine));
+
         // limit line length to terminal_width by introducing newline characters
-        let args = args
+        let mut args = args
             .split('\n')
             .flat_map(|line| {
                 line.chars()
@@ -116,31 +136,37 @@ pub(crate) fn output_update_fn(args: fmt::Arguments<'_>) {
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<String>>()
-            .join("\n");
+            .join(&lf);
+        args.push_str(&lf);
 
-        let mut cleanup_string = CLEANUP_STRING.lock().unwrap();
-        let up = cleanup_string.chars().filter(|c| *c == '\n').count() as u16;
-        let up_string = if up > 0 {
-            cursor::MoveUp(up).to_string()
+        let rows = args.chars().filter(|c| *c == '\n').count() as u16;
+        let mut prev_rows = ROWS_PREV_MSG.lock().unwrap();
+        let pre_up_string = if *prev_rows > 0 {
+            cursor::MoveUp(*prev_rows).to_string()
         } else {
             "".to_string()
         };
-        std::println!(
-            "{}{}{}{}{}{}",
+        let cleanup_string = if rows < *prev_rows {
+            str::repeat(&lf, (*prev_rows - rows).into())
+        } else {
+            "".to_string()
+        };
+        let post_up_string = if rows < *prev_rows {
+            cursor::MoveUp(*prev_rows - rows).to_string()
+        } else {
+            "".to_string()
+        };
+
+        std::print!(
+            "{}{}{}{}{}",
             cursor::MoveToColumn(0),
-            up_string,
+            pre_up_string,
+            args,
             cleanup_string,
-            cursor::MoveToColumn(0),
-            up_string,
-            args
+            post_up_string
         );
 
-        let mut new_cleanup_string: String = args
-            .chars()
-            .map(|x| if x == '\n' { '\n' } else { ' ' })
-            .collect();
-        new_cleanup_string.push('\n');
-        *cleanup_string = new_cleanup_string;
+        *prev_rows = rows;
     }
 }
 

--- a/ank/src/log.rs
+++ b/ank/src/log.rs
@@ -12,9 +12,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, fmt, process::exit, sync::Mutex};
+use std::{
+    env, fmt,
+    io::{self, IsTerminal},
+    process::exit,
+    sync::Mutex,
+};
 
-use atty::Stream;
 use crossterm::{
     cursor,
     style::Stylize,
@@ -97,7 +101,7 @@ pub(crate) fn output_fn(args: fmt::Arguments<'_>) {
 }
 
 pub fn interactive() -> bool {
-    atty::is(Stream::Stdout)
+    io::stdout().is_terminal()
 }
 
 pub fn terminal_width() -> usize {

--- a/justfile
+++ b/justfile
@@ -31,6 +31,10 @@ clean:
 check-licenses:
     cargo deny check licenses
 
+# Check advisories as part of https://rustsec.org/advisories/
+check-advisories:
+    cargo deny check advisories
+
 # Prevent non ghcr.io images to be used in test due to rate limit problem
 check-test-images:
     test -z "$(find tests/resources/configs -type f -exec grep -H -P 'image: (?!ghcr\.io/|image_typo:latest)' {} \;)"


### PR DESCRIPTION
Before this change, a table output created by ank apply was sometimes flickering. This was caused by printing cleanup strings that had been overwritten by the new message in the same println statement. This change uses a mechanism as described in https://stackoverflow.com/a/71453783.

To fix the stests, this change also detects non-interactive use and does not print control characters in that case.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
