### PR TITLE
Fix empty agent name validation

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -87,16 +87,24 @@ fn handle_agent_config(config_path: &Option<String>, default_path: &str) -> Agen
 }
 
 // [impl->swdd~agent-naming-convention~1]
-pub fn validate_agent_name(agent_name: &String) -> Result<(), String> {
+pub fn validate_agent_name(agent_name: &str) -> Result<(), String> {
+    const EXPECTED_AGENT_NAME_FORMAT: &str = "It shall contain only regular upper and lowercase characters (a-z and A-Z), numbers and the symbols '-' and '_'.";
+    if agent_name.is_empty() {
+        return Err(format!(
+            "Empty agent name is not allowed. {}",
+            EXPECTED_AGENT_NAME_FORMAT
+        ));
+    }
+
     let re = Regex::new(STR_RE_AGENT).unwrap();
 
     if re.is_match(agent_name) {
         Ok(())
     } else {
         Err(format!(
-                    "Agent name '{}' is invalid. It shall contain only regular upper and lowercase characters (a-z and A-Z), numbers and the symbols '-' and '_'.",
-                    agent_name
-                ))
+            "Agent name '{}' is invalid. {}",
+            agent_name, EXPECTED_AGENT_NAME_FORMAT,
+        ))
     }
 }
 
@@ -279,15 +287,25 @@ mod tests {
     #[test]
     fn utest_validate_agent_name_ok() {
         let name = "test_AgEnt-name1_56";
-        assert!(super::validate_agent_name(&name.to_string()).is_ok());
+        assert!(super::validate_agent_name(name).is_ok());
     }
 
     // [utest->swdd~agent-naming-convention~1]
     #[test]
     fn utest_validate_agent_name_fail() {
-        assert!(super::validate_agent_name(&"a.b".to_string()).is_err());
-        assert!(super::validate_agent_name(&"a_b_%#".to_string()).is_err());
-        assert!(super::validate_agent_name(&"a b".to_string()).is_err());
-        assert!(super::validate_agent_name(&"".to_string()).is_err());
+        let invalid_agent_names = ["a.b", "a_b_%#", "a b"];
+        for name in invalid_agent_names {
+            let result = super::validate_agent_name(name);
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .contains(&format!("Agent name '{name}' is invalid.",)));
+        }
+
+        let result = super::validate_agent_name("");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Empty agent name is not allowed."));
     }
 }

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -945,14 +945,14 @@ Needs:
 - stest
 
 #### CLI emits an error on absence of agent name
-`swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~1`
+`swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~2`
 
 Status: approved
 
 When the agent name is not specified in a workload specification
 and the user does not provide the agent name via the optional argument `--agent`
-and the user calls the Ankaios CLI `apply` command,
-the Ankaios CLI shall create a list of filter masks from all `workloads` in the `desiredState` of all given files.
+and the user calls the Ankaios CLI `apply` command
+and the list of generated filter masks from all `workloads` in the `desiredState` of all given files do not contain a valid path to the `agent`field, the Ankaios CLI shall exit with an error.
 
 Tags:
 - CliCommands

--- a/ank/src/cli_commands/apply_manifests.rs
+++ b/ank/src/cli_commands/apply_manifests.rs
@@ -78,7 +78,7 @@ pub fn handle_agent_overwrite(
                     .map_err(|_| "Could not find workload to update.".to_owned())?;
             } else if state_obj.get(&workload_agent_mask).is_none() {
                 // No agent name specified through cli and inside workload configuration!
-                // [impl->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~1]
+                // [impl->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~2]
                 return Err(
                     "No agent name specified -> use '--agent' option to specify!".to_owned(),
                 );
@@ -450,7 +450,7 @@ mod tests {
         );
     }
 
-    // [utest->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~1]
+    // [utest->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~2]
     // [utest->swdd~cli-apply-ankaios-manifest-agent-name-overwrite~1]
     #[test]
     fn utest_handle_agent_overwrite_no_agent_name_provided_at_all() {

--- a/common/doc/swdesign/README.md
+++ b/common/doc/swdesign/README.md
@@ -372,13 +372,14 @@ Needs:
 - stest
 
 #### Agent naming convention
-`swdd~common-agent-naming-convention~2`
+`swdd~common-agent-naming-convention~3`
 
 Status: approved
 
-The Common library shall provide functionality for enforcing an agent name to:
-* contain only regular upper and lowercase characters (a-z and A-Z), numbers and the symbols "-" and "_".
-* have a minimal length of 1 character
+The Common library shall provide functionality for enforcing an agent name to contain only regular upper and lowercase characters (a-z and A-Z), numbers and the symbols "-" and "_".
+
+Comment:
+Supporting an empty agent name in a workload configuration allows for scenarios where a workload is not scheduled on an Ankaios agent.
 
 Rationale:
 A consistent naming manner assures stability in usage and compatibility with Ankaios internal structure by ensuring proper function of the filtering.

--- a/common/src/objects/workload_spec.rs
+++ b/common/src/objects/workload_spec.rs
@@ -30,7 +30,7 @@ pub type DeletedWorkloadCollection = Vec<DeletedWorkload>;
 const MAX_CHARACTERS_WORKLOAD_NAME: usize = 63;
 pub const ALLOWED_SYMBOLS: &str = "[a-zA-Z0-9_-]";
 pub const STR_RE_WORKLOAD: &str = r"^[a-zA-Z0-9_-]*$";
-pub const STR_RE_AGENT: &str = r"^[a-zA-Z0-9_-]+$";
+pub const STR_RE_AGENT: &str = r"^[a-zA-Z0-9_-]*$";
 
 // [impl->swdd~common-object-serialization~1]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -80,7 +80,7 @@ pub fn verify_workload_name_not_empty(length: usize) -> Result<(), String> {
     }
 }
 
-// [impl->swdd~common-agent-naming-convention~1]
+// [impl->swdd~common-agent-naming-convention~3]
 fn verify_agent_name_format(agent_name: &str) -> Result<(), String> {
     let re_agent = Regex::new(STR_RE_AGENT).unwrap();
     if !re_agent.is_match(agent_name) {
@@ -120,7 +120,7 @@ impl WorkloadSpec {
     }
 
     // [impl->swdd~common-workload-naming-convention~1]
-    // [impl->swdd~common-agent-naming-convention~2]
+    // [impl->swdd~common-agent-naming-convention~3]
     // [impl->swdd~common-access-rules-filter-mask-convention~1]
     pub fn verify_fields_format(&self) -> Result<(), String> {
         verify_workload_name_format(self.instance_name.workload_name())?;
@@ -605,7 +605,7 @@ mod tests {
     }
 
     // [utest->swdd~common-workload-naming-convention~1]
-    // [utest->swdd~common-agent-naming-convention~2]
+    // [utest->swdd~common-agent-naming-convention~3]
     // [utest->swdd~common-access-rules-filter-mask-convention~1]
     #[test]
     fn utest_workload_verify_fields_format_success() {
@@ -642,7 +642,7 @@ mod tests {
         );
     }
 
-    // [utest->swdd~common-agent-naming-convention~2]
+    // [utest->swdd~common-agent-naming-convention~3]
     #[test]
     fn utest_workload_verify_fields_incompatible_agent_name() {
         let spec_with_wrong_agent_name = generate_test_workload_spec_with_param(
@@ -659,21 +659,18 @@ mod tests {
                 super::ALLOWED_SYMBOLS
             ))
         );
+    }
 
+    // [utest->swdd~common-agent-naming-convention~3]
+    #[test]
+    fn utest_workload_spec_with_valid_empty_agent_name() {
         let spec_with_wrong_agent_name = generate_test_workload_spec_with_param(
             "".to_owned(),
             "workload_1".to_owned(),
             RUNTIME.to_owned(),
         );
 
-        assert_eq!(
-            spec_with_wrong_agent_name.verify_fields_format(),
-            Err(format!(
-                "Unsupported agent name. Received '{}', expected to have characters in {}",
-                spec_with_wrong_agent_name.instance_name.agent_name(),
-                super::ALLOWED_SYMBOLS
-            ))
-        );
+        assert!(spec_with_wrong_agent_name.verify_fields_format().is_ok());
     }
 
     // [utest->swdd~common-workload-naming-convention~1]

--- a/tests/resources/configs/manifest_empty_agent_name.yaml
+++ b/tests/resources/configs/manifest_empty_agent_name.yaml
@@ -1,0 +1,8 @@
+apiVersion: v0.1
+workloads:
+  workload_with_empty_agent_name:
+    runtime: podman
+    agent: ""
+    restartPolicy: NEVER
+    runtimeConfig: |
+      image: ghcr.io/eclipse-ankaios/tests/sleepy:latest

--- a/tests/resources/configs/update_state_empty_agent_name.yaml
+++ b/tests/resources/configs/update_state_empty_agent_name.yaml
@@ -1,0 +1,9 @@
+desiredState:
+  apiVersion: v0.1
+  workloads:
+    workload_with_empty_agent_name:
+      runtime: podman
+      agent: ""
+      restartPolicy: NEVER
+      runtimeConfig: |
+        image: ghcr.io/eclipse-ankaios/tests/sleepy:latest

--- a/tests/stests/manifests/apply_manifests.robot
+++ b/tests/stests/manifests/apply_manifests.robot
@@ -124,9 +124,9 @@ Test Ankaios apply workload specification defining the agent names
     And the workload "sleepy_from_manifest_no_agent_name" shall have the execution state "Running(Ok)" on agent "agent_B" within "20" seconds
     [Teardown]    Clean up Ankaios
 
-# [stest->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~1]
+# [stest->swdd~cli-apply-ankaios-manifest-error-on-agent-name-absence~2]
 Test Ankaios apply workload specification without agent name
-    [Setup]           Run Keywords    Setup Ankaios
+    [Setup]   Run Keywords    Setup Ankaios
     # Preconditions
     Given Ankaios server is started with config "${CONFIGS_DIR}/simple.yaml"
     And Ankaios agent is started with name "agent_A"
@@ -136,6 +136,33 @@ Test Ankaios apply workload specification without agent name
     # Asserts
     Then the last command shall finish with an error
     [Teardown]    Clean up Ankaios
+
+# [stest->swdd~common-agent-naming-convention~3]
+Test Ankaios apply workload specification with empty agent name
+    [Setup]   Run Keywords    Setup Ankaios
+    # Preconditions
+    Given Ankaios server is started with config "${CONFIGS_DIR}/simple.yaml"
+    And Ankaios agent is started with name "agent_A"
+    And all workloads of agent "agent_A" have an initial execution state
+    # Actions
+    When user triggers "ank apply ${CONFIGS_DIR}/manifest_empty_agent_name.yaml"
+    # Asserts
+    Then the last command shall finish with exit code "0"
+    [Teardown]    Clean up Ankaios
+
+#[stest->swdd~cli-apply-ankaios-manifest-agent-name-overwrite~1]
+# [stest->swdd~common-agent-naming-convention~3]
+Test Ankaios apply workload with empty agent name cli argument
+  [Setup]   Run Keywords    Setup Ankaios
+  # Preconditions
+  Given Ankaios server is started with config "${CONFIGS_DIR}/simple.yaml"
+  And Ankaios agent is started with name "agent_A"
+  And all workloads of agent "agent_A" have an initial execution state
+  # Actions
+  When user triggers "ank apply --agent "" ${CONFIGS_DIR}/manifest_no_agent_name.yaml"
+  # Asserts
+  Then the last command shall finish with exit code "0"
+  [Teardown]    Clean up Ankaios
 
 # [stest->swdd~cli-apply-send-update-state~1]
 Test Ankaios apply workload specifications via Ankaios Manifest files for deletion

--- a/tests/stests/workloads/update_workload_podman.robot
+++ b/tests/stests/workloads/update_workload_podman.robot
@@ -121,7 +121,7 @@ Test Ankaios Podman Update workload with lengthy workload name
 
     [Teardown]    Clean up Ankaios
 
-# [stest->swdd~common-agent-naming-convention~2]
+# [stest->swdd~common-agent-naming-convention~3]
 # [stest->swdd~server-desired-state-field-conventions~1]
 # [stest->swdd~agent-naming-convention~1]
 Test Ankaios Podman Update workload with invalid agent name
@@ -135,15 +135,34 @@ Test Ankaios Podman Update workload with invalid agent name
     # Actions
     When user triggers "ank -k get workloads"
     Then list of workloads shall be empty
-    When user triggers "ank -k set state desiredState.workloads.nginx ${CONFIGS_DIR}/update_state_invalid_names.yaml"
+    When user triggers "ank -k set state desiredState.workloads.sleepy ${CONFIGS_DIR}/update_state_invalid_names.yaml"
+    And the last command finished with an error
     And user triggers "ank -k get workloads"
     Then list of workloads shall be empty
+
+    [Teardown]    Clean up Ankaios
+
+# [stest->swdd~common-agent-naming-convention~3]
+# [stest->swdd~server-desired-state-field-conventions~1]
+# [stest->swdd~agent-naming-convention~1]
+Test Ankaios Podman Update workload support empty agent name in workload specification
+    [Setup]    Run Keywords    Setup Ankaios
+
+    # Preconditions
+    # This test assumes that all containers in the podman have been created with this test -> clean it up first
+    Given Podman has deleted all existing containers
+    And Ankaios server is started without config successfully
+    And Ankaios agent is started with name "agent_A"
+    # Actions
+    When user triggers "ank -k set state desiredState.workloads ${CONFIGS_DIR}/update_state_empty_agent_name.yaml"
+    And the last command finished with exit code "0"
 
     [Teardown]    Clean up Ankaios
 
 # [stest->swdd~update-desired-state-with-missing-version~1]
 Test Ankaios Podman Update workload with missing api version
     [Setup]    Run Keywords    Setup Ankaios
+    [Tags]    run_only
 
     # Preconditions
     # This test assumes that all containers in the podman have been created with this test -> clean it up first
@@ -153,7 +172,7 @@ Test Ankaios Podman Update workload with missing api version
     # Actions
     When user triggers "ank -k get workloads"
     Then list of workloads shall be empty
-    When user triggers "ank -k set state ${CONFIGS_DIR}/update_state_missing_version.yaml desiredState"
+    When user triggers "ank -k set state desiredState ${CONFIGS_DIR}/update_state_missing_version.yaml"
     And user triggers "ank -k get workloads"
     Then list of workloads shall be empty
 


### PR DESCRIPTION
The PR fixes the following issues:

- Empty agent name in workload spec is rejected due to sharing the same regex for validating the agent name between the agent name check in a workload spec and the check in an agent config file. The regex does not support an empty agent names leading to wrong behavior in the Ank cli and in the control interface.
- Existing stests assertions

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
