### PR TITLE
Stabilize the utests for the config files by adding a mutex

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -235,6 +235,10 @@ mod tests {
     insecure = true
     #";
 
+    mockall::lazy_static! {
+        pub static ref CONTEXT_SYNC: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    }
+
     #[test]
     fn utest_handle_agent_config_valid_config() {
         let mut tmp_config = NamedTempFile::new().expect("could not create temp file");
@@ -255,6 +259,8 @@ mod tests {
 
     #[test]
     fn utest_handle_agent_config_default_path() {
+        let _guard = CONTEXT_SYNC.lock().unwrap();
+
         if let Some(parent) = PathBuf::from(DEFAULT_AGENT_CONFIG_FILE_PATH).parent() {
             fs::create_dir_all(parent).expect("Failed to create directories");
         }
@@ -276,6 +282,11 @@ mod tests {
 
     #[test]
     fn utest_handle_agent_config_default() {
+        // The guard here is a quick workaround for the sync issues resulting from using real files
+        // on the filesystem instead of mocking the calls to try_exists(). More information on a
+        // proper fix is available here: https://github.com/eclipse-ankaios/ankaios/issues/480
+        let _guard = CONTEXT_SYNC.lock().unwrap();
+
         let agent_config = handle_agent_config(&None);
 
         assert_eq!(agent_config, AgentConfig::default());

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -274,6 +274,10 @@ mod tests {
     [default]
     #";
 
+    mockall::lazy_static! {
+        pub static ref CONTEXT_SYNC: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    }
+
     #[test]
     fn utest_handle_ank_config_valid_config() {
         let mut tmp_config_file = NamedTempFile::new().expect("could not create temp file");
@@ -293,6 +297,8 @@ mod tests {
 
     #[test]
     fn utest_handle_ank_config_default_path() {
+        let _guard = CONTEXT_SYNC.lock().unwrap();
+
         if let Some(parent) = PathBuf::from(DEFAULT_ANK_CONFIG_FILE_PATH).parent() {
             fs::create_dir_all(parent).expect("Failed to create directories");
         }
@@ -307,6 +313,10 @@ mod tests {
 
     #[test]
     fn utest_handle_ank_config_default() {
+        // The guard here is a quick workaround for the sync issues resulting from using real files
+        // on the filesystem instead of mocking the calls to try_exists(). More information on a
+        // proper fix is available here: https://github.com/eclipse-ankaios/ankaios/issues/480
+        let _guard = CONTEXT_SYNC.lock().unwrap();
         let ank_config = handle_ank_config(&None);
 
         assert_eq!(ank_config, AnkConfig::default());


### PR DESCRIPTION
This is just a workaround for stabilizing the unit tests. 
A proper fix can be done with #480. See the issue for more details.

Example of the problem:
<img width="1604" alt="image" src="https://github.com/user-attachments/assets/c0de7039-b475-4dfb-93c6-3442a369d40b" />


<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
