### PR TITLE
Forbid empty filter mask access rules in ControlInterfaceAccess 

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -3143,7 +3143,7 @@ Status: approved
 When the Authorizer checks if an individual entry of the update/field mask of a request matches an individual entry of the filter mask of an allow rule, the Authorizer shall consider them matching if all segments of the allow rule's filter mask match the corresponding segments of the request's update/field mask.
 
 Comment:
-An allow rule matches, if it is the same or a prefix of the request's update/field mask.
+An allow rule matches, if it is the same or a prefix of the request's update/field mask. Consequently, when the allow rule consists only of the wildcards symbol "*", all possible update/field mask, including the empty one, match it.
 
 Tags:
 - Authorizer
@@ -3160,7 +3160,7 @@ Status: approved
 When the Authorizer checks if an individual entry of the update/field mask of a request matches an individual entry of the filter mask of a deny rule, the Authorizer shall consider them matching if all segments of the allow rule's filter mask match the corresponding segments of the request's update/field mask.
 
 Comment:
-A deny rule matches, if the request's update/field mask is the same or a prefix of the rule.
+An allow rule matches, if it is the same or a prefix of the request's update/field mask. Consequently, when the allow rule consists only of the wildcards symbol "*", all possible update/field mask, including the empty one, match it.
 
 Tags:
 - Authorizer

--- a/agent/src/control_interface/authorizer.rs
+++ b/agent/src/control_interface/authorizer.rs
@@ -77,7 +77,7 @@ impl Authorizer {
                     } else if let (true, reason) = self.allow_read_write_state_rule.matches(&path) {
                         reason
                     } else {
-                        log::debug!(
+                        log::info!(
                             "Denying field mask '{}' of request '{}' as no rule matches",
                             path_string,
                             request.request_id
@@ -101,7 +101,7 @@ impl Authorizer {
                         return true;
                     };
 
-                    log::debug!(
+                    log::info!(
                         "Deny field mask '{}' of request '{}',also allowed by '{}', as denied by '{}'",
                         path_string,
                         request.request_id,
@@ -128,7 +128,7 @@ impl Authorizer {
                     } else if let (true, reason) = self.allow_read_write_state_rule.matches(&path) {
                         reason
                     } else {
-                        log::debug!(
+                        log::info!(
                             "Deny update mask '{}' of request '{}' as no rule matches",
                             path_string,
                             request.request_id
@@ -152,7 +152,7 @@ impl Authorizer {
                         return true;
                     };
 
-                    log::debug!(
+                    log::info!(
                         "Deny update mask '{}' of request '{}', also allowed by '{}', as denied by '{}'",
                         path_string,
                         request.request_id,
@@ -328,6 +328,7 @@ mod test {
     #[test]
     fn utest_allow_empty_request() {
         let authorizer = create_authorizer(&[RuleType::AllowReadWrite]);
+
         let request = Request {
             request_id: "".into(),
             request_content: common::commands::RequestContent::CompleteStateRequest(

--- a/agent/src/control_interface/authorizer/path_pattern.rs
+++ b/agent/src/control_interface/authorizer/path_pattern.rs
@@ -26,8 +26,8 @@ pub trait PathPattern {
 
 impl<T: PathPattern + std::fmt::Debug> PathPattern for Vec<T> {
     fn matches(&self, path: &Path) -> (bool, PathPatternMatchReason) {
-        for r in self {
-            if let (true, reason) = r.matches(path) {
+        for rule in self {
+            if let (true, reason) = rule.matches(path) {
                 return (true, reason);
             }
         }
@@ -55,7 +55,9 @@ impl From<&str> for AllowPathPattern {
 impl PathPattern for AllowPathPattern {
     // [impl->swdd~agent-authorizing-matching-allow-rules~1]
     fn matches(&self, other: &Path) -> (bool, PathPatternMatchReason) {
-        if self.sections.len() > other.sections.len() {
+        if self.sections.len() > other.sections.len()
+            && self.sections.first() != Some(&PathPatternSection::Wildcard)
+        {
             return (false, String::new());
         }
         for (a, b) in self.sections.iter().zip(other.sections.iter()) {
@@ -207,12 +209,23 @@ mod tests {
         assert!(!p.matches(&"some.pre.fixtest".into()).0);
         assert!(!p.matches(&"some.pre.test".into()).0);
         assert!(!p.matches(&"some.pre.test.2".into()).0);
+        assert!(!p.matches(&"some.pre.bla.fix".into()).0);
         assert!(p.matches(&"some.pre2.fix".into()).0);
         assert!(p.matches(&"some.pre2.fix.test".into()).0);
         assert!(!p.matches(&"some.pre2".into()).0);
         assert!(!p.matches(&"some.pre2.fixtest".into()).0);
         assert!(!p.matches(&"some.pre2.test".into()).0);
         assert!(!p.matches(&"some.pre2.test.2".into()).0);
+    }
+
+    // [utest->swdd~agent-authorizing-matching-allow-rules~1]
+    #[test]
+    fn utest_allow_path_pattern_with_wildcard_only() {
+        let p = AllowPathPattern::from("*");
+
+        assert!(p.matches(&"".into()).0);
+        assert!(p.matches(&"some".into()).0);
+        assert!(p.matches(&"some.pre.fix.test".into()).0);
     }
 
     // [utest->swdd~agent-authorizing-matching-allow-rules~1]
@@ -253,6 +266,7 @@ mod tests {
         assert!(!p.matches(&"some2.pre.fix".into()).0);
         assert!(!p.matches(&"some.pre.fix2".into()).0);
         assert!(!p.matches(&"some.pre.fix2.test".into()).0);
+        assert!(!p.matches(&"some.pre.bla.fix".into()).0);
         assert!(p.matches(&"some.pre2".into()).0);
         assert!(p.matches(&"some.pre2.fix".into()).0);
         assert!(p.matches(&"some.pre2.fix.test".into()).0);
@@ -260,6 +274,16 @@ mod tests {
         assert!(!p.matches(&"some2.pre2.fix".into()).0);
         assert!(!p.matches(&"some.pre2.fix2".into()).0);
         assert!(!p.matches(&"some.pre2.fix2.test".into()).0);
+    }
+
+    // [utest->swdd~agent-authorizing-matching-deny-rules~1]
+    #[test]
+    fn utest_deny_path_pattern_with_wildcard_only() {
+        let p = AllowPathPattern::from("*");
+
+        assert!(p.matches(&"".into()).0);
+        assert!(p.matches(&"some".into()).0);
+        assert!(p.matches(&"some.pre.fix.test".into()).0);
     }
 
     // [utest->swdd~agent-authorizing-matching-deny-rules~1]

--- a/common/src/objects/control_interface_access.rs
+++ b/common/src/objects/control_interface_access.rs
@@ -77,7 +77,7 @@ impl AccessRightsRule {
                 state_rule.filter_mask.iter().try_for_each(|filter| {
                     if filter.is_empty() {
                         return Err(
-                            "Empty filter masks are not allowed in access rights rules".to_string()
+                            "Empty filter masks are not allowed in Control Interface access rules".to_string()
                         );
                     }
                     Ok(())

--- a/common/src/objects/workload_spec.rs
+++ b/common/src/objects/workload_spec.rs
@@ -63,6 +63,7 @@ impl WorkloadSpec {
     pub fn verify_fields_format(workload_spec: &WorkloadSpec) -> Result<(), String> {
         Self::verify_workload_name_format(workload_spec.instance_name.workload_name())?;
         Self::verify_agent_name_format(workload_spec.instance_name.agent_name())?;
+        workload_spec.control_interface_access.verify_format()?;
         Ok(())
     }
 

--- a/justfile
+++ b/justfile
@@ -43,8 +43,11 @@ check-test-images:
 check-copyright-headers:
     ./tools/check_copyright_headers.sh
 
+# Run all tests
+test: utest stest
+
 # Run unit tests
-test:
+utest:
     cargo nextest run
 
 # Build debug and run all system tests

--- a/tests/resources/ankaios.resource
+++ b/tests/resources/ankaios.resource
@@ -594,7 +594,7 @@ The controller workload is forbidden to ${operation} on ${filter_mask}
     The controller workload sends initial hello with correct version
 
 The controller workload does not send hello
-    internal_allow_control_interface    read    ${EMPTY}
+    internal_allow_control_interface    read    *
 
 The controller workload sends initial hello with correct version
     internal_send_initial_hello    ${ANKAIOS_VERSION}

--- a/tests/stests/control_interface/authorization.robot
+++ b/tests/stests/control_interface/authorization.robot
@@ -45,16 +45,16 @@ No rules
 
     Then the controller workload has no access to Control Interface
 
-Allow write rule with empty string allows all writes
-    Given the controller workload is allowed to write on ${EMPTY}
+Allow write rule with wildcard string allows all writes
+    Given the controller workload is allowed to write on *
 
     When the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple
     And the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple_existing.tags
 
     Then the controller workload requests shall all succeed
 
-Allow write rule with empty string denies all reads
-    Given the controller workload is allowed to write on ${EMPTY}
+Allow write rule with wildcard string denies all reads
+    Given the controller workload is allowed to write on *
 
     When the controller workload gets the state
     And the controller workload gets the state of fields desiredState.workloads.simple_existing
@@ -62,16 +62,16 @@ Allow write rule with empty string denies all reads
 
     Then the controller workload requests shall all fail
 
-Allow read rule with empty string denies all writes
-    Given the controller workload is allowed to read on ${EMPTY}
+Allow read rule with wildcard string denies all writes
+    Given the controller workload is allowed to read on *
 
     When the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple
     And the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple_existing.tags
 
     Then the controller workload requests shall all fail
 
-Allow read rule with empty string allows all reads
-    Given the controller workload is allowed to read on ${EMPTY}
+Allow read rule with wildcard string allows all reads
+    Given the controller workload is allowed to read on *
 
     When the controller workload gets the state
     And the controller workload gets the state of fields desiredState.workloads.simple_existing
@@ -79,8 +79,8 @@ Allow read rule with empty string allows all reads
 
     Then the controller workload requests shall all succeed
 
-Allow read write rule with empty string allows allow read and writes
-    Given the controller workload is allowed to read and write on ${EMPTY}
+Allow read write rule with wildcard string allows allow read and writes
+    Given the controller workload is allowed to read and write on *
 
     When the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple
     And the controller workload updates the state with manifest "${CONFIGS_DIR}/simple_state.yaml" and update mask desiredState.workloads.simple_existing.tags


### PR DESCRIPTION
Access rules that deny or allow access to all branches of the config shall be explicitly state it by including the wildcard character * in the filter mask.
An empty filter mask could be misunderstood as no access.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
