### PR TITLE
Fix unstable unit tests

### DIFF
--- a/agent/src/agent_config.rs
+++ b/agent/src/agent_config.rs
@@ -26,11 +26,7 @@ use toml::from_str;
 
 const CONFIG_VERSION: &str = "v1";
 
-#[cfg(not(test))]
 pub const DEFAULT_AGENT_CONFIG_FILE_PATH: &str = "/etc/ankaios/ank-agent.conf";
-
-#[cfg(test)]
-pub const DEFAULT_AGENT_CONFIG_FILE_PATH: &str = "/tmp/ankaios/ank-agent.conf";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConversionErrors {

--- a/ank/src/ank_config.rs
+++ b/ank/src/ank_config.rs
@@ -24,25 +24,18 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use toml::{from_str, Value};
 
-#[cfg(not(test))]
 use common::std_extensions::GracefulExitResult;
-#[cfg(not(test))]
 use once_cell::sync::Lazy;
-#[cfg(not(test))]
 use std::env;
 
 pub const CONFIG_VERSION: &str = "v1";
 pub const DEFAULT_CONFIG: &str = "default";
 pub const DEFAULT_RESPONSE_TIMEOUT: u64 = 3000;
 
-#[cfg(not(test))]
 pub static DEFAULT_ANK_CONFIG_FILE_PATH: Lazy<String> = Lazy::new(|| {
     let home_dir = env::var("HOME").unwrap_or_exit("HOME environment variable not set");
     format!("{}/.config/ankaios/ank.conf", home_dir)
 });
-
-#[cfg(test)]
-pub const DEFAULT_ANK_CONFIG_FILE_PATH: &str = "/tmp/ankaios/ank.conf";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConversionErrors {

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -26,11 +26,7 @@ use toml::from_str;
 
 const CONFIG_VERSION: &str = "v1";
 
-#[cfg(not(test))]
 pub const DEFAULT_SERVER_CONFIG_FILE_PATH: &str = "/etc/ankaios/ank-server.conf";
-
-#[cfg(test)]
-pub const DEFAULT_SERVER_CONFIG_FILE_PATH: &str = "/tmp/ankaios/ank-server.conf";
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConversionErrors {


### PR DESCRIPTION
Fix the unstable unit tests for the config files by providing the default path outside of the function.
This is still just a workaround for #480.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
