### PR TITLE
Improve ank logs help text

### DIFF
--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -360,10 +360,10 @@ pub struct LogsArgs {
     /// Output the workload name in front of the log line
     #[arg(short = 'n', long = "names", default_value_t = false)]
     pub output_names: bool,
-    /// Show logs after a specific TIMESTAMP
+    /// Show logs after a specific TIMESTAMP in RFC3339 format
     #[arg(short = 's', long = "since")]
     pub since: Option<String>,
-    /// Show logs before a specific TIMESTAMP
+    /// Show logs before a specific TIMESTAMP in RFC3339 format
     #[arg(short = 'u', long = "until")]
     pub until: Option<String>,
 }


### PR DESCRIPTION
Issues: #90 

The PR just adds the correct timestamp format to the ank-cli help text.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
