### PR TITLE
Update resource usage in documentation

### DIFF
--- a/doc/docs/reference/resource-usage.md
+++ b/doc/docs/reference/resource-usage.md
@@ -1,6 +1,6 @@
 # Resource usage
 
-The following table shows the resource usage of Ankaios v0.2.0 with the setup:
+The following table shows the resource usage of Ankaios v0.5.1 with the setup:
 
 * Raspberry PI 4B BCM2711
 * Quad core Cortex-A72 (ARM v8) 64-bit SoC @ 1.8GHz
@@ -8,5 +8,5 @@ The following table shows the resource usage of Ankaios v0.2.0 with the setup:
 
 | Component      | CPU | RAM |
 | -------------- | ------- | ------- |
-| Ankaios server | 0.0%    | 3.1 MB  |
-| Ankaios agent  | 0.0%    | 3.9 MB  |
+| Ankaios server | 0.0%    | 4.6 MiB  |
+| Ankaios agent  | 0.1%    | 4.8 MiB  |


### PR DESCRIPTION
The is PR updates the resource usage in the documentation. The previous one was based on v0.2.

The results were determined using:

```shell
$ ps -o pid,%cpu,%mem,rss,nlwp,cmd -C ank-server,ank-agent
    PID %CPU %MEM   RSS NLWP CMD
1893674  0.0  0.1  4736    5 /usr/local/bin/ank-server --insecure --startup-config /etc/ankaios/state.yaml
1893805  0.1  0.1  4948    5 /usr/local/bin/ank-agent --insecure --name agent_A
```

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
