### PR TITLE
Add quality manifest as release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,3 +80,16 @@ jobs:
           linux-arm64/ankaios-linux-arm64.tar.gz \
           linux-arm64/ankaios-linux-arm64.tar.gz.sha512sum.txt \
           licenses.html
+      - name: Collect quality artifacts
+        id: collect_quality_artifacts
+        uses: eclipse-dash/quevee@770b5e569ebbd4ff3603ee2ed4e17a4791fc028f # no release yet
+        with:
+          release_url: "https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
+          artifacts_documentation: "https://eclipse-ankaios.github.io/ankaios"
+          artifacts_license: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/licenses.html"
+          artifacts_readme: "https://raw.githubusercontent.com/${{ github.repository }}/refs/tags/${{ github.ref_name }}/README.md"
+          artifacts_requirements: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/req_tracing_report.html"
+          artifacts_testing: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/test-results.zip,https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/test-results.tar.gz"
+      - name: Upload quality manifest
+        run: |
+          gh release upload ${{ github.ref_name }} ${{ steps.collect_quality_artifacts.outputs.manifest_file }}


### PR DESCRIPTION
For getting Eclipse SDV quality badges, a manifest file needs to be provided as part of the release using the action [eclipse-dash/quevee](https://github.com/eclipse-dash/quevee). This PR adds the required file.

A test release has been created in https://github.com/windsource/ankaios/releases/tag/v0.0.2 which contains the required file `sdv-manifest.toml`.

**First merge #468 before merging this PR.**

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
