### PR TITLE
Fix link for self service playground

### DIFF
--- a/doc/docs/development/self-service.md
+++ b/doc/docs/development/self-service.md
@@ -14,7 +14,7 @@ A detailed overview of the self-service please have a look into the [self-servic
 If a configuration needs to be changed the process is the following:
 
 1. Fork the [.eclipsefdn](https://github.com/eclipse-ankaios/.eclipsefdn) repository.
-2. Do the configuration changes (Use the [Eclipse playground](https://otterdog.eclipse.org/organizations/eclipse-ankaios/playground/) for trying out the available settings).
+2. Do the configuration changes (Use the [Eclipse playground](https://otterdog.eclipse.org/organizations/eclipse-ankaios/playground) for trying out the available settings).
 3. Open a PR pointing from your fork's branch to the [.eclipsefdn](https://github.com/eclipse-ankaios/.eclipsefdn) repository.
 4. Make sure that a review is requested from: Ankaios project committer, eclipsefdn-releng, eclipsefdn-security.
 5. After the changes were approved by the reviewers, a member of Eclipse Foundation IT staff will merge the PR and applies the new settings by using the [otterdog cli](https://otterdog.readthedocs.io/en/latest/).

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -77,7 +77,6 @@ plugins:
       ignore_pages:
         - reference/_ankaios.proto.md
       raise_error_excludes:
-        503: ['https://otterdog.eclipse.org/organizations/eclipse-ankaios/playground/']
         404: ['https://crates.io/crates/symphony']
 
 extra:


### PR DESCRIPTION
The link in the documentation for the Eclipse otterdog self service has been corrected.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
