### PR TITLE
Fix unneeded error handling

### DIFF
--- a/ank/src/cli_commands/set_state.rs
+++ b/ank/src/cli_commands/set_state.rs
@@ -68,7 +68,7 @@ async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<O
                     error
                 ))
             })?;
-            Ok(Object::try_from(&value)?)
+            Ok(value.into())
         }
         _ => {
             let state_object_data =
@@ -85,7 +85,7 @@ async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<O
                         error
                     ))
                 })?;
-            Ok(Object::try_from(&value)?)
+            Ok(value.into())
         }
     }
 }
@@ -245,7 +245,7 @@ mod tests {
         };
         let mut complete_state_object: Object = complete_state.try_into().unwrap();
         let value: serde_yaml::Value = serde_yaml::from_str(SAMPLE_CONFIG).unwrap();
-        let temp_object = Object::try_from(&value).unwrap();
+        let temp_object = value.into();
         let update_mask = vec!["desiredState.workloads.nginx".to_string()];
 
         complete_state_object =
@@ -275,7 +275,7 @@ mod tests {
         let temp_obj = process_inputs(reader, &state_object_file).await.unwrap();
 
         let value: Value = serde_yaml::from_str(SAMPLE_CONFIG).unwrap();
-        let expected_obj = Object::try_from(&value).unwrap();
+        let expected_obj = value.into();
 
         assert_eq!(temp_obj, expected_obj);
     }
@@ -290,7 +290,7 @@ mod tests {
             .unwrap();
 
         let value: Value = serde_yaml::from_str(SAMPLE_CONFIG).unwrap();
-        let expected_obj = Object::try_from(&value).unwrap();
+        let expected_obj = value.into();
 
         assert_eq!(temp_obj, expected_obj);
     }

--- a/common/src/state_manipulation/object.rs
+++ b/common/src/state_manipulation/object.rs
@@ -36,13 +36,9 @@ impl Default for Object {
     }
 }
 
-impl TryFrom<&serde_yaml::Value> for Object {
-    type Error = serde_yaml::Error;
-
-    fn try_from(value: &serde_yaml::Value) -> Result<Self, Self::Error> {
-        Ok(Object {
-            data: value.to_owned(),
-        })
+impl From<serde_yaml::Value> for Object {
+    fn from(data: serde_yaml::Value) -> Self {
+        Object { data }
     }
 }
 


### PR DESCRIPTION
The `TryFrom<&serde_yaml::Value> for Object` is needed and can be supplemented with a simple 'From<serde_yaml::Value> for Object'.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
