### PR TITLE
Create test reports and store as release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Run unit tests
-        run: RUST_LOG=debug cargo nextest run
+        run: just utest
+      - uses: actions/upload-artifact@v4.3.3
+        with:
+          name: unit-test-results
+          path: target/nextest/default/unit-test-report.xml
       - name: Run clippy code checks
         run: just clippy
       - name: Prevent docker.io images in test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,14 +50,27 @@ jobs:
         with:
           name: licenses
           path: dist/
+      - name: Download unit test results
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: unit-test-results
+          path: dist/test-results
+      - name: Download robot test results
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: robot-tests-result
+          path: dist/test-results/robot
       - name: Package release artifacts
         run: tools/create_release.sh
       - name: Upload release artifacts
         run: |
           cd dist
           tree
-          gh release upload ${{ github.ref_name }} coverage-report.tar.gz \
+          gh release upload ${{ github.ref_name }} \
+          coverage-report.tar.gz \
           coverage-report.zip \
+          test-results.tar.gz \
+          test-results.zip \
           req_tracing_report.html \
           install.sh \
           ank_base.proto \

--- a/justfile
+++ b/justfile
@@ -48,7 +48,7 @@ test: utest stest
 
 # Run unit tests
 utest:
-    cargo nextest run
+    RUST_LOG=debug cargo nextest --config-file nextest.toml run
 
 # Build debug and run all system tests
 stest: build stest-only

--- a/nextest.toml
+++ b/nextest.toml
@@ -1,0 +1,21 @@
+[profile.default.junit]
+# Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
+# If unspecified, JUnit is not written out.
+
+path = "unit-test-report.xml"
+
+# The name of the top-level "report" element in JUnit report. If aggregating
+# reports across different test runs, it may be useful to provide separate names
+# for each report.
+report-name = "ankaios"
+
+# Whether standard output and standard error for passing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+store-success-output = false
+
+# Whether standard output and standard error for failing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+#
+# Note that if a description can be extracted from the output, it is always stored in the
+# <description> element.
+store-failure-output = true

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -15,6 +15,10 @@ echo "Exporting coverage report"
 tar -cvzf "${DIST_DIR}/"coverage-report.tar.gz --directory="${DIST_DIR}/coverage" $(ls "${DIST_DIR}/coverage")
 (cd "${DIST_DIR}/coverage" && zip -r "${DIST_DIR}/"coverage-report.zip .)
 
+echo "Exporting test results"
+tar -cvzf "${DIST_DIR}/"test-results.tar.gz --directory="${DIST_DIR}/test-results" $(ls "${DIST_DIR}/test-results")
+(cd "${DIST_DIR}/test-results" && zip -r "${DIST_DIR}/"test-results.zip .)
+
 echo "Exporting control api protos"
 cp "${ROOT_DIR}"/api/proto/*.proto "${DIST_DIR}"
 

--- a/tools/run_robot_tests.sh
+++ b/tools/run_robot_tests.sh
@@ -60,4 +60,4 @@ echo Generate certificates and keys for stests...
 $tools_dir/certs/create_certs.sh /tmp/.certs
 echo done.
 
-ANK_BIN_DIR=$ANK_BIN_DIR robot --pythonpath tests --loglevel=TRACE:TRACE -d ${target_dir} "$@"
+ANK_BIN_DIR=$ANK_BIN_DIR robot --pythonpath tests --loglevel=TRACE:TRACE -x xunitOut.xml -d ${target_dir} "$@"


### PR DESCRIPTION
The Eclipse SDV badge program requires test reports to be stored as release artifacts. This PR adds the unit test results and the robot test results as release artifacts.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
