### PR TITLE
Update fleet management tutorial for v0.6

### DIFF
--- a/doc/docs/usage/tutorial-fleet-management.md
+++ b/doc/docs/usage/tutorial-fleet-management.md
@@ -176,7 +176,7 @@ workloads:
             - "*"
     restartPolicy: NEVER
     runtimeConfig: |
-      image: ghcr.io/eclipse-ankaios/fleet-connector:0.5.4
+      image: ghcr.io/eclipse-ankaios/fleet-connector:0.6.0
       commandOptions: [ "--net=host", "-e", "VIN=1"]
 ```
 

--- a/tools/tutorial_fleet_management/fleet-connector/requirements.txt
+++ b/tools/tutorial_fleet_management/fleet-connector/requirements.txt
@@ -1,2 +1,2 @@
-ankaios-sdk == 0.5.1
+ankaios-sdk == 0.6.0
 paho-mqtt == 2.1.0


### PR DESCRIPTION
Issues: #524

This PR updates the fleet management tutorial for Ankaios v0.6.0. It refences an image `ghcr.io/eclipse-ankaios/fleet-connector:0.6.0` which does not exist yet as it requires the ank-sdk-python v0.6.0.

Nevertheless this PR updates everything related to the tutorial and needs to be merged first before the ank-sdk-python v0.6.0 is available as Ankaios is released first and then the Python SDK.

Once the new Python SDK is available the image can be build and pushed and the tutorial will work.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
