### PR TITLE
Adapt tutorial for getting logs

### DIFF
--- a/api/proto/control_api.proto
+++ b/api/proto/control_api.proto
@@ -52,7 +52,7 @@ message Hello {
 message FromAnkaios {
   oneof FromAnkaiosEnum {
     ank_base.Response response = 3; /// A message containing a response to a previous request.
-    ConnectionClosed connectionClosed = 5; /// A message sent by Ankaios to inform a workload that the connection to Anakios was closed.
+    ConnectionClosed connectionClosed = 5; /// A message sent by Ankaios to inform a workload that the connection to Ankaios was closed.
   }
 }
 

--- a/doc/docs/usage/quickstart.md
+++ b/doc/docs/usage/quickstart.md
@@ -6,7 +6,7 @@ installation script has been used with default options.
 
 You can start workloads in Ankaios in a number of ways.
 For example, you can define a file with the startup configuration and use systemd to start Ankaios.
-The startup configuration file contains all of the workloads and their configuration that you want to be started by Ankaios.
+The startup manifest file contains all of the workloads and their configuration that you want to be started by Ankaios.
 
 Let's modify the default config which is stored in `/etc/ankaios/state.yaml`:
 
@@ -73,6 +73,7 @@ desiredState:
         image: docker.io/nginx:latest
         commandOptions: ["-p", "8081:80"]
       configs: {}
+      files: []
   configs: {}
 workloadStates:
   agent_A:

--- a/doc/docs/usage/tutorial-fleet-management.md
+++ b/doc/docs/usage/tutorial-fleet-management.md
@@ -307,6 +307,6 @@ podman run --rm --net=host -v $PWD/$FILE:/$FILE docker.io/eclipse-mosquitto:2.0.
 
 ## Conclusion
 
-This tutorial presented a simple way to manage a fleet of vehicles using Ankaios as an embedded container and workload orchestrator. A sample fleet connector was created using some of the features of the Ankaios SDK for Python. In the near future there will also be an [Ankaios SDK for Rust](https://github.com/eclipse-ankaios/ank-sdk-rust).
+This tutorial presented a simple way to manage a fleet of vehicles using Ankaios as an embedded container and workload orchestrator. A sample fleet connector was created using some of the features of the Ankaios SDK for Python. In addition to that, there is also an [Ankaios SDK for Rust](https://github.com/eclipse-ankaios/ank-sdk-rust).
 
 If you have questions or want to to discuss a specific use case, you can contact the Ankaios maintainers via [Slack](https://join.slack.com/t/ankaios/shared_invite/zt-38857n3r5-1nXR7gSAMDtTdYjz_LBmzg) or [Github discussions](https://github.com/eclipse-ankaios/ankaios/discussions) (see also [Support](../support.md)).

--- a/doc/docs/usage/tutorial-fleet-management.md
+++ b/doc/docs/usage/tutorial-fleet-management.md
@@ -309,4 +309,4 @@ podman run --rm --net=host -v $PWD/$FILE:/$FILE docker.io/eclipse-mosquitto:2.0.
 
 This tutorial presented a simple way to manage a fleet of vehicles using Ankaios as an embedded container and workload orchestrator. A sample fleet connector was created using some of the features of the Ankaios SDK for Python. In the near future there will also be an [Ankaios SDK for Rust](https://github.com/eclipse-ankaios/ank-sdk-rust).
 
-If you have questions or want to to discuss a specific use case, you can contact the Ankaios maintainers via [Slack](https://join.slack.com/t/ankaios/shared_invite/zt-2inyhbehh-iVp3YZD09VIgybv8D1gDpQ) or [Github discussions](https://github.com/eclipse-ankaios/ankaios/discussions) (see also [Support](../support.md)).
+If you have questions or want to to discuss a specific use case, you can contact the Ankaios maintainers via [Slack](https://join.slack.com/t/ankaios/shared_invite/zt-38857n3r5-1nXR7gSAMDtTdYjz_LBmzg) or [Github discussions](https://github.com/eclipse-ankaios/ankaios/discussions) (see also [Support](../support.md)).

--- a/doc/docs/usage/tutorial-vehicle-signals.md
+++ b/doc/docs/usage/tutorial-vehicle-signals.md
@@ -86,7 +86,7 @@ workloads:
         - "--net=host"
 ```
 
-The source code for that image is available in the [Anakios repo](https://github.com/eclipse-ankaios/ankaios/tree/main/tools/tutorial_vehicle_signals).
+The source code for that image is available in the [Ankaios repository](https://github.com/eclipse-ankaios/ankaios/tree/main/tools/tutorial_vehicle_signals).
 
 Start the workload with:
 
@@ -228,16 +228,11 @@ Optionally, you can re-run the previous `ank -k get agents` command again, to ve
 ## Reading workload logs
 
 The speed-consumer workload subscribes to the vehicle speed signal and prints it to stdout.
-Use the web UI of the speed-provider to send a few vehicle speed values and watch the log messages of the speed-consumer.
-As the logs are specific for a runtime, we use Podman to read the logs:
+Use the web UI of the speed-provider to send a few vehicle speed values and watch the log messages of the speed-consumer with:
 
 ```shell
-podman logs -f $(podman ps -a | grep speed-consumer | awk '{print $1}')
+ank logs speed-consumer
 ```
-
-!!! info
-
-    If you want to see the logs of the databroker or speed-provider you need to use `sudo podman` instead of `podman` (two occurences) as those workloads run on podman as root on agent_A.
 
 Now, we want to change the existing Ankaios manifest of the speed-provider to use auto mode which sends a new speed limit value every second.
 
@@ -280,23 +275,9 @@ ank -k get state
 ```
 
 If we want to start the three workloads on startup of the Ankaios server and agents we need to create a startup manifest file.
-In the default installation this file is `/etc/ankaios/state.yaml` as we can see in the systemd until file of the Ankaios server:
+In the default server config (see `/etc/ankaios/ank-server.conf`), a startup manifest is read from `/etc/ankaios/state.yaml`.
 
-```shell
-$ systemctl cat ank-server
-# /etc/systemd/system/ank-server.service
-[Unit]
-Description=Ankaios server
-
-[Service]
-Environment="RUST_LOG=info"
-ExecStart=/usr/local/bin/ank-server --insecure --startup-config /etc/ankaios/state.yaml
-
-[Install]
-WantedBy=default.target
-```
-
-Now we create a startup manifest file containing all three workloads:
+Now we create such a startup manifest file containing all three workloads:
 
 ```yaml title="/etc/ankaios/state.yaml" hl_lines="13 14 24 25"
 apiVersion: v0.1

--- a/doc/docs/usage/tutorial-vehicle-signals.md
+++ b/doc/docs/usage/tutorial-vehicle-signals.md
@@ -256,7 +256,11 @@ We apply the changes with:
 ank -k apply speed-provider.yaml
 ```
 
-and recognize that we get a new speed value every 1 second.
+and recognize that we get a new speed value every 1 second:
+
+```shell
+ank logs --follow speed-consumer
+```
 
 ## Ankaios state
 


### PR DESCRIPTION
This PR adapts the tutorial "Sending and receiving vehicle signals" to use `ank logs` rather than `podman logs`.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
