### PR TITLE
Fix authorizer edgecase

### DIFF
--- a/agent/src/control_interface/authorizer/rules.rs
+++ b/agent/src/control_interface/authorizer/rules.rs
@@ -69,7 +69,9 @@ impl LogRule {
                 let wildcard_pos = pattern.find(WILDCARD_SYMBOL).unwrap_or_unreachable();
                 let prefix = &pattern[..wildcard_pos];
                 let suffix = &pattern[wildcard_pos + WILDCARD_SYMBOL.len()..];
-                return workload_name.starts_with(prefix) && workload_name.ends_with(suffix);
+                return workload_name.starts_with(prefix)
+                    && workload_name.ends_with(suffix)
+                    && prefix.len() + suffix.len() <= workload_name.len();
             }
         }
         false
@@ -235,5 +237,10 @@ mod test {
         assert!(rule.matches("abef"));
         assert!(!rule.matches("abc"));
         assert!(!rule.matches("def"));
+
+        let rule = LogRule::from(vec![format!("a{}ab", WILDCARD_SYMBOL)]);
+        assert!(rule.matches("aab"));
+        assert!(rule.matches("abab"));
+        assert!(!rule.matches("ab"));
     }
 }


### PR DESCRIPTION
Issues: #90 

The case where the rule looks like `a*ab` should allow any combination of `aab` / `abab` etc. but it should not allow `ab`.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
