### PR TITLE
Update quevee action to v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,14 @@ jobs:
           licenses.html
       - name: Collect quality artifacts
         id: collect_quality_artifacts
-        uses: eclipse-dash/quevee@770b5e569ebbd4ff3603ee2ed4e17a4791fc028f # no release yet
+        uses: eclipse-dash/quevee@b62d7faa1cf68654758754aaed8616b19f227583 # v1.0.0
         with:
           release_url: "https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
-          artifacts_documentation: "https://eclipse-ankaios.github.io/ankaios"
-          artifacts_license: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/licenses.html"
-          artifacts_readme: "https://raw.githubusercontent.com/${{ github.repository }}/refs/tags/${{ github.ref_name }}/README.md"
           artifacts_requirements: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/req_tracing_report.html"
           artifacts_testing: "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/test-results.zip,https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/test-results.tar.gz"
+          artifacts_documentation: "https://eclipse-ankaios.github.io/ankaios"
+          artifacts_coding_guidelines: "https://eclipse-ankaios.github.io/ankaios/latest/development/rust-coding-guidelines/"
+          artifacts_release_process: "https://eclipse-ankaios.github.io/ankaios/latest/development/ci-cd-release/"
       - name: Upload quality manifest
         run: |
           gh release upload ${{ github.ref_name }} ${{ steps.collect_quality_artifacts.outputs.manifest_file }}


### PR DESCRIPTION
Recently the [eclipse-dash/quevee](https://github.com/eclipse-dash/quevee) action has been released for the first time to v1.0.0. This PR uses this quevee version for creating the `sdv-manifest.toml` release asset.

With these changes I have created a [test release](https://github.com/windsource/ankaios/releases/tag/v0.4.4).


<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
