### PR TITLE
Provided source package including dependencies with each release

### DIFF
--- a/.github/actions/use-vendored-source/action.yml
+++ b/.github/actions/use-vendored-source/action.yml
@@ -1,0 +1,12 @@
+name: Download and extract vendored source
+description: Download and extract vendored source. Usually only called for release builds
+runs:
+  using: "composite"
+  steps:
+    - name: Get vendored source
+      uses: actions/download-artifact@v4.1.7
+      with:
+        name: vendored-sources
+    - name: Unpack vendored source in current folder (overwrite existing)
+      run: tar --strip-components=1 -xzf ankaios-vendored-source*.tar.gz
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,14 +16,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  vendor:
+    name: Vendor dependencies
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    container:
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Vendor all dependencies locally
+        run: just vendor
+      - uses: actions/upload-artifact@v4.3.3
+        with:
+          name: vendored-sources
+          path: dist/ankaios-vendored-source*.tar.gz
+
   build_and_system_tests_linux_amd64:
     name: Build and run system tests Linux amd64
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build debug
         run: cargo build
       - name: Prepare system tests
@@ -49,12 +69,17 @@ jobs:
 
   unit_tests_and_code_checks_linux_amd64:
     name: Run unit tests Linux amd64
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Run unit tests
         run: just utest
       - uses: actions/upload-artifact@v4.3.3
@@ -89,12 +114,17 @@ jobs:
 
   code_coverage_linux_amd64:
     name: Create code coverage report
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Create code coverage html report
         run: |
           rustup component add llvm-tools-preview
@@ -107,12 +137,17 @@ jobs:
 
   build_linux_amd64_debian_package:
     name: Build Linux amd64 debian package
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --privileged
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - name: Build linux-amd64 release-mode
         run: |
           cargo build --release
@@ -138,12 +173,17 @@ jobs:
     # if arm64 variants will be released we can switch to an arm64 image and save the longer built time for cross platform build
     # and in addition, tests for arm64 can be enabled in this job, too
     name: Build Linux arm64 debian package
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build linux-arm64 release-mode
         run: |
@@ -165,12 +205,17 @@ jobs:
 
   requirements:
     name: Build requirements tracing
+    if: ${{ always() }}
+    needs: vendor
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
       options: --user root
     steps:
       - uses: actions/checkout@v4.1.1
+      - name: Use vendored source for release builds
+        uses: ./.github/actions/use-vendored-source
+        if: ${{ startsWith(github.ref, 'refs/tags/') }}
       - run: |
           just trace-requirements dist/req_tracing_report.html
       - uses: actions/upload-artifact@v4.3.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,11 @@ jobs:
         with:
           name: robot-tests-result
           path: dist/test-results/robot
+      - name: Download vendored source
+        uses: actions/download-artifact@v4.1.7
+        with:
+          name: vendored-sources
+          path: dist/
       - name: Package release artifacts
         run: tools/create_release.sh
       - name: Upload release artifacts
@@ -80,7 +85,8 @@ jobs:
           linux-amd64/ankaios-linux-amd64.tar.gz.sha512sum.txt \
           linux-arm64/ankaios-linux-arm64.tar.gz \
           linux-arm64/ankaios-linux-arm64.tar.gz.sha512sum.txt \
-          licenses.html
+          licenses.html \
+          ankaios-vendored-source*.tar.gz
       - name: Collect quality artifacts
         id: collect_quality_artifacts
         uses: eclipse-dash/quevee@770b5e569ebbd4ff3603ee2ed4e17a4791fc028f # no release yet

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ temp
 req_in
 dist
 logs
+vendor
 
 #ignore plantuml out folder
 /out

--- a/tools/check_copyright_headers.sh
+++ b/tools/check_copyright_headers.sh
@@ -11,6 +11,7 @@ FILE_EXT=(
 # Exclude paths from search
 EXCLUDE_PATHS=(
     "$SEARCH_DIR/target/*"
+    "$SEARCH_DIR/vendor/*"
 )
 
 function check_copyright_headers() {


### PR DESCRIPTION
This PR adds a source archive as an asset for every release which includes the vendored dependencies, that have been used for that specific release. So everyone has the chance to rebuild Ankaios based on the same source and the same dependencies for that release.

For non-release builds (PRs and branches) the dependencies are not vendored in order not to increase the build time.

The newly create source package can later on be used to build packages for Linux distributions like Debian, Ubuntu or RHEL which usually require an archive with all dependencies.

A test release is available, see https://github.com/windsource/ankaios/releases/tag/v0.4.2 and the asset [`ankaios-vendored-source-0.4.2.tar.gz`](https://github.com/windsource/ankaios/releases/download/v0.4.2/ankaios-vendored-source-0.4.2.tar.gz).

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
