### PR TITLE
Handle invalid runtime

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -676,6 +676,7 @@ Tags:
 Needs:
 - impl
 - utest
+- stest
 
 #### RuntimeManager stores Workload in the list of running workloads
 `swdd~agent-stores-running-workload~1`

--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -672,6 +672,12 @@ When the Ankaios Agent gets an add Workload command with the `UpdateWorkload` me
 * skip this workload
 * send a `Pending(StartingFailed)` workload state with additional information.
 
+Comment:
+The `UnsupportedRuntime` implementation returns appropriate errors for unsupported operations while allowing the workload object lifecycle to be managed normally. When the workload attempts to be created through the `UnsupportedRuntime`, it will receive a `RuntimeError::Unsupported` error, which causes the workload to report a `Pending(StartingFailed)` state.
+
+Rationale:
+This approach provides better error handling and user feedback compared to completely skipping unknown runtime workloads. It allows the workload to be tracked and managed while clearly indicating why it cannot be started.
+
 Tags:
 - RuntimeManager
 
@@ -3294,9 +3300,7 @@ Needs:
 
 Status: approved
 
-When the Authorizer checks if a Workload is allowed to make a request
-and all entries of the update/field mask are allowed,
-the Authorizer shall allow the request.
+When the Authorizer checks if an individual entry of the update/field mask of a request matches an individual entry of the filter mask of an allow rule, the Authorizer shall allow the request.
 
 Tags:
 - Authorizer

--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -668,7 +668,9 @@ Needs:
 
 Status: approved
 
-When the Ankaios Agent gets an add Workload command with the `UpdateWorkload` message and the runtime of the Workload is unknown, the RuntimeManager shall skip this Workload and send a `Pending(StartingFailed)` workload state with additional information.
+When the Ankaios Agent gets an add Workload command with the `UpdateWorkload` message and the runtime of the Workload is unknown, the RuntimeManager shall:
+* skip this workload
+* send a `Pending(StartingFailed)` workload state with additional information.
 
 Tags:
 - RuntimeManager

--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -664,11 +664,11 @@ Needs:
 - stest
 
 #### Agent skips unknown runtime
-`swdd~agent-skips-unknown-runtime~1`
+`swdd~agent-skips-unknown-runtime~2`
 
 Status: approved
 
-When the Ankaios Agent gets an add Workload command with the `UpdateWorkload` message and the runtime of the Workload is unknown, the RuntimeManager shall skip this Workload.
+When the Ankaios Agent gets an add Workload command with the `UpdateWorkload` message and the runtime of the Workload is unknown, the RuntimeManager shall skip this Workload and send a `Pending(StartingFailed)` workload state with additional information.
 
 Tags:
 - RuntimeManager

--- a/agent/src/runtime_connectors/dummy_state_checker.rs
+++ b/agent/src/runtime_connectors/dummy_state_checker.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use common::objects::WorkloadSpec;
+
+use crate::workload_state::WorkloadStateSender;
+
+use super::{RuntimeStateGetter, StateChecker};
+
+pub struct DummyStateChecker();
+
+#[async_trait]
+impl<WorkloadId> StateChecker<WorkloadId> for DummyStateChecker
+where
+    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
+{
+    fn start_checker(
+        _workload_spec: &WorkloadSpec,
+        _workload_id: WorkloadId,
+        _manager_interface: WorkloadStateSender,
+        _state_getter: impl RuntimeStateGetter<WorkloadId>,
+    ) -> Self {
+        Self()
+    }
+    async fn stop_checker(self) {}
+}

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -20,6 +20,9 @@ pub(crate) mod podman;
 
 pub(crate) mod podman_kube;
 
+pub(crate) mod dummy_state_checker;
+pub(crate) mod unsupported_runtime;
+
 mod runtime_connector;
 pub use runtime_connector::{
     OwnableRuntime, ReusableWorkloadState, RuntimeConnector, RuntimeError,
@@ -29,6 +32,8 @@ pub use runtime_connector::{
 pub use runtime_connector::test;
 
 mod runtime_facade;
+#[cfg(test)]
+pub use runtime_facade::MockGenericRuntimeFacade;
 pub use runtime_facade::{GenericRuntimeFacade, RuntimeFacade};
 
 #[cfg(test)]

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -20,6 +20,10 @@ use common::{
     objects::{AgentName, ExecutionState, WorkloadInstanceName, WorkloadSpec},
     std_extensions::IllegalStateResult,
 };
+
+#[cfg(test)]
+use crate::runtime_connectors::dummy_state_checker::DummyStateChecker;
+
 #[cfg(test)]
 use mockall::automock;
 
@@ -407,6 +411,42 @@ impl<
                 .report_workload_execution_state(&instance_name, ExecutionState::removed())
                 .await;
         })
+    }
+}
+
+#[cfg(test)]
+mockall::mock! {
+    pub GenericRuntimeFacade {
+        pub fn new(runtime: Box<dyn OwnableRuntime<String, DummyStateChecker>>,
+            run_folder: PathBuf) -> Self;
+    }
+
+    #[async_trait]
+    impl RuntimeFacade for GenericRuntimeFacade {
+        async fn get_reusable_workloads(
+            &self,
+            agent_name: &AgentName,
+        ) -> Result<Vec<ReusableWorkloadState>, RuntimeError>;
+
+        fn create_workload(
+            &self,
+            runtime_workload: ReusableWorkloadSpec,
+            control_interface_info: Option<ControlInterfaceInfo>,
+            update_state_tx: &WorkloadStateSender,
+        ) -> Workload;
+
+        fn resume_workload(
+            &self,
+            runtime_workload: WorkloadSpec,
+            control_interface: Option<ControlInterfaceInfo>,
+            update_state_tx: &WorkloadStateSender,
+        ) -> Workload;
+
+        fn delete_workload(
+            &self,
+            instance_name: WorkloadInstanceName,
+            update_state_tx: &WorkloadStateSender,
+        );
     }
 }
 

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -417,7 +417,7 @@ impl<
 #[cfg(test)]
 mockall::mock! {
     pub GenericRuntimeFacade {
-        pub fn new(runtime: Box<dyn OwnableRuntime<String, DummyStateChecker>>,
+        pub fn new(runtime: Box<dyn OwnableRuntime<String, DummyStateChecker<String>>>,
             run_folder: PathBuf) -> Self;
     }
 

--- a/agent/src/runtime_connectors/unsupported_runtime.rs
+++ b/agent/src/runtime_connectors/unsupported_runtime.rs
@@ -24,10 +24,12 @@ use super::{
 };
 
 #[derive(Clone)]
+// [impl->swdd~agent-skips-unknown-runtime~2]
 pub struct UnsupportedRuntime(pub String);
 
+// [impl->swdd~agent-skips-unknown-runtime~2]
 #[async_trait]
-impl RuntimeConnector<String, DummyStateChecker> for UnsupportedRuntime {
+impl RuntimeConnector<String, DummyStateChecker<String>> for UnsupportedRuntime {
     fn name(&self) -> String {
         self.0.clone()
     }
@@ -46,7 +48,7 @@ impl RuntimeConnector<String, DummyStateChecker> for UnsupportedRuntime {
         _control_interface_path: Option<PathBuf>,
         _update_state_tx: WorkloadStateSender,
         _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(String, DummyStateChecker), RuntimeError> {
+    ) -> Result<(String, DummyStateChecker<String>), RuntimeError> {
         if runtime_workload_config.runtime == self.0 {
             Err(RuntimeError::Unsupported("Unsupported Runtime".into()))
         } else {
@@ -71,11 +73,142 @@ impl RuntimeConnector<String, DummyStateChecker> for UnsupportedRuntime {
         _workload_id: &String,
         _runtime_workload_config: WorkloadSpec,
         _update_state_tx: WorkloadStateSender,
-    ) -> Result<DummyStateChecker, RuntimeError> {
-        Ok(DummyStateChecker())
+    ) -> Result<DummyStateChecker<String>, RuntimeError> {
+        Ok(DummyStateChecker::new())
     }
 
     async fn delete_workload(&self, _workload_id: &String) -> Result<(), RuntimeError> {
         Ok(())
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime_connectors::RuntimeConnector;
+
+    use super::{RuntimeError, UnsupportedRuntime};
+    use common::objects::{AgentName, WorkloadInstanceName, WorkloadSpec};
+    use std::collections::HashMap;
+
+    const TEST_RUNTIME_NAME: &str = "test_runtime";
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_name_returns_runtime_name() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+
+        assert_eq!(unsupported_runtime.name(), TEST_RUNTIME_NAME.to_string());
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_get_reusable_workloads_returns_empty_vec() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+        let agent_name = AgentName::from("dummy_agent");
+
+        let result = unsupported_runtime
+            .get_reusable_workloads(&agent_name)
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_create_workload_returns_unsupported_error_for_matching_runtime() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+
+        let workload_spec = WorkloadSpec {
+            runtime: TEST_RUNTIME_NAME.to_string(),
+            ..WorkloadSpec::default()
+        };
+
+        let result = unsupported_runtime
+            .create_workload(
+                workload_spec,
+                None,
+                None,
+                tokio::sync::mpsc::channel(1).0,
+                HashMap::new(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RuntimeError::Unsupported(msg)) if msg == "Unsupported Runtime"
+        ));
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_create_workload_returns_unsupported_error_for_different_runtime() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+        let workload_spec = WorkloadSpec {
+            runtime: "different_runtime".to_string(),
+            ..WorkloadSpec::default()
+        };
+
+        let result = unsupported_runtime
+            .create_workload(
+                workload_spec,
+                None,
+                None,
+                tokio::sync::mpsc::channel(1).0,
+                HashMap::new(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(RuntimeError::Unsupported(msg)) if msg.contains("Received a spec for the wrong runtime")
+        ));
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_get_workload_id_returns_list_error() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+        let instance_name = WorkloadInstanceName::new("test-agent", "test-workload", "test-id");
+
+        let result = unsupported_runtime.get_workload_id(&instance_name).await;
+
+        assert!(matches!(
+            result,
+            Err(RuntimeError::List(msg)) if msg.contains("Cannot get information about workload")
+        ));
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_start_checker_returns_dummy_checker() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+        let workload_id = "test_id".to_string();
+        let workload_spec = WorkloadSpec::default();
+
+        let result = unsupported_runtime
+            .start_checker(&workload_id, workload_spec, tokio::sync::mpsc::channel(1).0)
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    // [utest->swdd~agent-skips-unknown-runtime~2]
+    #[tokio::test]
+    async fn utest_delete_workload_returns_ok() {
+        let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
+        let workload_id = "test_id".to_string();
+
+        let result = unsupported_runtime.delete_workload(&workload_id).await;
+
+        assert!(result.is_ok());
     }
 }

--- a/agent/src/runtime_connectors/unsupported_runtime.rs
+++ b/agent/src/runtime_connectors/unsupported_runtime.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, path::PathBuf};
+
+use async_trait::async_trait;
+use common::objects::{AgentName, WorkloadInstanceName, WorkloadSpec};
+
+use crate::workload_state::WorkloadStateSender;
+
+use super::{
+    dummy_state_checker::DummyStateChecker, ReusableWorkloadState, RuntimeConnector, RuntimeError,
+};
+
+#[derive(Clone)]
+pub struct UnsupportedRuntime(pub String);
+
+#[async_trait]
+impl RuntimeConnector<String, DummyStateChecker> for UnsupportedRuntime {
+    fn name(&self) -> String {
+        self.0.clone()
+    }
+
+    async fn get_reusable_workloads(
+        &self,
+        _agent_name: &AgentName,
+    ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
+        Ok(Vec::new())
+    }
+
+    async fn create_workload(
+        &self,
+        runtime_workload_config: WorkloadSpec,
+        _reusable_workload_id: Option<String>,
+        _control_interface_path: Option<PathBuf>,
+        _update_state_tx: WorkloadStateSender,
+        _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
+    ) -> Result<(String, DummyStateChecker), RuntimeError> {
+        if runtime_workload_config.runtime == self.0 {
+            Err(RuntimeError::Unsupported("Unsupported Runtime".into()))
+        } else {
+            Err(RuntimeError::Unsupported(format!(
+                "Received a spec for the wrong runtime: '{}'",
+                runtime_workload_config.runtime
+            )))
+        }
+    }
+
+    async fn get_workload_id(
+        &self,
+        _instance_name: &WorkloadInstanceName,
+    ) -> Result<String, RuntimeError> {
+        Err(RuntimeError::List(
+            "Cannot get information about workload with unsupported runtime".into(),
+        ))
+    }
+
+    async fn start_checker(
+        &self,
+        _workload_id: &String,
+        _runtime_workload_config: WorkloadSpec,
+        _update_state_tx: WorkloadStateSender,
+    ) -> Result<DummyStateChecker, RuntimeError> {
+        Ok(DummyStateChecker())
+    }
+
+    async fn delete_workload(&self, _workload_id: &String) -> Result<(), RuntimeError> {
+        Ok(())
+    }
+}

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -31,7 +31,12 @@ use common::{
 #[cfg_attr(test, mockall_double::double)]
 use crate::control_interface::control_interface_info::ControlInterfaceInfo;
 
-use crate::control_interface::ControlInterfacePath;
+#[cfg_attr(test, mockall_double::double)]
+use crate::runtime_connectors::GenericRuntimeFacade;
+use crate::{
+    control_interface::ControlInterfacePath,
+    runtime_connectors::unsupported_runtime::UnsupportedRuntime,
+};
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::workload_scheduler::scheduler::WorkloadScheduler;
@@ -529,34 +534,32 @@ impl RuntimeManager {
             None
         };
 
+        let unsupported_runtime: Box<dyn RuntimeFacade>;
+
         // [impl->swdd~agent-uses-specified-runtime~1]
         // [impl->swdd~agent-skips-unknown-runtime~2]
-        if let Some(runtime) = self.runtime_map.get(&workload_spec.runtime) {
-            // [impl->swdd~agent-executes-create-workload-operation~1]
-            let workload = runtime.create_workload(
-                reusable_workload_spec,
-                control_interface_info,
-                &self.update_state_tx,
-            );
-            // [impl->swdd~agent-stores-running-workload~1]
-            self.workloads.insert(workload_name, workload);
+        let runtime = if let Some(runtime) = self.runtime_map.get(&workload_spec.runtime) {
+            runtime
         } else {
             log::warn!(
                 "Could not find runtime '{}'. Workload '{}' not scheduled.",
                 workload_spec.runtime,
                 workload_name
             );
-
-            self.update_state_tx
-                .report_workload_execution_state(
-                    &workload_spec.instance_name,
-                    ExecutionState::starting_failed(format!(
-                        "Runtime '{}' not found.",
-                        workload_spec.runtime
-                    )),
-                )
-                .await;
-        }
+            unsupported_runtime = Box::new(GenericRuntimeFacade::new(
+                Box::new(UnsupportedRuntime(workload_spec.runtime.clone())),
+                PathBuf::new(),
+            ));
+            &unsupported_runtime
+        };
+        // [impl->swdd~agent-executes-create-workload-operation~1]
+        let workload = runtime.create_workload(
+            reusable_workload_spec,
+            control_interface_info,
+            &self.update_state_tx,
+        );
+        // [impl->swdd~agent-stores-running-workload~1]
+        self.workloads.insert(workload_name, workload);
     }
 
     async fn delete_workload(&mut self, deleted_workload: DeletedWorkload) {
@@ -656,7 +659,9 @@ mod tests {
         authorizer::MockAuthorizer, control_interface_info::MockControlInterfaceInfo,
         MockControlInterface,
     };
-    use crate::runtime_connectors::{MockRuntimeFacade, ReusableWorkloadState, RuntimeError};
+    use crate::runtime_connectors::{
+        MockGenericRuntimeFacade, MockRuntimeFacade, ReusableWorkloadState, RuntimeError,
+    };
     use crate::runtime_manager::ToReusableWorkloadSpecs;
     use crate::workload::{MockWorkload, WorkloadError};
     use crate::workload_operation::ReusableWorkloadSpec;
@@ -669,7 +674,7 @@ mod tests {
         self, generate_test_control_interface_access,
         generate_test_workload_spec_with_control_interface_access,
         generate_test_workload_spec_with_dependencies, generate_test_workload_spec_with_param,
-        AddCondition, ExecutionStateEnum, WorkloadInstanceNameBuilder, WorkloadState,
+        AddCondition, WorkloadInstanceNameBuilder, WorkloadState,
     };
     use common::test_utils::{
         self, generate_test_complete_state, generate_test_deleted_workload,
@@ -854,7 +859,19 @@ mod tests {
 
         runtime_facade_mock.expect_create_workload().never(); // workload shall not be created due to unknown runtime
 
-        let (mut server_recv, mut runtime_manager, mut wl_state_receiver) =
+        let mock_workload = MockWorkload::default();
+
+        let mut mock_generic_runtime_facade = MockGenericRuntimeFacade::default();
+        mock_generic_runtime_facade
+            .expect_create_workload()
+            .return_once(|_, _, _| mock_workload);
+
+        let runtime_facade_mock_new_context = MockGenericRuntimeFacade::new_context();
+        runtime_facade_mock_new_context
+            .expect()
+            .return_once(|_, _| mock_generic_runtime_facade);
+
+        let (_server_recv, mut runtime_manager, _wl_state_receiver) =
             RuntimeManagerBuilder::default()
                 .with_runtime(
                     RUNTIME_NAME,
@@ -865,16 +882,6 @@ mod tests {
         runtime_manager
             .handle_server_hello(added_workloads, &MockWorkloadStateStore::default())
             .await;
-
-        assert!(runtime_manager.workloads.is_empty());
-
-        server_recv.close();
-        let received_wl_state = wl_state_receiver.recv().await;
-
-        assert_eq!(
-            received_wl_state.unwrap().execution_state.state,
-            ExecutionStateEnum::Pending(objects::PendingSubstate::StartingFailed)
-        );
     }
 
     // [utest->swdd~agent-existing-workloads-finds-list~1]
@@ -981,8 +988,24 @@ mod tests {
 
         let control_interface_info_new_context = MockControlInterfaceInfo::new_context();
 
+        let mut mock_workload = MockWorkload::default();
+        mock_workload
+            .expect_update()
+            .once()
+            .returning(|_, _| Ok(()));
+
+        let mut runtime_facade_mock = MockRuntimeFacade::new();
+        runtime_facade_mock
+            .expect_create_workload()
+            .return_once(move |_, _, _| mock_workload);
+
         let (_server_recv, mut runtime_manager, _wl_state_receiver) =
-            RuntimeManagerBuilder::default().build();
+            RuntimeManagerBuilder::default()
+                .with_runtime(
+                    RUNTIME_NAME,
+                    Box::new(runtime_facade_mock) as Box<dyn RuntimeFacade>,
+                )
+                .build();
 
         control_interface_info_new_context
             .expect()
@@ -1524,8 +1547,18 @@ mod tests {
 
         let control_interface_info_new_context = MockControlInterfaceInfo::new_context();
 
+        let mut runtime_facade_mock = MockRuntimeFacade::new();
+        runtime_facade_mock
+            .expect_create_workload()
+            .returning(move |_, _, _| MockWorkload::default());
+
         let (_server_receiver, mut runtime_manager, _wl_state_receiver) =
-            RuntimeManagerBuilder::default().build();
+            RuntimeManagerBuilder::default()
+                .with_runtime(
+                    RUNTIME_NAME,
+                    Box::new(runtime_facade_mock) as Box<dyn RuntimeFacade>,
+                )
+                .build();
 
         control_interface_info_new_context
             .expect()

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -530,7 +530,7 @@ impl RuntimeManager {
         };
 
         // [impl->swdd~agent-uses-specified-runtime~1]
-        // [impl->swdd~agent-skips-unknown-runtime~1]
+        // [impl->swdd~agent-skips-unknown-runtime~2]
         if let Some(runtime) = self.runtime_map.get(&workload_spec.runtime) {
             // [impl->swdd~agent-executes-create-workload-operation~1]
             let workload = runtime.create_workload(
@@ -807,7 +807,7 @@ mod tests {
         assert!(runtime_manager.workloads.contains_key(WORKLOAD_2_NAME));
     }
 
-    // [utest->swdd~agent-skips-unknown-runtime~1]
+    // [utest->swdd~agent-skips-unknown-runtime~2]
     #[tokio::test]
     async fn utest_handle_update_workload_no_workload_with_unknown_runtime() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC

--- a/doc/docs/reference/complete-state.md
+++ b/doc/docs/reference/complete-state.md
@@ -103,7 +103,7 @@ desiredState:
 
 !!! Note
 
-    Although updating the runtime of a workload is not prohibited, in practice it is not possible. Thus, updating the state of a workload with a different runtime will yield in failure when starting the updated workload.
+    Although updating the runtime of a workload is not prohibited, in practice it is not possible. Thus, updating the state of a workload with a different runtime will yield in sending a `Pending(StartingFailed)` workload state with an unsupported runtime message and the workload shall not start.
 
 ## Object field mask
 

--- a/doc/docs/reference/complete-state.md
+++ b/doc/docs/reference/complete-state.md
@@ -101,6 +101,10 @@ desiredState:
     - have a maximal length of 63 characters<br>
     Also, agent name shall contain only regular upper and lowercase characters (a-z and A-Z), numbers and the symbols "-" and "_".
 
+!!! Note
+
+    Although updating the runtime of a workload is not prohibited, in practice it is not possible. Thus, updating the state of a workload with a different runtime will yield in failure when starting the updated workload.
+
 ## Object field mask
 
 With the object field mask only specific parts of the Ankaios state could be retrieved or updated.

--- a/tests/resources/configs/simple_with_invalid_runtime.yaml
+++ b/tests/resources/configs/simple_with_invalid_runtime.yaml
@@ -1,0 +1,9 @@
+apiVersion: v0.1
+workloads:
+  simple:
+    runtime: invalid_runtime
+    restartPolicy: NEVER
+    agent: agent_A
+    runtimeConfig: |
+      image: ghcr.io/eclipse-ankaios/tests/alpine:latest
+      commandArgs: [ "echo", "Hello Ankaios"]

--- a/tests/stests/workloads/add_update_invalid_runtime.robot
+++ b/tests/stests/workloads/add_update_invalid_runtime.robot
@@ -1,0 +1,36 @@
+# Copyright (c) 2025 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+
+*** Settings ***
+Documentation       Tests to verify that Ankaios creates and mounts workload files
+...                 assigned to workloads.
+
+Resource            ../../resources/ankaios.resource
+Resource            ../../resources/variables.resource
+
+*** Test Cases ***
+# [stest->swdd~agent-skips-unknown-runtime~1]
+Test Ankaios shall not start a workload with an invalid runtime
+    [Setup]    Run Keywords    Setup Ankaios
+    # Preconditions
+    # This test assumes that all pods and volumes in the podman have been created with this test -> clean it up first
+    Given Podman has deleted all existing pods
+    And Podman has deleted all existing volumes
+    And Ankaios server is started with config "${CONFIGS_DIR}/simple_with_invalid_runtime.yaml"
+    # Actions
+    When Ankaios agent is started with name "agent_A"
+    # Asserts
+    Then the workload "simple" shall have the execution state "Pending(StartingFailed)" on agent "agent_A" within "20" seconds
+    [Teardown]    Clean up Ankaios

--- a/tests/stests/workloads/add_update_invalid_runtime.robot
+++ b/tests/stests/workloads/add_update_invalid_runtime.robot
@@ -21,7 +21,7 @@ Resource            ../../resources/ankaios.resource
 Resource            ../../resources/variables.resource
 
 *** Test Cases ***
-# [stest->swdd~agent-skips-unknown-runtime~1]
+# [stest->swdd~agent-skips-unknown-runtime~2]
 Test Ankaios shall not start a workload with an invalid runtime
     [Setup]    Run Keywords    Setup Ankaios
     # Preconditions

--- a/tests/stests/workloads/add_update_invalid_runtime.robot
+++ b/tests/stests/workloads/add_update_invalid_runtime.robot
@@ -14,8 +14,7 @@
 
 
 *** Settings ***
-Documentation       Tests to verify that Ankaios creates and mounts workload files
-...                 assigned to workloads.
+Documentation       Tests to verify that Ankaios handles workloads with invalid runtimes correctly.
 
 Resource            ../../resources/ankaios.resource
 Resource            ../../resources/variables.resource
@@ -25,8 +24,8 @@ Resource            ../../resources/variables.resource
 Test Ankaios shall not start a workload with an invalid runtime
     [Setup]    Run Keywords    Setup Ankaios
     # Preconditions
-    # This test assumes that all pods and volumes in the podman have been created with this test -> clean it up first
-    Given Podman has deleted all existing pods
+    # This test assumes that all containers and volumes in the podman have been created with this test -> clean it up first
+    Given Podman has deleted all existing containers
     And Podman has deleted all existing volumes
     And Ankaios server is started with config "${CONFIGS_DIR}/simple_with_invalid_runtime.yaml"
     # Actions


### PR DESCRIPTION
Issues: #370

<!--  Description of the change in case no issue is mentioned -->
Workloads started with invalid runtimes are now handled properly by keeping them in `Pending(StartingFailed)` state.

# Steps taken

- [x] implementation
- [x] unit tests updated
- [x] added system test
- [x] linked requirements
- [x] updated documentation

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
