### PR TITLE
Add support for auto line indentation of multi line config to ConfigRenderer

### DIFF
--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -600,7 +600,6 @@ mod tests {
         if let ToServer::AgentLoadStatus(load_status) = result {
             assert_eq!(load_status.agent_name, AGENT_NAME.to_string());
             assert_ne!(load_status.cpu_usage.cpu_usage, 0);
-            assert_ne!(load_status.cpu_usage.cpu_usage, 0);
         } else {
             panic!("Expected AgentLoadStatus, got something else");
         }

--- a/doc/docs/usage/manifest/config-rendering.md
+++ b/doc/docs/usage/manifest/config-rendering.md
@@ -93,7 +93,7 @@ http {
 ...
 ```
 
-By using the `indent` control structure, incorrect indentation will be prevented and the line indentation of the current context will be considered. This results in an error-free YAML file.
+By using the `indent` control structure, the line indentation of the current context will be considered which results in an error-free YAML file.
 
 ```yaml
 ...

--- a/doc/docs/usage/manifest/config-rendering.md
+++ b/doc/docs/usage/manifest/config-rendering.md
@@ -1,0 +1,112 @@
+# Sharable configuration
+
+Ankaios supports the sharable configuration approach, which allows configurations to be defined once and assigned to any number of workloads. It uses the [handlebars](https://github.com/sunng87/handlebars-rust) templating syntax to extend certain fields of workloads. For a detailed look at supported workload fields and a basic example of sharing configuration with workloads, see [here](../../reference/startup-configuration.md).
+
+## Indentation for multi-line configuration
+
+When using the default handlebars template syntax (`{{config_variable}}`), the line indentation of the current context is not considered. To ensure the validity of certain layouts that rely on the indentation level of multi-line configuration, utilize the following custom `indent` control structure, highlighted below:
+
+```yaml linenums="1" hl_lines="16"
+apiVersion: v0.1
+workloads:
+  frontend:
+    agent: agent_A
+    runtime: podman-kube
+    configs:
+      nginx_conf: nginx_config
+    runtimeConfig: |
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: nginx-config
+        data:
+          nginx.conf: |
+            {{> indent content=nginx_conf}}
+        ---
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: nginx-container
+            image: ghcr.io/eclipse-ankaios/tests/nginx:alpine-slim
+            ports:
+            - containerPort: 80
+              hostPort: 8080
+            volumeMounts:
+            - name: nginx-config-volume
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          volumes:
+          - name: nginx-config-volume
+            configMap:
+              name: nginx-config
+configs:
+  nginx_config: |
+    worker_processes  1;
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+        server {
+            listen 80;
+            server_name custom_nginx;
+
+            location /custom {
+                default_type text/plain;
+                return 200 "The mounted custom nginx.conf is being used!\n";
+            }
+        }
+    }
+```
+
+With the default template syntax (`{{nginx_conf}}`) instead, the expanded state will result in an invalid YAML:
+
+```yaml
+...
+    runtimeConfig: |
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: nginx-config
+        data:
+          nginx.conf: |
+            worker_processes  1;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    server {
+...
+```
+
+By using the `indent` control structure, incorrect indentation will be prevented and the line indentation of the current context will be considered. This results in an error-free YAML file.
+
+```yaml
+...
+    runtimeConfig: |
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: nginx-config
+        data:
+          nginx.conf: |
+            worker_processes  1;
+
+            events {
+                worker_connections  1024;
+            }
+
+            http {
+                server {
+...
+```

--- a/doc/docs/usage/manifest/config-rendering.md
+++ b/doc/docs/usage/manifest/config-rendering.md
@@ -1,6 +1,11 @@
 # Shareable configuration
 
-Ankaios supports the shareable configuration approach, which allows configurations to be defined once and assigned to any number of workloads. It uses the [handlebars](https://github.com/sunng87/handlebars-rust) templating syntax to extend certain fields of workloads. For a detailed look at supported workload fields and a basic example of sharing configuration with workloads, see [here](../../reference/startup-configuration.md).
+Ankaios supports a shareable configuration approach, which allows configurations to be defined once and assigned to any number of workloads. To use sharable configurations, you can define config references in the [handlebars](https://github.com/sunng87/handlebars-rust) templating syntax. The following workload configuration fields currently support template expansion:
+
+* `agent`
+* `runtimeConfig`
+
+For a basic example of sharing configuration with workloads, see [here](../../reference/startup-configuration.md).
 
 ## Indentation for multi-line configuration
 

--- a/doc/docs/usage/manifest/config-rendering.md
+++ b/doc/docs/usage/manifest/config-rendering.md
@@ -1,6 +1,6 @@
-# Sharable configuration
+# Shareable configuration
 
-Ankaios supports the sharable configuration approach, which allows configurations to be defined once and assigned to any number of workloads. It uses the [handlebars](https://github.com/sunng87/handlebars-rust) templating syntax to extend certain fields of workloads. For a detailed look at supported workload fields and a basic example of sharing configuration with workloads, see [here](../../reference/startup-configuration.md).
+Ankaios supports the shareable configuration approach, which allows configurations to be defined once and assigned to any number of workloads. It uses the [handlebars](https://github.com/sunng87/handlebars-rust) templating syntax to extend certain fields of workloads. For a detailed look at supported workload fields and a basic example of sharing configuration with workloads, see [here](../../reference/startup-configuration.md).
 
 ## Indentation for multi-line configuration
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
     - usage/awesome-ankaios.md
     - usage/mtls-setup.md
     - usage/shell-completion.md
+    - Manifest:
+      - usage/manifest/config-rendering.md
     - Upgrading:
       - usage/upgrading/v0_2_to_v0_3.md
       - usage/upgrading/v0_3_to_v0_4.md

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -816,7 +816,7 @@ Rationale:
 This ensures the validity of certain file layouts that rely on the indentation level of the content when replacing the template with a multi-line config value.
 
 Comment:
-To enforce to keep the line indentation a customized templated string syntax is used: `{{> indent content=<config_item_reference>}}` where `conifg_item_reference` is the path to the referenced config value.
+To support keeping the line indentation, a customized templated string syntax is used: `{{> indent content=<config_item_reference>}}` where `conifg_item_reference` is the path to the referenced config value.
 
 Tags:
 - ConfigRenderer

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -805,6 +805,26 @@ Needs:
 - impl
 - utest
 
+#### ConfigRenderer supports rendering with keeping line indent
+`swdd~config-renderer-supports-rendering-with-keeping-line-indent~1`
+
+Status: approved
+
+The ConfigRenderer shall support rendering templates with keeping line indentation.
+
+Rationale:
+This ensures the validity of certain file layouts that rely on the indentation level of the content when replacing the template with a multi-line config value.
+
+Comment:
+To enforce to keep the line indentation a customized templated string syntax is used: `{{> indent content=<config_item_reference>}}` where `conifg_item_reference` is the path to the referenced config value.
+
+Tags:
+- ConfigRenderer
+
+Needs:
+- impl
+- utest
+
 #### ServerState rejects state with cycle
 `swdd~server-state-rejects-state-with-cyclic-dependencies~1`
 

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -824,6 +824,7 @@ Tags:
 Needs:
 - impl
 - utest
+- stest
 
 #### ServerState rejects state with cycle
 `swdd~server-state-rejects-state-with-cyclic-dependencies~1`

--- a/server/src/ankaios_server/config_renderer.rs
+++ b/server/src/ankaios_server/config_renderer.rs
@@ -417,11 +417,12 @@ mod tests {
     // [utest->swdd~config-renderer-renders-workload-configuration~1]
     #[test]
     fn utest_render_workloads_prevent_escaping_special_characters() {
-        let templated_runtime_config = "config_of_special_char_sequences: {{special_conf}}";
+        const CONFIG_VALUE: &str = "value\"with\"escape\'characters\'";
+
         let mut stored_workload = generate_test_stored_workload_spec_with_config(
             AGENT_A,
             RUNTIME,
-            templated_runtime_config,
+            "config_of_special_char_sequences: {{special_conf}}",
         );
 
         stored_workload.configs =
@@ -430,7 +431,7 @@ mod tests {
         let workloads = HashMap::from([(WORKLOAD_NAME_1.to_owned(), stored_workload)]);
         let configs = HashMap::from([(
             "config_special_chars".to_string(),
-            ConfigItem::String("value\"with\"escape\'characters\'".to_string()),
+            ConfigItem::String(CONFIG_VALUE.to_owned()),
         )]);
 
         let renderer = ConfigRenderer::default();
@@ -439,7 +440,7 @@ mod tests {
             AGENT_A.to_owned(),
             WORKLOAD_NAME_1.to_owned(),
             RUNTIME.to_owned(),
-            "config_of_special_char_sequences: value\"with\"escape\'characters\'".to_owned(),
+            format!("config_of_special_char_sequences: {CONFIG_VALUE}"),
         );
 
         let result = renderer.render_workloads(&workloads, &configs);

--- a/server/src/ankaios_server/config_renderer.rs
+++ b/server/src/ankaios_server/config_renderer.rs
@@ -54,6 +54,11 @@ impl Default for ConfigRenderer {
     fn default() -> Self {
         let mut template_engine = Handlebars::new();
         template_engine.set_strict_mode(true); // enable throwing render errors if context data is valid
+
+        // [impl->swdd~config-renderer-supports-rendering-with-keeping-line-indent~1]
+        template_engine
+            .register_partial("indent", "{{content}}")
+            .unwrap();
         Self { template_engine }
     }
 }
@@ -166,7 +171,7 @@ mod tests {
 
     use common::objects::{
         generate_test_configs, generate_test_stored_workload_spec_with_config,
-        generate_test_workload_spec_with_runtime_config,
+        generate_test_workload_spec_with_runtime_config, ConfigItem,
     };
 
     const WORKLOAD_NAME_1: &str = "workload_1";
@@ -361,5 +366,50 @@ mod tests {
         let renderer = ConfigRenderer::default();
 
         assert!(renderer.render_workloads(&workloads, &configs).is_err());
+    }
+
+    // [utest->swdd~config-renderer-renders-workload-configuration~1]
+    // [utest->swdd~config-renderer-supports-rendering-with-keeping-line-indent~1]
+    #[test]
+    fn utest_render_workloads_with_keeping_indentation_level_with_partial() {
+        let runtime_config_with_partial_template = r#"
+        some:
+          keys:
+            before:
+              config_with_indent: |
+                {{> indent content=ref1}}"#;
+
+        let mut stored_workload = generate_test_stored_workload_spec_with_config(
+            AGENT_A,
+            RUNTIME,
+            runtime_config_with_partial_template,
+        );
+
+        stored_workload.configs = HashMap::from([("ref1".to_owned(), "config_1".to_owned())]);
+
+        let workloads = HashMap::from([(WORKLOAD_NAME_1.to_owned(), stored_workload)]);
+        let multi_line_config_value = "value_1\nvalue_2\nvalue_3".to_string();
+        let configs = HashMap::from([(
+            "config_1".to_string(),
+            ConfigItem::String(multi_line_config_value),
+        )]);
+        let renderer = ConfigRenderer::default();
+
+        let render_result = renderer.render_workloads(&workloads, &configs);
+        assert!(render_result.is_ok());
+        let rendered_workloads = render_result.unwrap();
+
+        let workload = rendered_workloads.get(WORKLOAD_NAME_1).unwrap();
+
+        let expected_expanded_runtime_config = r#"
+        some:
+          keys:
+            before:
+              config_with_indent: |
+                value_1
+                value_2
+                value_3"#;
+
+        assert_eq!(workload.runtime_config, expected_expanded_runtime_config);
     }
 }

--- a/server/src/ankaios_server/config_renderer.rs
+++ b/server/src/ankaios_server/config_renderer.rs
@@ -54,6 +54,7 @@ impl Default for ConfigRenderer {
     fn default() -> Self {
         let mut template_engine = Handlebars::new();
         template_engine.set_strict_mode(true); // enable throwing render errors if context data is valid
+        template_engine.register_escape_fn(|s| s.into()); // prevent escaping like double quotes to &quot; ...
 
         // [impl->swdd~config-renderer-supports-rendering-with-keeping-line-indent~1]
         template_engine

--- a/server/src/ankaios_server/config_renderer.rs
+++ b/server/src/ankaios_server/config_renderer.rs
@@ -92,7 +92,7 @@ impl ConfigRenderer {
 
             rendered_workloads.insert(workload_name.clone(), workload_spec);
         }
-        log::debug!("Rendered CompleteState: {:?}", rendered_workloads);
+        log::trace!("Rendered CompleteState: {:?}", rendered_workloads);
         Ok(rendered_workloads)
     }
 

--- a/tests/resources/configs/manifest_with_multi_line_config.yaml
+++ b/tests/resources/configs/manifest_with_multi_line_config.yaml
@@ -1,0 +1,57 @@
+apiVersion: v0.1
+workloads:
+  nginx_with_custom_config:
+    agent: agent_A
+    runtime: podman-kube
+    configs:
+      nginx_conf: file_data
+    runtimeConfig: |
+      manifest: |
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: nginx-config
+        data:
+          nginx.conf: |
+            {{> indent content=nginx_conf.web_server_config}}
+        ---
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: nginx-container
+            image: ghcr.io/eclipse-ankaios/tests/nginx:alpine-slim
+            ports:
+            - containerPort: 80
+              hostPort: 8086
+            volumeMounts:
+            - name: nginx-config-volume
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+          volumes:
+          - name: nginx-config-volume
+            configMap:
+              name: nginx-config
+configs:
+  file_data:
+    web_server_config: |
+      worker_processes  1;
+
+      events {
+          worker_connections  1024;
+      }
+
+      http {
+          server {
+              listen 80;
+              server_name custom_nginx;
+
+              location /custom {
+                  default_type text/plain;
+                  return 200 "The mounted custom nginx.conf is being used!\n";
+              }
+          }
+      }

--- a/tests/stests/workloads/workload_configs_podman_kube.robot
+++ b/tests/stests/workloads/workload_configs_podman_kube.robot
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+*** Settings ***
+Documentation       Test of different cases related to workloads and their rendered configuration.
+
+Resource            ../../resources/ankaios.resource
+Resource            ../../resources/variables.resource
+
+
+*** Variables ***
+${start_up_yaml_file}           ${EMPTY}
+
+
+*** Test Cases ***
+# [stest->swdd~config-renderer-supports-rendering-with-keeping-line-indent~1]
+Test Ankaios start up with templated Ankaios manifest keeping indentation level of rendered multi-line config
+    [Setup]    Run Keywords    Setup Ankaios
+    [Tags]    multi_line_config
+
+    # Preconditions
+    # This test assumes that all pods and volume in the podman have been created with this test -> clean it up first
+    Given Podman has deleted all existing pods
+    And Podman has deleted all existing volumes
+    And Ankaios server is started with config "${CONFIGS_DIR}/manifest_with_multi_line_config.yaml"
+    # Actions
+    When Ankaios agent is started with name "agent_A"
+    # Asserts
+    Then the workload "nginx_with_custom_config" shall have the execution state "Running(Ok)" on agent "agent_A" within "20" seconds
+    And the command "curl -fL localhost:8086/custom" shall finish with exit code "0" within "2" seconds
+    [Teardown]    Clean up Ankaios

--- a/tests/stests/workloads/workload_configs_podman_kube.robot
+++ b/tests/stests/workloads/workload_configs_podman_kube.robot
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Elektrobit Automotive GmbH
+# Copyright (c) 2025 Elektrobit Automotive GmbH
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at
@@ -31,7 +31,7 @@ Test Ankaios start up with templated Ankaios manifest keeping indentation level 
     [Tags]    multi_line_config
 
     # Preconditions
-    # This test assumes that all pods and volume in the podman have been created with this test -> clean it up first
+    # This test assumes that all pods and volumes in the podman have been created with this test -> clean it up first
     Given Podman has deleted all existing pods
     And Podman has deleted all existing volumes
     And Ankaios server is started with config "${CONFIGS_DIR}/manifest_with_multi_line_config.yaml"

--- a/tests/stests/workloads/workload_configs_podman_kube.robot
+++ b/tests/stests/workloads/workload_configs_podman_kube.robot
@@ -28,7 +28,6 @@ ${start_up_yaml_file}           ${EMPTY}
 # [stest->swdd~config-renderer-supports-rendering-with-keeping-line-indent~1]
 Test Ankaios start up with templated Ankaios manifest keeping indentation level of rendered multi-line config
     [Setup]    Run Keywords    Setup Ankaios
-    [Tags]    multi_line_config
 
     # Preconditions
     # This test assumes that all pods and volumes in the podman have been created with this test -> clean it up first


### PR DESCRIPTION
<!--  Description of the change in case no issue is mentioned -->

The PR fixes expansion of multi-line configuration items with no indentation level consideration when using the default handlebars template syntax.

Scenario:
A user defines a multi-line sharable configuration item in the state and uses this configuration item in a workload field where line indentation must be considered in the current context during expansion of templates. The indentation level shall be considered to ensure validity of indentation-sensitive formats like YAML.

**Changes:**
- register a custom partial named `indent` in the handlebars template engine object (when rendering partials the line indentation will be automatically considered according to the current render context)
- prevent escaping special character sequences like quotes `\"` to `&quot`, ...
- user documentation about sharable configuration with multi-line content

The added system test shows an example use case with podman kube's ConfigMaps where it is important to keep line indentation while expanding templates in workload configuration.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
