### PR TITLE
Fix server to not crash on missing hello message

### DIFF
--- a/grpc/src/grpc_agent_connection.rs
+++ b/grpc/src/grpc_agent_connection.rs
@@ -177,14 +177,14 @@ impl AgentConnection for GRPCAgentConnection {
                         sans
                     )));
                 }
+                Ok(Response::new(Box::pin(ReceiverStream::new(
+                    new_agent_receiver,
+                ))))
             }
-            _ => Err::<(), &str>("No AgentHello received.").unwrap_or_exit("Protocol error."),
+            _ => Err(Status::invalid_argument("No AgentHello received.")),
         }
 
         // [impl->swdd~grpc-agent-connection-responds-with-from-server-channel-rx~1]
-        Ok(Response::new(Box::pin(ReceiverStream::new(
-            new_agent_receiver,
-        ))))
     }
 }
 

--- a/grpc/src/grpc_cli_connection.rs
+++ b/grpc/src/grpc_cli_connection.rs
@@ -110,11 +110,10 @@ impl CliConnection for GRPCCliConnection {
                         cli_connection_name
                     );
                 });
+                // [impl->swdd~grpc-commander-connection-responds-with-from-server-channel-rx~1]
+                Ok(Response::new(Box::pin(ReceiverStream::new(new_receiver))))
             }
-            _ => Err::<(), &str>("No CommanderHello received.").unwrap_or_exit("Protocol error."),
+            _ => Err(Status::invalid_argument("No CommanderHello received.")),
         }
-
-        // [impl->swdd~grpc-commander-connection-responds-with-from-server-channel-rx~1]
-        Ok(Response::new(Box::pin(ReceiverStream::new(new_receiver))))
     }
 }

--- a/grpc/src/grpc_cli_connection.rs
+++ b/grpc/src/grpc_cli_connection.rs
@@ -14,7 +14,6 @@
 
 use std::pin::Pin;
 
-use common::std_extensions::GracefulExitResult;
 use common::{check_version_compatibility, to_server_interface};
 use tokio::sync::mpsc::Sender;
 use tokio_stream::wrappers::ReceiverStream;


### PR DESCRIPTION
Until now the server crashes if the first message received from a agent and the CLI is not the correct hello message. Now the server returns an error and drops the connection.


# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
