### PR TITLE
Implement automatic unsubscribe of log subscriptions

### DIFF
--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -11,41 +11,24 @@
 // under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-use std::{future::Future, pin::Pin};
-
-use api::ank_base;
-use futures_util::{stream::FuturesUnordered, StreamExt};
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
 use common::{
     commands::AgentLoadStatus,
     from_server_interface::{FromServer, FromServerReceiver},
-    objects::{CpuUsage, FreeMemory, WorkloadInstanceName, WorkloadState},
+    objects::{CpuUsage, FreeMemory, WorkloadState},
     std_extensions::{GracefulExitResult, IllegalStateResult},
     to_server_interface::{ToServerInterface, ToServerSender},
 };
-
-#[cfg(test)]
-use tests::spawn;
-#[cfg(not(test))]
-use tokio::spawn;
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::workload_state::workload_state_store::WorkloadStateStore;
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::runtime_manager::RuntimeManager;
+#[cfg_attr(test, mockall_double::double)]
+use crate::workload_log_facade::WorkloadLogFacade;
 use crate::{subscription_store::SubscriptionStore, workload_state::WorkloadStateReceiver};
-
-#[cfg(not(test))]
-use crate::runtime_connectors::log_channel::Receiver;
-#[cfg(test)]
-use tests::MockRuntimeConnectorReceiver as Receiver;
-
-#[cfg(not(test))]
-use crate::runtime_connectors::log_collector_subscription::LogCollectorSubscription;
-#[cfg(test)]
-use tests::MockLogCollectorSubscription as LogCollectorSubscription;
 
 const RESOURCE_MEASUREMENT_INTERVAL_TICK: std::time::Duration = tokio::time::Duration::from_secs(2);
 
@@ -75,6 +58,8 @@ impl ResourceMonitor {
     }
 }
 
+pub type SynchronizedSubscriptionStore = std::sync::Arc<std::sync::Mutex<SubscriptionStore>>;
+
 // [impl->swdd~agent-shall-use-interfaces-to-server~1]
 pub struct AgentManager {
     agent_name: String,
@@ -85,7 +70,7 @@ pub struct AgentManager {
     workload_state_receiver: WorkloadStateReceiver,
     workload_state_store: WorkloadStateStore,
     res_monitor: ResourceMonitor,
-    subscription_store: SubscriptionStore,
+    subscription_store: SynchronizedSubscriptionStore,
 }
 
 impl AgentManager {
@@ -215,54 +200,15 @@ impl AgentManager {
                 None
             }
             FromServer::LogsRequest(request_id, logs_request) => {
-                let (names, log_collectors): (Vec<_>, _) = self
-                    .runtime_manager
-                    .get_logs(logs_request)
-                    .await
-                    .into_iter()
-                    .unzip();
-                let (subscription, receivers) =
-                    LogCollectorSubscription::start_collecting_logs(log_collectors);
-                let receivers = names.into_iter().zip(receivers).collect::<Vec<_>>();
-                self.subscription_store
-                    .add_subscription(request_id.clone(), subscription);
-                let to_server = self.to_server.clone();
-                spawn(async move {
-                    type ContinuableResult = (WorkloadInstanceName, Receiver, Option<Vec<String>>);
-                    let mut futures = FuturesUnordered::from_iter(receivers.into_iter().map(
-                        |mut x| -> Pin<Box<dyn Future<Output = ContinuableResult> + Send>> {
-                            Box::pin(async {
-                                let n = x.1.read_log_lines().await;
-                                (x.0, x.1, n)
-                            })
-                        },
-                    ));
-                    while let Some((workload, mut receiver, log_lines)) = futures.next().await {
-                        log::debug!("Got new log lines: {:?}", log_lines);
-                        if let Some(log_lines) = log_lines {
-                            to_server
-                                .logs_response(
-                                    request_id.clone(),
-                                    ank_base::LogsResponse {
-                                        log_entries: log_lines
-                                            .into_iter()
-                                            .map(|x| ank_base::LogEntry {
-                                                workload_name: Some(workload.clone().into()),
-                                                message: x,
-                                            })
-                                            .collect(),
-                                    },
-                                )
-                                .await
-                                .unwrap();
-                            let x = async move {
-                                let n = receiver.read_log_lines().await;
-                                (workload, receiver, n)
-                            };
-                            futures.push(Box::pin(x));
-                        }
-                    }
-                });
+                WorkloadLogFacade::spawn_log_collection(
+                    request_id,
+                    logs_request,
+                    self.to_server.clone(),
+                    self.subscription_store.clone(),
+                    &self.runtime_manager,
+                )
+                .await;
+
                 Some(())
             }
             FromServer::LogsCancelRequest(request_id) => {
@@ -271,7 +217,10 @@ impl AgentManager {
                     self.agent_name,
                     request_id
                 );
-                self.subscription_store.delete_subscription(&request_id);
+                self.subscription_store
+                    .lock()
+                    .unwrap()
+                    .delete_subscription(&request_id);
                 Some(())
             }
         }
@@ -345,14 +294,9 @@ impl AgentManager {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::future::Future;
-    use std::sync::{Arc, Mutex};
-    use std::time::Duration;
-
     use super::RuntimeManager;
     use crate::agent_manager::AgentManager;
-    use crate::runtime_connectors::log_collector::MockLogCollector;
+    use crate::workload_log_facade::MockWorkloadLogFacade;
     use crate::workload_state::{
         workload_state_store::{mock_parameter_storage_new_returns, MockWorkloadStateStore},
         WorkloadStateSenderInterface,
@@ -364,14 +308,12 @@ mod tests {
         objects::{generate_test_workload_spec_with_param, ExecutionState},
         to_server_interface::ToServer,
     };
-    use lazy_static::lazy_static;
-    use mockall::mock;
-    use mockall::predicate::{self, eq};
 
-    use tokio::sync::mpsc;
-    use tokio::task::JoinHandle;
-    use tokio::time::timeout;
-    use tokio::{join, sync::mpsc::channel};
+    use mockall::predicate::{self, eq};
+    use tokio::{
+        join,
+        sync::mpsc::{channel, Sender},
+    };
 
     const BUFFER_SIZE: usize = 20;
     const AGENT_NAME: &str = "agent_x";
@@ -704,107 +646,45 @@ mod tests {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;
-        reset_spawn_mock();
-
-        let (to_manager, manager_receiver) = channel(BUFFER_SIZE);
-        let (to_server, mut to_server_receiver) = channel(BUFFER_SIZE);
-        let (_workload_state_sender, workload_state_receiver) = channel(BUFFER_SIZE);
 
         let mock_wl_state_store = MockWorkloadStateStore::default();
-
         mock_parameter_storage_new_returns(mock_wl_state_store);
 
-        let mock_log_collector_1 = MockLogCollector::new();
-        let mock_log_collector_2 = MockLogCollector::new();
+        let (to_manager, manager_receiver) = channel(BUFFER_SIZE);
+        let (to_server, _server_receiver) = channel(BUFFER_SIZE);
+        let (_workload_state_sender, workload_state_receiver) = channel(BUFFER_SIZE);
 
-        let mut mock_runtime_connector_receiver_1 = MockRuntimeConnectorReceiver::new();
-        let mut mock_runtime_connector_receiver_2 = MockRuntimeConnectorReceiver::new();
+        let workload_spec = generate_test_workload_spec_with_param(
+            AGENT_NAME.into(),
+            WORKLOAD_1_NAME.into(),
+            RUNTIME_NAME.into(),
+        );
 
-        mock_runtime_connector_receiver_1
-            .expect_read_log_lines()
-            .once()
-            .return_once(|| Some(vec!["rec1: line1".into(), "rec1: line2".into()]));
-        mock_runtime_connector_receiver_2
-            .expect_read_log_lines()
-            .once()
-            .return_once(|| Some(vec!["rec2: line1".into()]));
-        mock_runtime_connector_receiver_2
-            .expect_read_log_lines()
-            .once()
-            .return_once(|| None);
-        mock_runtime_connector_receiver_1
-            .expect_read_log_lines()
-            .once()
-            .return_once(|| Some(vec!["rec1: line3".into()]));
-        mock_runtime_connector_receiver_1
-            .expect_read_log_lines()
-            .once()
-            .return_once(|| None);
+        let mock_runtime_manager = RuntimeManager::default();
 
-        let mut mock_log_collector_subscription = MockLogCollectorSubscription::new();
-        let mock_log_collector_subscription_dropped = Arc::new(Mutex::new(false));
-        let mock_log_collector_subscription_dropped_clone =
-            mock_log_collector_subscription_dropped.clone();
-        mock_log_collector_subscription
-            .expect_drop()
-            .returning(move || {
-                *mock_log_collector_subscription_dropped_clone
-                    .lock()
-                    .unwrap() = true;
-            });
-
-        let collecting_logs_context = MockLogCollectorSubscription::start_collecting_logs_context();
-        collecting_logs_context.expect().return_once(|_| {
-            (
-                mock_log_collector_subscription,
-                vec![
-                    mock_runtime_connector_receiver_1,
-                    mock_runtime_connector_receiver_2,
-                ],
-            )
-        });
-
-        let workload_instance_name_1 = ank_base::WorkloadInstanceName {
-            workload_name: WORKLOAD_1_NAME.into(),
-            agent_name: AGENT_NAME.into(),
-            id: "1234".into(),
-        };
-
-        let workload_instance_name_2 = ank_base::WorkloadInstanceName {
-            workload_name: WORKLOAD_2_NAME.into(),
-            agent_name: AGENT_NAME.into(),
-            id: "1234".into(),
-        };
-
-        let logs_request = ank_base::LogsRequest {
-            workload_names: vec![
-                workload_instance_name_1.clone(),
-                workload_instance_name_2.clone(),
-            ],
-            follow: None,
-            tail: None,
+        let logs_request = common::commands::LogsRequest {
+            workload_names: vec![workload_spec.instance_name],
+            follow: false,
+            tail: -1,
             since: None,
             until: None,
         };
 
-        let mut mock_runtime_manager = RuntimeManager::default();
-        mock_runtime_manager
-            .expect_get_logs()
-            .with(predicate::eq(common::commands::LogsRequest::from(
-                logs_request.clone(),
-            )))
-            .return_once(|_| {
-                vec![
-                    (
-                        workload_instance_name_1.into(),
-                        Box::new(mock_log_collector_1),
-                    ),
-                    (
-                        workload_instance_name_2.into(),
-                        Box::new(mock_log_collector_2),
-                    ),
-                ]
-            });
+        let to_server_clone = to_server.clone();
+        let mock_workload_log_facade = MockWorkloadLogFacade::spawn_log_collection_context();
+        mock_workload_log_facade
+            .expect()
+            .once()
+            .with(
+                predicate::eq(REQUEST_ID.to_string()),
+                predicate::eq(logs_request.clone()),
+                predicate::function(move |to_server_sender: &Sender<ToServer>| {
+                    to_server_sender.same_channel(&to_server_clone)
+                }),
+                predicate::always(),
+                predicate::always(),
+            )
+            .return_const(());
 
         let mut agent_manager = AgentManager::new(
             AGENT_NAME.to_string(),
@@ -814,140 +694,27 @@ mod tests {
             workload_state_receiver,
         );
 
-        let handle = tokio::spawn(async move {
-            agent_manager.start().await;
-        });
-
-        to_manager
-            .logs_request(REQUEST_ID.into(), logs_request)
-            .await
-            .unwrap();
-
-        let log_responses = get_log_responses(3, &mut to_server_receiver).await.unwrap();
-
-        assert_eq!(log_responses.len(), 2);
-        assert!(log_responses.contains_key(&(REQUEST_ID.into(), WORKLOAD_1_NAME.into())));
-        assert_eq!(
-            log_responses
-                .get(&(REQUEST_ID.into(), WORKLOAD_1_NAME.into()))
-                .unwrap(),
-            &vec![
-                "rec1: line1".to_string(),
-                "rec1: line2".to_string(),
-                "rec1: line3".to_string(),
-            ]
-        );
-        assert!(log_responses.contains_key(&(REQUEST_ID.into(), WORKLOAD_2_NAME.into())));
-        assert_eq!(
-            log_responses
-                .get(&(REQUEST_ID.into(), WORKLOAD_2_NAME.into()))
-                .unwrap(),
-            &vec!["rec2: line1".to_string(),]
-        );
-
-        let log_responses = timeout(
-            Duration::from_millis(10),
-            get_log_responses(1, &mut to_server_receiver),
-        )
-        .await;
-        assert!(log_responses.is_err());
-
-        assert!(!*mock_log_collector_subscription_dropped.lock().unwrap());
-        to_manager
-            .logs_cancel_request(REQUEST_ID.into())
-            .await
-            .unwrap();
-        let log_responses = timeout(
-            Duration::from_millis(10),
-            get_log_responses(1, &mut to_server_receiver),
-        )
-        .await;
-        assert!(log_responses.is_err());
-        assert!(*mock_log_collector_subscription_dropped.lock().unwrap());
-
-        assert!(spawn_mock_task_is_finished());
-        to_manager.stop().await.unwrap();
-        tokio::time::timeout(Duration::from_millis(1000), handle)
-            .await
-            .unwrap()
-            .unwrap();
-    }
-
-    async fn get_log_responses(
-        num: usize,
-        to_server: &mut mpsc::Receiver<ToServer>,
-    ) -> Option<HashMap<(String, String), Vec<String>>> {
-        let mut result: HashMap<(String, String), Vec<String>> = HashMap::new();
-        let mut responses = 0;
-        while responses != num {
-            let candidate = to_server.recv().await?;
-            if let ToServer::LogsResponse(request_id, logs_response) = candidate {
-                responses += 1;
-                for entry in logs_response.log_entries {
-                    result
-                        .entry((
-                            request_id.clone(),
-                            entry.workload_name.unwrap().workload_name,
-                        ))
-                        .or_default()
-                        .push(entry.message);
+        assert!(to_manager
+            .logs_request(
+                REQUEST_ID.to_string(),
+                ank_base::LogsRequest {
+                    workload_names: vec![ank_base::WorkloadInstanceName {
+                        workload_name: logs_request.workload_names[0].workload_name().to_string(),
+                        agent_name: logs_request.workload_names[0].agent_name().to_string(),
+                        id: logs_request.workload_names[0].id().to_string()
+                    }],
+                    follow: Some(logs_request.follow),
+                    tail: Some(logs_request.tail),
+                    since: logs_request.since,
+                    until: logs_request.until,
                 }
-            };
-        }
-        Some(result)
-    }
+            )
+            .await
+            .is_ok());
 
-    lazy_static! {
-        static ref SPAWN_JOIN_HANDLE: Mutex<BoxedJoinHandle> = Mutex::new(None);
-    }
+        let handle = tokio::spawn(async move { agent_manager.start().await });
 
-    type BoxedJoinHandle = Option<Box<dyn TypelessJoinHandle>>;
-
-    trait TypelessJoinHandle: Send + Sync {
-        fn is_finished(&mut self) -> bool;
-    }
-
-    impl<T: Send> TypelessJoinHandle for JoinHandle<T> {
-        fn is_finished(&mut self) -> bool {
-            JoinHandle::is_finished(self)
-        }
-    }
-
-    pub fn spawn<F>(future: F)
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        let jh = tokio::spawn(future);
-        let x = Box::new(jh);
-        SPAWN_JOIN_HANDLE.lock().unwrap().replace(x);
-    }
-
-    pub fn reset_spawn_mock() {
-        SPAWN_JOIN_HANDLE.lock().unwrap().take();
-    }
-
-    pub fn spawn_mock_task_is_finished() -> bool {
-        let jh = SPAWN_JOIN_HANDLE.lock().unwrap().take();
-        match jh {
-            Some(mut jh) => jh.is_finished(),
-            None => panic!("The function spawn was not called."),
-        }
-    }
-
-    mock! {
-        pub LogCollectorSubscription {
-            pub fn start_collecting_logs(log_collectors: Vec<Box<dyn crate::runtime_connectors::log_collector::LogCollector>>) -> (Self, Vec<MockRuntimeConnectorReceiver>);
-        }
-
-        impl Drop for LogCollectorSubscription {
-            fn drop(&mut self);
-        }
-    }
-
-    mock! {
-        pub RuntimeConnectorReceiver {
-            pub async fn read_log_lines(&mut self) -> Option<Vec<String>>;
-        }
+        to_manager.stop().await.unwrap();
+        assert!(join!(handle).0.is_ok());
     }
 }

--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -199,6 +199,7 @@ impl AgentManager {
                 log::debug!("Agent '{}' received Stop from server", self.agent_name);
                 None
             }
+            // [impl->swdd~agent-handles-logs-requests-from-server~1]
             FromServer::LogsRequest(request_id, logs_request) => {
                 WorkloadLogFacade::spawn_log_collection(
                     request_id,
@@ -641,6 +642,7 @@ mod tests {
         assert!(join!(handle).0.is_ok());
     }
 
+    // [utest->swdd~agent-handles-logs-requests-from-server~1]
     #[tokio::test]
     async fn utest_agent_manager_request_logs() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -35,6 +35,7 @@ mod runtime_manager;
 mod subscription_store;
 mod workload;
 mod workload_files;
+mod workload_log_facade;
 mod workload_scheduler;
 mod workload_state;
 

--- a/agent/src/subscription_store.rs
+++ b/agent/src/subscription_store.rs
@@ -13,7 +13,6 @@
 // SPDX-License-Identifier: Apache-2.
 
 use std::{any::Any, collections::HashMap};
-
 type SubscriptionId = String;
 
 #[derive(Default)]
@@ -26,8 +25,8 @@ impl SubscriptionStore {
         self.store.insert(id, Box::new(subscription));
     }
 
-    pub fn delete_subscription(&mut self, id: &SubscriptionId) {
-        self.store.remove(id);
+    pub fn delete_subscription(&mut self, id: &SubscriptionId) -> Option<Box<dyn Any + Send>> {
+        self.store.remove(id)
     }
 }
 

--- a/agent/src/workload_log_facade.rs
+++ b/agent/src/workload_log_facade.rs
@@ -15,7 +15,7 @@
 use api::ank_base;
 use common::commands::LogsRequest;
 use common::objects::WorkloadInstanceName;
-use common::std_extensions::UnreachableResult;
+use common::std_extensions::IllegalStateResult;
 use common::to_server_interface::{ToServerInterface, ToServerSender};
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use std::{future::Future, pin::Pin};
@@ -91,7 +91,7 @@ impl WorkloadLogFacade {
                             },
                         )
                         .await
-                        .unwrap_or_unreachable();
+                        .unwrap_or_illegal_state();
 
                     let workload_log_info = async move {
                         let received_log_lines = receiver.read_log_lines().await;

--- a/agent/src/workload_log_facade.rs
+++ b/agent/src/workload_log_facade.rs
@@ -1,0 +1,335 @@
+// Copyright (c) 2025 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use api::ank_base;
+use common::commands::LogsRequest;
+use common::objects::WorkloadInstanceName;
+use common::std_extensions::UnreachableResult;
+use common::to_server_interface::{ToServerInterface, ToServerSender};
+use futures_util::{stream::FuturesUnordered, StreamExt};
+use std::{future::Future, pin::Pin};
+
+use crate::agent_manager::SynchronizedSubscriptionStore;
+
+#[cfg(not(test))]
+use crate::runtime_connectors::log_channel::Receiver;
+#[cfg(test)]
+use tests::MockRuntimeConnectorReceiver as Receiver;
+
+#[cfg(not(test))]
+use crate::runtime_connectors::log_collector_subscription::LogCollectorSubscription;
+#[cfg(test)]
+use tests::MockLogCollectorSubscription as LogCollectorSubscription;
+
+#[cfg_attr(test, mockall_double::double)]
+use crate::runtime_manager::RuntimeManager;
+
+#[cfg(test)]
+use mockall::automock;
+
+pub struct WorkloadLogFacade;
+
+#[cfg_attr(test, automock)]
+impl WorkloadLogFacade {
+    pub async fn spawn_log_collection(
+        request_id: String,
+        logs_request: LogsRequest,
+        to_server: ToServerSender,
+        synchronized_subscription_store: SynchronizedSubscriptionStore,
+        runtime_manager: &RuntimeManager,
+    ) {
+        let (names, log_collectors): (Vec<_>, _) = runtime_manager
+            .get_logs(logs_request)
+            .await
+            .into_iter()
+            .unzip();
+        let (subscription, receivers) =
+            LogCollectorSubscription::start_collecting_logs(log_collectors);
+        let receivers = names.into_iter().zip(receivers).collect::<Vec<_>>();
+        let cloned_request_id = request_id.clone();
+        let subscription_store = synchronized_subscription_store.clone();
+        let log_collection_join_handle = tokio::spawn(async move {
+            let _subscription = subscription;
+            type ContinuableResult = (WorkloadInstanceName, Receiver, Option<Vec<String>>);
+            let mut futures = FuturesUnordered::from_iter(receivers.into_iter().map(
+                |workload_log_info| -> Pin<Box<dyn Future<Output = ContinuableResult> + Send>> {
+                    let workload_instance_name = workload_log_info.0;
+                    let mut log_receiver = workload_log_info.1;
+
+                    Box::pin(async {
+                        let received_log_lines = log_receiver.read_log_lines().await;
+                        (workload_instance_name, log_receiver, received_log_lines)
+                    })
+                },
+            ));
+            while let Some((workload_instance_name, mut receiver, log_lines)) = futures.next().await
+            {
+                log::debug!("Got new log lines: {:?}", log_lines);
+                if let Some(log_lines) = log_lines {
+                    to_server
+                        .logs_response(
+                            cloned_request_id.clone(),
+                            ank_base::LogsResponse {
+                                log_entries: log_lines
+                                    .into_iter()
+                                    .map(|log_message| ank_base::LogEntry {
+                                        workload_name: Some(workload_instance_name.clone().into()),
+                                        message: log_message,
+                                    })
+                                    .collect(),
+                            },
+                        )
+                        .await
+                        .unwrap_or_unreachable();
+
+                    let workload_log_info = async move {
+                        let received_log_lines = receiver.read_log_lines().await;
+                        (workload_instance_name, receiver, received_log_lines)
+                    };
+                    futures.push(Box::pin(workload_log_info));
+                }
+            }
+
+            subscription_store
+                .lock()
+                .unwrap()
+                .delete_subscription(&cloned_request_id);
+        });
+
+        synchronized_subscription_store
+            .lock()
+            .unwrap()
+            .add_subscription(request_id, log_collection_join_handle);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::SynchronizedSubscriptionStore;
+    use crate::runtime_connectors::log_collector::MockLogCollector;
+    use crate::runtime_manager::MockRuntimeManager;
+    use crate::workload_log_facade::WorkloadLogFacade;
+    use api::ank_base;
+    use common::to_server_interface::ToServer;
+    use mockall::{mock, predicate};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+    use tokio::{sync::mpsc, sync::mpsc::channel, time::timeout};
+
+    const BUFFER_SIZE: usize = 20;
+    const AGENT_NAME: &str = "agent_x";
+    const WORKLOAD_1_NAME: &str = "workload1";
+    const WORKLOAD_2_NAME: &str = "workload2";
+    const REQUEST_ID: &str = "request_id";
+
+    async fn get_log_responses(
+        num: usize,
+        to_server: &mut mpsc::Receiver<ToServer>,
+    ) -> Option<HashMap<(String, String), Vec<String>>> {
+        let mut result: HashMap<(String, String), Vec<String>> = HashMap::new();
+        let mut responses = 0;
+        while responses != num {
+            let candidate = to_server.recv().await?;
+            if let ToServer::LogsResponse(request_id, logs_response) = candidate {
+                responses += 1;
+                for entry in logs_response.log_entries {
+                    result
+                        .entry((
+                            request_id.clone(),
+                            entry.workload_name.unwrap().workload_name,
+                        ))
+                        .or_default()
+                        .push(entry.message);
+                }
+            };
+        }
+        Some(result)
+    }
+
+    mock! {
+        pub LogCollectorSubscription {
+            pub fn start_collecting_logs(log_collectors: Vec<Box<dyn crate::runtime_connectors::log_collector::LogCollector>>) -> (Self, Vec<MockRuntimeConnectorReceiver>);
+        }
+
+        impl Drop for LogCollectorSubscription {
+            fn drop(&mut self);
+        }
+    }
+
+    mock! {
+        pub RuntimeConnectorReceiver {
+            pub async fn read_log_lines(&mut self) -> Option<Vec<String>>;
+        }
+    }
+
+    #[tokio::test]
+    async fn utest_workload_log_facade_spawn_log_collection() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
+            .get_lock_async()
+            .await;
+
+        let (to_server, mut to_server_receiver) = channel(BUFFER_SIZE);
+
+        let mock_log_collector_1 = MockLogCollector::new();
+        let mock_log_collector_2 = MockLogCollector::new();
+
+        let mut mock_runtime_connector_receiver_1 = MockRuntimeConnectorReceiver::new();
+        let mut mock_runtime_connector_receiver_2 = MockRuntimeConnectorReceiver::new();
+
+        mock_runtime_connector_receiver_1
+            .expect_read_log_lines()
+            .once()
+            .return_once(|| Some(vec!["rec1: line1".into(), "rec1: line2".into()]));
+        mock_runtime_connector_receiver_2
+            .expect_read_log_lines()
+            .once()
+            .return_once(|| Some(vec!["rec2: line1".into()]));
+        mock_runtime_connector_receiver_2
+            .expect_read_log_lines()
+            .once()
+            .return_once(|| None);
+        mock_runtime_connector_receiver_1
+            .expect_read_log_lines()
+            .once()
+            .return_once(|| Some(vec!["rec1: line3".into()]));
+        mock_runtime_connector_receiver_1
+            .expect_read_log_lines()
+            .once()
+            .return_once(|| None);
+
+        let mut mock_log_collector_subscription = MockLogCollectorSubscription::new();
+        let mock_log_collector_subscription_dropped = Arc::new(Mutex::new(false));
+        let mock_log_collector_subscription_dropped_clone =
+            mock_log_collector_subscription_dropped.clone();
+        mock_log_collector_subscription
+            .expect_drop()
+            .returning(move || {
+                *mock_log_collector_subscription_dropped_clone
+                    .lock()
+                    .unwrap() = true;
+            });
+
+        let collecting_logs_context = MockLogCollectorSubscription::start_collecting_logs_context();
+        collecting_logs_context.expect().return_once(|_| {
+            (
+                mock_log_collector_subscription,
+                vec![
+                    mock_runtime_connector_receiver_1,
+                    mock_runtime_connector_receiver_2,
+                ],
+            )
+        });
+
+        let workload_instance_name_1 = ank_base::WorkloadInstanceName {
+            workload_name: WORKLOAD_1_NAME.into(),
+            agent_name: AGENT_NAME.into(),
+            id: "1234".into(),
+        };
+
+        let workload_instance_name_2 = ank_base::WorkloadInstanceName {
+            workload_name: WORKLOAD_2_NAME.into(),
+            agent_name: AGENT_NAME.into(),
+            id: "1234".into(),
+        };
+
+        let logs_request = ank_base::LogsRequest {
+            workload_names: vec![
+                workload_instance_name_1.clone(),
+                workload_instance_name_2.clone(),
+            ],
+            follow: None,
+            tail: None,
+            since: None,
+            until: None,
+        };
+
+        let mut mock_runtime_manager = MockRuntimeManager::default();
+        mock_runtime_manager
+            .expect_get_logs()
+            .with(predicate::eq(common::commands::LogsRequest::from(
+                logs_request.clone(),
+            )))
+            .return_once(|_| {
+                vec![
+                    (
+                        workload_instance_name_1.into(),
+                        Box::new(mock_log_collector_1),
+                    ),
+                    (
+                        workload_instance_name_2.into(),
+                        Box::new(mock_log_collector_2),
+                    ),
+                ]
+            });
+
+        WorkloadLogFacade::spawn_log_collection(
+            REQUEST_ID.into(),
+            common::commands::LogsRequest::from(logs_request),
+            to_server,
+            SynchronizedSubscriptionStore::default(),
+            &mock_runtime_manager,
+        )
+        .await;
+
+        let log_responses = get_log_responses(3, &mut to_server_receiver).await.unwrap();
+
+        assert_eq!(log_responses.len(), 2);
+        assert!(log_responses.contains_key(&(REQUEST_ID.into(), WORKLOAD_1_NAME.into())));
+        assert_eq!(
+            log_responses
+                .get(&(REQUEST_ID.into(), WORKLOAD_1_NAME.into()))
+                .unwrap(),
+            &vec![
+                "rec1: line1".to_string(),
+                "rec1: line2".to_string(),
+                "rec1: line3".to_string(),
+            ]
+        );
+        assert!(log_responses.contains_key(&(REQUEST_ID.into(), WORKLOAD_2_NAME.into())));
+        assert_eq!(
+            log_responses
+                .get(&(REQUEST_ID.into(), WORKLOAD_2_NAME.into()))
+                .unwrap(),
+            &vec!["rec2: line1".to_string(),]
+        );
+
+        let log_responses = timeout(
+            Duration::from_millis(10),
+            get_log_responses(1, &mut to_server_receiver),
+        )
+        .await;
+        assert!(log_responses.is_ok());
+        assert!(log_responses.unwrap().is_none());
+
+        let log_responses = timeout(
+            Duration::from_millis(10),
+            get_log_responses(1, &mut to_server_receiver),
+        )
+        .await;
+        assert!(log_responses.is_ok());
+        assert!(log_responses.unwrap().is_none());
+
+        assert!(*mock_log_collector_subscription_dropped.lock().unwrap());
+    }
+}

--- a/agent/src/workload_log_facade.rs
+++ b/agent/src/workload_log_facade.rs
@@ -46,6 +46,7 @@ type UnorderedLogReceiverFutures =
 
 #[cfg_attr(test, automock)]
 impl WorkloadLogFacade {
+    // [impl->swdd~workload-log-facade-starts-log-collection-campaign~1]
     pub async fn spawn_log_collection(
         request_id: String,
         logs_request: LogsRequest,
@@ -68,6 +69,7 @@ impl WorkloadLogFacade {
             let _subscription = subscription;
             let futures = Self::convert_log_receivers_to_futures(receivers);
 
+            // [impl->swdd~workload-log-facade-forwards-logs-to-server~1]
             Self::consume_futures_and_forward_logs_until_stop(
                 futures,
                 cloned_request_id.clone(),
@@ -75,6 +77,7 @@ impl WorkloadLogFacade {
             )
             .await;
 
+            // [impl->swdd~workload-log-facade-automatically-unsubscribes-log-subscriptions~1]
             subscription_store
                 .lock()
                 .unwrap()
@@ -104,6 +107,7 @@ impl WorkloadLogFacade {
         ))
     }
 
+    // [impl->swdd~workload-log-facade-forwards-logs-to-server~1]
     async fn consume_futures_and_forward_logs_until_stop(
         mut log_futures: UnorderedLogReceiverFutures,
         request_id: String,
@@ -207,6 +211,8 @@ mod tests {
         }
     }
 
+    // [utest->swdd~workload-log-facade-starts-log-collection-campaign~1]
+    // [utest->swdd~workload-log-facade-forwards-logs-to-server~1]
     #[tokio::test]
     async fn utest_workload_log_facade_spawn_log_collection() {
         let _ = env_logger::builder().is_test(true).try_init();
@@ -358,6 +364,7 @@ mod tests {
         assert!(*mock_log_collector_subscription_dropped.lock().unwrap());
     }
 
+    // [utest->swdd~workload-log-facade-automatically-unsubscribes-log-subscriptions~1]
     #[tokio::test]
     async fn utest_workload_log_facade_spawn_log_collection_unsubscribe_log_subscription() {
         let _ = env_logger::builder().is_test(true).try_init();


### PR DESCRIPTION
Issues: #90

The PR includes the following changes:
- Implement automatic unsubscribe of log subscriptions when there are no more log messages to forward (simplifies client logic and API)
- Refactor huge code block of `LogsRequest` in `agent_manager.rs` into a new component `WorkloadLogFacade`
- Swdd requirements for the newly introduced `WorkloadLogFacade`

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
