### PR TITLE
[#495] Downgrade log level when control interface folder is already missing

### DIFF
--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -11,6 +11,7 @@
 // under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
+use crate::io_utils::FileSystemError;
 
 use std::{path::PathBuf, str::FromStr};
 
@@ -380,15 +381,27 @@ impl<
             );
 
             let workload_dir = instance_name.pipes_folder_name(&run_folder);
-            filesystem_async::remove_dir_all(&workload_dir)
-                .await
-                .unwrap_or_else(|err| {
-                    log::error!(
+            match filesystem_async::remove_dir_all(&workload_dir).await {
+                Ok(_) => {
+                    log::info!(
+                        "Successfully deleted workload subfolder of workload '{}'",
+                        instance_name
+                    );
+                }
+                Err(FileSystemError::NotFoundDirectory(_)) => {
+                    log::debug!(
+                        "Workload subfolder for '{}' already missing, skipping deletion.",
+                        instance_name
+                    );
+                }
+                Err(err) => {
+                    log::warn!(
                         "Failed to delete workload subfolder after deletion of workload '{}': '{}'",
                         instance_name,
                         err
                     );
-                });
+                }
+            }
 
             update_state_tx
                 .report_workload_execution_state(&instance_name, ExecutionState::removed())

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -383,7 +383,7 @@ impl<
             let workload_dir = instance_name.pipes_folder_name(&run_folder);
             match filesystem_async::remove_dir_all(&workload_dir).await {
                 Ok(_) => {
-                    log::info!(
+                    log::trace!(
                         "Successfully deleted workload subfolder of workload '{}'",
                         instance_name
                     );


### PR DESCRIPTION
Downgrade log level when control interface folder is already missing

Issues: #495

This PR downgrades the log level from `error!` to `debug!` when the control interface folder is already missing during workload deletion. This is a non-critical condition and should not be treated as an error, as discussed in issue #495.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All builds and tests pass (`cargo build`, GitHub Actions)
- [x] Change tested manually (folder deletion simulated)
- [x] No documentation updates required
- [x] No new requirements or tracing needed
- [x] Follows Rust coding and logging guidelines
- [ ] Unit test not added as the change affects log level only; manually verified instead
