### PR TITLE
Rename log collector to log picker in agent

### DIFF
--- a/agent/src/runtime_connectors/generic_log_collector.rs
+++ b/agent/src/runtime_connectors/generic_log_collector.rs
@@ -19,7 +19,7 @@ use tokio::{
     select,
 };
 
-use super::log_collector::{GetOutputStreams, LogCollector, NextLinesResult};
+use super::log_picker::{GetOutputStreams, LogPicker, NextLinesResult};
 
 const LINE_FEED: u8 = 0x0A;
 
@@ -51,9 +51,7 @@ impl<T: GetOutputStreams> GenericLogCollector<T> {
 }
 
 #[async_trait]
-impl<T: GetOutputStreams + std::fmt::Debug + Send + 'static> LogCollector
-    for GenericLogCollector<T>
-{
+impl<T: GetOutputStreams + std::fmt::Debug + Send + 'static> LogPicker for GenericLogCollector<T> {
     async fn next_lines(&mut self) -> NextLinesResult {
         loop {
             match (&mut self.stdout, &mut self.stderr) {
@@ -167,7 +165,7 @@ pub mod test {
     use super::NextLinesResult;
     use crate::runtime_connectors::{
         generic_log_collector::{GenericLogCollector, GenericSingleLogCollector},
-        log_collector::{LogCollector, StreamTrait},
+        log_picker::{LogPicker, StreamTrait},
         podman::{podman_log_collector::PodmanLogCollector, PodmanWorkloadId},
         runtime_connector::LogRequestOptions,
     };

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -42,5 +42,5 @@ pub use state_checker::MockRuntimeStateGetter;
 
 pub mod generic_log_collector;
 pub mod log_channel;
-pub mod log_collector;
+pub mod log_picker;
 pub mod log_collector_subscription;

--- a/agent/src/runtime_connectors/podman/podman_log_collector.rs
+++ b/agent/src/runtime_connectors/podman/podman_log_collector.rs
@@ -21,7 +21,7 @@ use tokio::process::{Child, Command};
 
 use crate::runtime_connectors::runtime_connector::LogRequestOptions;
 
-use super::super::log_collector::{GetOutputStreams, StreamTrait};
+use super::super::log_picker::{GetOutputStreams, StreamTrait};
 use super::PodmanWorkloadId;
 
 #[derive(Debug)]
@@ -140,7 +140,7 @@ mod tests {
 
     use super::PodmanLogCollector;
     use crate::runtime_connectors::{
-        log_collector::GetOutputStreams, podman::PodmanWorkloadId, LogRequestOptions,
+        log_picker::GetOutputStreams, podman::PodmanWorkloadId, LogRequestOptions,
     };
 
     const WORKLOAD_ID: &str = "workload_id";

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -24,7 +24,7 @@ use common::{
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
-        log_collector::LogCollector, podman_cli::PodmanStartConfig,
+        log_picker::LogPicker, podman_cli::PodmanStartConfig,
         runtime_connector::LogRequestOptions, ReusableWorkloadState, RuntimeConnector,
         RuntimeError, RuntimeStateGetter, StateChecker,
         generic_log_collector::GenericLogCollector,
@@ -279,7 +279,7 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
         &self,
         workload_id: PodmanWorkloadId,
         options: &LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector + Send>, RuntimeError> {
+    ) -> Result<Box<dyn LogPicker + Send>, RuntimeError> {
         let x = super::podman_log_collector::PodmanLogCollector::new(&workload_id, options);
         let log_collector = GenericLogCollector::new(x);
         Ok(Box::new(log_collector))

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_log_collector.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_log_collector.rs
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use super::super::log_collector::{GetOutputStreams, StreamTrait};
+use super::super::log_picker::{GetOutputStreams, StreamTrait};
 use super::PodmanKubeWorkloadId;
 use crate::runtime_connectors::runtime_connector::LogRequestOptions;
 

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -28,7 +28,7 @@ use crate::runtime_connectors::podman_cli::PodmanCli;
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
-        generic_log_collector::GenericLogCollector, log_collector::LogCollector, podman_cli,
+        generic_log_collector::GenericLogCollector, log_picker::LogPicker, podman_cli,
         runtime_connector::LogRequestOptions, ReusableWorkloadState, RuntimeConnector,
         RuntimeError, RuntimeStateGetter, StateChecker,
     },
@@ -283,7 +283,7 @@ impl RuntimeConnector<PodmanKubeWorkloadId, GenericPollingStateChecker> for Podm
         &self,
         workload_id: PodmanKubeWorkloadId,
         options: &LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector + Send>, RuntimeError> {
+    ) -> Result<Box<dyn LogPicker + Send>, RuntimeError> {
         let x =
             super::podman_kube_log_collector::PodmanKubeLogCollector::new(&workload_id, options);
         let log_collector = GenericLogCollector::new(x);

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -23,7 +23,7 @@ use common::{
 
 use crate::{runtime_connectors::StateChecker, workload_state::WorkloadStateSender};
 
-use super::log_collector::LogCollector;
+use super::log_picker::LogPicker;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuntimeError {
@@ -141,7 +141,7 @@ where
         &self,
         workload_id: WorkloadId,
         options: &LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector + Send>, RuntimeError>;
+    ) -> Result<Box<dyn LogPicker + Send>, RuntimeError>;
 
     async fn delete_workload(&self, workload_id: &WorkloadId) -> Result<(), RuntimeError>;
 }
@@ -186,7 +186,7 @@ pub mod test {
 
     use crate::{
         runtime_connectors::{
-            log_collector::LogCollector, ReusableWorkloadState, RuntimeStateGetter, StateChecker,
+            log_picker::LogPicker, ReusableWorkloadState, RuntimeStateGetter, StateChecker,
         },
         workload_state::WorkloadStateSender,
     };
@@ -262,7 +262,7 @@ pub mod test {
         DeleteWorkload(String, Result<(), RuntimeError>),
         StartLogCollector(
             LogRequestOptions,
-            Result<Box<dyn LogCollector + Send>, RuntimeError>,
+            Result<Box<dyn LogPicker + Send>, RuntimeError>,
         ),
     }
 
@@ -456,7 +456,7 @@ pub mod test {
             &self,
             workload_id: String,
             options: &LogRequestOptions,
-        ) -> Result<Box<dyn LogCollector + Send>, RuntimeError> {
+        ) -> Result<Box<dyn LogPicker + Send>, RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::StartLogCollector(expected_options, result)
                     if expected_options == *options =>

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -34,7 +34,7 @@ use crate::control_interface::control_interface_info::ControlInterfaceInfo;
 
 use crate::{
     control_interface::ControlInterfacePath,
-    runtime_connectors::{log_collector::LogCollector, LogRequestOptions},
+    runtime_connectors::{log_picker::LogPicker, LogRequestOptions},
 };
 
 #[cfg_attr(test, mockall_double::double)]
@@ -631,10 +631,10 @@ impl RuntimeManager {
         }
     }
 
-    pub async fn get_logs(
+    pub async fn get_log_pickers(
         &self,
         log_request: LogsRequest,
-    ) -> Vec<(WorkloadInstanceName, Box<dyn LogCollector>)> {
+    ) -> Vec<(WorkloadInstanceName, Box<dyn LogPicker>)> {
         let mut res = Vec::new();
         let log_request_options: LogRequestOptions = log_request.clone().into();
         for workload in log_request.workload_names {
@@ -678,7 +678,7 @@ mod tests {
         authorizer::MockAuthorizer, control_interface_info::MockControlInterfaceInfo,
         MockControlInterface,
     };
-    use crate::runtime_connectors::log_collector::MockLogCollector;
+    use crate::runtime_connectors::log_picker::MockLogPicker;
     use crate::runtime_connectors::{
         LogRequestOptions, MockRuntimeFacade, ReusableWorkloadState, RuntimeError,
     };
@@ -2909,7 +2909,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn utest_execute_workload_operations_get_logs() {
+    async fn utest_execute_workload_operations_get_log_pickers() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;
@@ -2934,7 +2934,7 @@ mod tests {
                 until: None,
             }))
             .once()
-            .returning(|_| Ok(Box::new(MockLogCollector::new())));
+            .returning(|_| Ok(Box::new(MockLogPicker::new())));
         let mut workload_2_mock = MockWorkload::default();
         workload_2_mock
             .expect_start_collecting_logs()
@@ -2955,7 +2955,7 @@ mod tests {
             .insert(WORKLOAD_2_NAME.to_string(), workload_2_mock);
 
         let res = runtime_manager
-            .get_logs(LogsRequest {
+            .get_log_pickers(LogsRequest {
                 workload_names: vec![
                     WorkloadInstanceName::new(AGENT_NAME, WORKLOAD_1_NAME, WORKLOAD_ID),
                     WorkloadInstanceName::new(AGENT_NAME, WORKLOAD_2_NAME, WORKLOAD_ID),

--- a/agent/src/workload.rs
+++ b/agent/src/workload.rs
@@ -35,7 +35,7 @@ use crate::control_interface::control_interface_info::ControlInterfaceInfo;
 use crate::control_interface::ControlInterface;
 use crate::{
     control_interface::ControlInterfacePath,
-    runtime_connectors::{log_collector::LogCollector, LogRequestOptions},
+    runtime_connectors::{log_picker::LogPicker, LogRequestOptions},
 };
 
 use api::ank_base;
@@ -74,7 +74,7 @@ pub enum WorkloadCommand {
     Retry(Box<WorkloadInstanceName>, RetryToken),
     Create,
     Resume,
-    StartLogCollector(LogRequestOptions, oneshot::Sender<Box<dyn LogCollector>>),
+    StartLogCollector(LogRequestOptions, oneshot::Sender<Box<dyn LogPicker>>),
 }
 
 #[cfg(test)]
@@ -222,7 +222,7 @@ impl Workload {
     pub async fn start_collecting_logs(
         &self,
         log_request_options: LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector>, Box<dyn Error>> {
+    ) -> Result<Box<dyn LogPicker>, Box<dyn Error>> {
         self.channel
             .start_collecting_logs(log_request_options)
             .await
@@ -258,7 +258,7 @@ mod tests {
             authorizer::MockAuthorizer, control_interface_info::MockControlInterfaceInfo,
             ControlInterfacePath, MockControlInterface,
         },
-        runtime_connectors::{log_collector::MockLogCollector, LogRequestOptions},
+        runtime_connectors::{log_picker::MockLogPicker, LogRequestOptions},
         workload::{Workload, WorkloadCommand, WorkloadCommandSender, WorkloadError},
     };
 
@@ -731,7 +731,7 @@ mod tests {
                 panic!("Did not receive StartLogCollection command")
             };
             assert_eq!(options, LOG_REQUEST_OPTIONS);
-            result_sink.send(Box::new(MockLogCollector::new())).unwrap();
+            result_sink.send(Box::new(MockLogPicker::new())).unwrap();
         });
 
         let test_workload =

--- a/agent/src/workload/workload_command_channel.rs
+++ b/agent/src/workload/workload_command_channel.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
     control_interface::ControlInterfacePath,
-    runtime_connectors::{log_collector::LogCollector, LogRequestOptions},
+    runtime_connectors::{log_picker::LogPicker, LogRequestOptions},
     workload::WorkloadCommand,
 };
 use common::objects::{WorkloadInstanceName, WorkloadSpec};
@@ -92,7 +92,7 @@ impl WorkloadCommandSender {
     pub async fn start_collecting_logs(
         &self,
         log_request_options: LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector>, Box<dyn std::error::Error>> {
+    ) -> Result<Box<dyn LogPicker>, Box<dyn std::error::Error>> {
         let (sender, receiver) = oneshot::channel();
         self.sender
             .send(WorkloadCommand::StartLogCollector(
@@ -115,7 +115,7 @@ impl WorkloadCommandSender {
 #[cfg(test)]
 mod tests {
     use crate::{
-        runtime_connectors::{log_collector::MockLogCollector, LogRequestOptions},
+        runtime_connectors::{log_picker::MockLogPicker, LogRequestOptions},
         workload::retry_manager::MockRetryToken,
     };
 
@@ -241,7 +241,7 @@ mod tests {
 
         let jh = listen_for_start_log_collector(
             workload_command_receiver,
-            Some(MockLogCollector::new()),
+            Some(MockLogPicker::new()),
         );
 
         let res = workload_command_sender
@@ -279,7 +279,7 @@ mod tests {
 
     fn listen_for_start_log_collector(
         mut receiver: Receiver<WorkloadCommand>,
-        res: Option<MockLogCollector>,
+        res: Option<MockLogPicker>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let command = receiver.recv().await.unwrap();

--- a/agent/src/workload/workload_control_loop.rs
+++ b/agent/src/workload/workload_control_loop.rs
@@ -14,7 +14,7 @@
 
 use crate::control_interface::ControlInterfacePath;
 use crate::io_utils::FileSystemError;
-use crate::runtime_connectors::log_collector::LogCollector;
+use crate::runtime_connectors::log_picker::LogPicker;
 use crate::runtime_connectors::{LogRequestOptions, RuntimeError, StateChecker};
 use crate::workload::{ControlLoopState, WorkloadCommand};
 use crate::workload_files::WorkloadFilesBasePath;
@@ -647,7 +647,7 @@ impl WorkloadControlLoop {
     fn start_logger<WorkloadId, StChecker>(
         control_loop_state: &ControlLoopState<WorkloadId, StChecker>,
         log_request_options: &LogRequestOptions,
-    ) -> Result<Box<dyn LogCollector + Send>, RuntimeError>
+    ) -> Result<Box<dyn LogPicker + Send>, RuntimeError>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
         StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
@@ -688,7 +688,7 @@ mockall::mock! {
 mod tests {
     use super::{ControlInterfacePath, WorkloadControlLoop};
     use crate::io_utils::mock_filesystem_async;
-    use crate::runtime_connectors::log_collector::MockLogCollector;
+    use crate::runtime_connectors::log_picker::MockLogPicker;
     use crate::runtime_connectors::{LogRequestOptions, RuntimeError};
     use crate::workload::retry_manager::MockRetryToken;
     use crate::workload::workload_command_channel::WorkloadCommandSender;
@@ -2762,7 +2762,7 @@ mod tests {
                 since: None,
                 until: None,
             },
-            Ok(Box::new(MockLogCollector::new())),
+            Ok(Box::new(MockLogPicker::new())),
         )]);
 
         let control_loop_state = ControlLoopState::builder()
@@ -2951,7 +2951,7 @@ mod tests {
                 since: None,
                 until: None,
             },
-            Ok(Box::new(MockLogCollector::new())),
+            Ok(Box::new(MockLogPicker::new())),
         )]);
 
         let control_loop_state = ControlLoopState::builder()


### PR DESCRIPTION
Issues: #90

Some renames were required to have unique terms for the log collection. Additionally the log collection is now in a single place.


<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
