### PR TITLE
Implement logs cancel request upon agent gone

### DIFF
--- a/server/src/ankaios_server.rs
+++ b/server/src/ankaios_server.rs
@@ -347,11 +347,12 @@ impl AnkaiosServer {
                     common::commands::RequestContent::LogsCancelRequest => {
                         log::debug!("Got log cancel request with ID: {}", request_id);
 
-                        self.agent_log_request_id_map
-                            .retain(|_agent_name, request_ids| {
-                                request_ids.remove(&request_id);
-                                !request_ids.is_empty()
-                            });
+                        self.agent_log_request_id_map.retain(
+                            |_agent_name, request_ids_per_agent| {
+                                request_ids_per_agent.remove(&request_id);
+                                !request_ids_per_agent.is_empty()
+                            },
+                        );
 
                         self.to_agents
                             .logs_cancel_request(request_id)


### PR DESCRIPTION
Issues: #90

When an agent notifies the server with an `AgentGone` message, for all workloads of the agent an `LogsCancelRequest` shall be sent to all other agents from the Ankaios Server. A data structure in the server tracks the mapping of the agents and request ids.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
