### PR TITLE
Handle LogsRequestAccepted messages in Ank CLI

### DIFF
--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -1111,8 +1111,10 @@ Status: approved
 
 When the user invokes the Ankaios CLI to output logs for specific workloads by providing their workload names, the Ankaios CLI shall:
 * convert the provided workload names into workload instance names
-* select the log format function depending on the provided log cli arguments
 * request the logs from the Ankaios server by sending a `LogsRequest` containing the workload instance names and additional log options provided by the user
+* wait for receiving the `LogsRequestAccepted` message
+* fail with an error message if a requested workload instance name does not match any of the accepted workload instance names part of the `LogsRequestAccepted` message
+* select the log format function depending on the provided log cli arguments
 * listen to the Ankaios Server for log responses until a logs stop message or a termination signal
 
 Tags:

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -829,26 +829,6 @@ mod tests {
         assert!(result.is_err());
     }
 
-    #[tokio::test]
-    async fn utest_get_complete_state_fails_response_timeout() {
-        let mut sim = CommunicationSimulator::default();
-        sim.expect_receive_request(
-            REQUEST,
-            RequestContent::CompleteStateRequest(CompleteStateRequest {
-                field_mask: vec![FIELD_MASK.into()],
-            }),
-        );
-        let (checker, mut server_connection) = sim.create_server_connection();
-        let (_to_client, from_server) = tokio::sync::mpsc::channel(1);
-        server_connection.from_server = from_server;
-
-        let result = server_connection
-            .get_complete_state(&[FIELD_MASK.into()])
-            .await;
-        assert!(result.is_err());
-        checker.check_communication();
-    }
-
     // [utest->swdd~cli-stores-unexpected-message~1]
     #[tokio::test]
     async fn utest_get_complete_state_other_response_in_between() {

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -1751,16 +1751,10 @@ mod tests {
             .stream_logs(instance_names_set, log_args)
             .await;
 
-        assert_eq!(
+        assert!(matches!(
             result,
-            Err(ServerConnectionError::ExecutionError(format!(
-                "Received unexpected message: {:?}",
-                FromServer::Response(ank_base::Response {
-                    request_id: REQUEST.into(),
-                    response_content: Some(unexpected_message)
-                })
-            )))
-        );
+            Err(ServerConnectionError::ExecutionError(msg)) if msg.starts_with("Received unexpected message:")
+        ));
 
         checker.check_communication();
     }

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -279,14 +279,22 @@ impl ServerConnection {
     async fn get_logs_accepted_response(
         &mut self,
     ) -> Result<LogsRequestAccepted, ServerConnectionError> {
-        match tokio::time::timeout(WAIT_TIME_MS, self.from_server.recv()).await {
-            Ok(Some(FromServer::Response(ank_base::Response {
+        let response = tokio::time::timeout(WAIT_TIME_MS, self.from_server.recv())
+            .await
+            .map_err(|_| {
+                ServerConnectionError::ExecutionError(format!(
+                "Failed to get LogsRequestAccepted response in time (timeout={WAIT_TIME_MS:?})."
+            ))
+            })?;
+
+        match response {
+            Some(FromServer::Response(ank_base::Response {
                 request_id,
                 response_content:
                     Some(ank_base::response::ResponseContent::LogsRequestAccepted(
                         logs_request_accepted_response,
                     )),
-            }))) => {
+            })) => {
                 output_debug!(
                     "LogsRequest accepted of request id '{}' for the following workload instance names: {:?}",
                     request_id,
@@ -294,16 +302,13 @@ impl ServerConnection {
                 );
                 Ok(logs_request_accepted_response)
             }
-            Ok(Some(message)) => Err(ServerConnectionError::ExecutionError(format!(
+            Some(message) => Err(ServerConnectionError::ExecutionError(format!(
                 "Received unexpected message: {message:?}"
             ))),
-            Ok(None) => Err(ServerConnectionError::ExecutionError(
+            None => Err(ServerConnectionError::ExecutionError(
                 "Connection to server interrupted while waiting for LogsRequestAccepted response."
                     .to_string(),
             )),
-            Err(_) => Err(ServerConnectionError::ExecutionError(format!(
-                "Failed to get LogsRequestAccepted response in time (timeout={WAIT_TIME_MS:?})."
-            ))),
         }
     }
 

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -311,9 +311,9 @@ impl ServerConnection {
                     }
                     Some(unexpected_message) => {
                         output_debug!("Ignore received unexpected message while waiting for LogsRequestAccepted response: {unexpected_message:?}");
-                        /* The unexpected message is not added to the queue of missed messages buffer
-                        because the intend of the CLI process is to receive logs.
-                        There is no need to wait for additional messages like UpdateWorkloadState messages. */
+                        /* The unexpected message is not added to the queue of missed messages,
+                        because the current intend is to receive logs. There is no need to wait for
+                        additional messages like UpdateWorkloadState messages. */
                     },
                     None => break Err(ServerConnectionError::ExecutionError(
                         "Connection to server interrupted while waiting for LogsRequestAccepted response."

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -299,41 +299,41 @@ impl ServerConnection {
     ) -> Result<LogsRequestAccepted, ServerConnectionError> {
         loop {
             match self.from_server.recv().await {
-                    Some(FromServer::Response(ank_base::Response {
-                        request_id: incoming_request_id,
-                        response_content:
-                            Some(ank_base::response::ResponseContent::LogsRequestAccepted(
-                                logs_request_accepted_response,
-                            )),
-                        })) if request_id == incoming_request_id => {
-                            output_debug!(
-                                "LogsRequest accepted of request id '{}' for the following workload instance names: {:?}",
-                                request_id,
-                                logs_request_accepted_response.workload_names
-                            );
-                            break Ok(logs_request_accepted_response);
-                    }
-                    Some(FromServer::Response(ank_base::Response {
-                        request_id: incoming_request_id,
-                        response_content:
-                            Some(ank_base::response::ResponseContent::Error(error)),
+                Some(FromServer::Response(ank_base::Response {
+                    request_id: incoming_request_id,
+                    response_content:
+                        Some(ank_base::response::ResponseContent::LogsRequestAccepted(
+                            logs_request_accepted_response,
+                        )),
                     })) if request_id == incoming_request_id => {
-                        break Err(ServerConnectionError::ExecutionError(format!(
-                            "Server replied with error: '{}'",
-                            error.message
-                        )));
-                    }
-                    Some(unexpected_message) => {
-                        output_debug!("Ignore received unexpected message while waiting for LogsRequestAccepted response: {unexpected_message:?}");
-                        /* The unexpected message is not added to the queue of missed messages,
-                        because the current intend is to receive logs. There is no need to wait for
-                        additional messages like UpdateWorkloadState messages. */
-                    },
-                    None => break Err(ServerConnectionError::ExecutionError(
-                        "Connection to server interrupted while waiting for LogsRequestAccepted response."
-                            .to_string(),
-                    )),
+                        output_debug!(
+                            "LogsRequest accepted of request id '{}' for the following workload instance names: {:?}",
+                            request_id,
+                            logs_request_accepted_response.workload_names
+                        );
+                        break Ok(logs_request_accepted_response);
                 }
+                Some(FromServer::Response(ank_base::Response {
+                    request_id: incoming_request_id,
+                    response_content:
+                        Some(ank_base::response::ResponseContent::Error(error)),
+                })) if request_id == incoming_request_id => {
+                    break Err(ServerConnectionError::ExecutionError(format!(
+                        "Server replied with error: '{}'",
+                        error.message
+                    )));
+                }
+                Some(unexpected_message) => {
+                    output_debug!("Ignore received unexpected message while waiting for LogsRequestAccepted response: {unexpected_message:?}");
+                    /* The unexpected message is not added to the queue of missed messages,
+                    because the current intend is to receive logs. There is no need to wait for
+                    additional messages like UpdateWorkloadState messages. */
+                },
+                None => break Err(ServerConnectionError::ExecutionError(
+                    "Connection to server interrupted while waiting for LogsRequestAccepted response."
+                        .to_string(),
+                )),
+            }
         }
     }
 

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -303,7 +303,6 @@ impl ServerConnection {
                         response_content:
                             Some(ank_base::response::ResponseContent::Error(error)),
                     })) if request_id == incoming_request_id => {
-                        output_debug!("Server replied with error for LogsRequest: '{:?}'", error);
                         break Err(ServerConnectionError::ExecutionError(format!(
                             "Server replied with error: '{}'",
                             error.message


### PR DESCRIPTION
Issues: #90 

The PR implements the handling of the `LogsRequestAccepted` message in the Ank CLI. However, the `LogsCancelRequestAccepted` message is not handled, because if a user terminates the CLI or closes the terminal window, the CLI would has to wait for the default timeout listening for the cancel accepted message which would lead to unnecessary blocking of the process without any significant benefit.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
