### PR TITLE
Fix the handling of unneeded workloads at server restart

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -815,13 +815,19 @@ Needs:
 - stest
 
 ##### RuntimeManager handles existing workloads deletes unneeded workloads
-`swdd~agent-existing-workloads-delete-unneeded~1`
+`swdd~agent-existing-workloads-delete-unneeded~2`
 
 Status: approved
 
-When handling existing workloads, for each found existing workload that is not in the provided list of initial workloads, the RuntimeManager shall request the RuntimeFacade to delete the workload.
+When handling existing workloads, for each found existing workload that is not in the provided list of initial workloads, the RuntimeManager shall delete the workload without considering its `DeleteConditions` by
+* requesting the workload to delete itself if it is in the list of managed workloads or
+* requesting the RuntimeFacade to delete the workload.
 
-Comment: If the RuntimeManager finds an existing Workload that is not in the provided list of initial workloads, the Ankaios Agent shall stop the existing Workload. The Ankaios agent cannot consider the `DeleteCondition`s of the existing workload because the information is not available after an agent restart.
+Rationale:
+Unneeded workloads are only handled after a downtime of either the server, the agent or both. The Ankaios agent cannot consider the `DeleteCondition`s of the existing workload because the information was missed during the downtime and is not available.
+
+Comment:
+In case of an agent downtime, no workload object is available and the unneeded workload can only be deleted via the runtime without going through the object. If there is an object, it must be deleted to clean up the system.
 
 Tags:
 - RuntimeManager

--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -819,7 +819,7 @@ Needs:
 
 Status: approved
 
-When handling existing workloads, for each found existing workload that is not in the provided list of initial workloads, the RuntimeManager shall delete the workload without considering its `DeleteConditions` by
+When handling existing workloads, for each found existing workload that is not in the provided list of initial workloads, the RuntimeManager shall delete the workload without considering its `DeleteConditions`s by
 * requesting the workload to delete itself if it is in the list of managed workloads or
 * requesting the RuntimeFacade to delete the workload.
 

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -313,8 +313,7 @@ impl RuntimeManager {
                             }
                         } else {
                             let workload_name = workload_state.instance_name.workload_name();
-                            log::info!("Existing workload '{}' is not needed.", workload_name);
-                            // No added workload matches the found running one => delete it
+                            log::info!("Found existing workload '{}' is not needed.", workload_name);
                             // [impl->swdd~agent-existing-workloads-delete-unneeded~2]
                             if let Some(workload) = self.workloads.remove(workload_name) {
                                 if let Err(err) = workload.delete().await {

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -1185,23 +1185,18 @@ mod tests {
 
     // [utest->swdd~agent-existing-workloads-delete-unneeded~2]
     #[tokio::test]
-    async fn utest_handle_update_workload_initial_call_delete_unneeded() {
+    async fn utest_handle_update_workload_initial_call_delete_unneeded_after_agent_restart() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;
 
-        let existing_workload_with_other_config = WorkloadInstanceNameBuilder::default()
+        let existing_unneeded_workload = WorkloadInstanceNameBuilder::default()
             .workload_name(WORKLOAD_1_NAME)
             .config(&String::from("different config"))
             .agent_name(AGENT_NAME)
             .build();
 
-        let existing_instance_name_clone = existing_workload_with_other_config.clone();
-
-        let workload_operations = vec![WorkloadOperation::Delete(DeletedWorkload {
-            instance_name: existing_instance_name_clone,
-            ..Default::default()
-        })];
+        let workload_operations = vec![];
         let mut mock_workload_scheduler = MockWorkloadScheduler::default();
         mock_workload_scheduler
             .expect_enqueue_filtered_workload_operations()
@@ -1221,7 +1216,7 @@ mod tests {
             .return_once(|_| {
                 Box::pin(async move {
                     Ok(vec![ReusableWorkloadState::new(
-                        existing_workload_with_other_config,
+                        existing_unneeded_workload,
                         ExecutionState::default(),
                         None,
                     )])


### PR DESCRIPTION
Issues: #446

We cannot properly handle unneeded workloads in a restart situation because we could have missed information during the downtime. The delete dependencies are not available in such scenarios and the only thing we can do is to delete the workload without waiting.

Still, the system **shall not be left in a dirty state** if we can avoid this, so in case of a server restart the existing workload shall be properly deleted using the workload object. This ensures that:
* Control Interface pipes are deleted
* Config files for the mounts are deleted
* Workload state checker is deleted
* Workload object is not ghosting in the agent

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
