### PR TITLE
Update rust edition and rust version in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.3
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:0.10.4
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -90,7 +90,7 @@ RUN mkdir -p -m 2777 $RUSTUP_HOME \
     && mkdir -p -m 2777 $CARGO_HOME \
     && chgrp rustlang $CARGO_HOME \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-       sh -s -- -y --default-toolchain 1.86 --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl --no-modify-path \
+       sh -s -- -y --default-toolchain 1.88 --target x86_64-unknown-linux-musl --target aarch64-unknown-linux-musl --no-modify-path \
     && chmod -R ag+w $RUSTUP_HOME $CARGO_HOME
 
 VOLUME /var/lib/containers
@@ -106,7 +106,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     else \
         exit 1; \
     fi; \
-    curl -sL https://github.com/casey/just/releases/download/1.40.0/just-1.40.0-${ITEMARCH}-unknown-linux-musl.tar.gz | \
+    curl -sL https://github.com/casey/just/releases/download/1.42.4/just-1.42.4-${ITEMARCH}-unknown-linux-musl.tar.gz | \
     tar xz --directory=/usr/local/bin just \
     && echo 'source <(just --completions bash)' >> /home/${USERNAME}/.bashrc \
     && echo 'source <(just --completions zsh)' >> /home/${USERNAME}/.zshrc
@@ -123,7 +123,7 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
     tar xz --directory=/usr/local/bin grpcurl
 
 # OpenFastTrace
-RUN curl -sL https://github.com/itsallcode/openfasttrace/releases/download/3.6.0/openfasttrace-3.6.0.jar -o /usr/local/bin/openfasttrace.jar
+RUN curl -sL https://github.com/itsallcode/openfasttrace/releases/download/4.2.0/openfasttrace-4.2.0.jar -o /usr/local/bin/openfasttrace.jar
 COPY oft /usr/local/bin
 
 RUN curl -sL https://github.com/plantuml/plantuml/releases/download/v1.2024.0/plantuml.jar -o /usr/local/bin/plantuml.jar

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ank-agent"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Eclipse Ankaios agent component"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/agent/src/agent_config.rs
+++ b/agent/src/agent_config.rs
@@ -14,8 +14,8 @@
 
 use crate::cli::Arguments;
 use crate::io_utils::DEFAULT_RUN_FOLDER;
-use common::std_extensions::UnreachableOption;
 use common::DEFAULT_SERVER_ADDRESS;
+use common::std_extensions::UnreachableOption;
 use grpc::security::read_pem_file;
 
 use serde::Deserialize;
@@ -40,16 +40,16 @@ impl fmt::Display for ConversionErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConversionErrors::WrongVersion(msg) => {
-                write!(f, "Wrong version: {}", msg)
+                write!(f, "Wrong version: {msg}")
             }
             ConversionErrors::ConflictingCertificates(msg) => {
-                write!(f, "Conflicting certificates: {}", msg)
+                write!(f, "Conflicting certificates: {msg}")
             }
             ConversionErrors::InvalidAgentConfig(msg) => {
-                write!(f, "Agent Config could not have been parsed due to: {}", msg)
+                write!(f, "Agent Config could not have been parsed due to: {msg}")
             }
             ConversionErrors::InvalidCertificate(msg) => {
-                write!(f, "Certificate could not have been read due to: {}", msg)
+                write!(f, "Certificate could not have been read due to: {msg}")
             }
         }
     }
@@ -229,7 +229,7 @@ mod tests {
         #";
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", agent_config_content).unwrap();
+        write!(tmp_config_file, "{agent_config_content}").unwrap();
 
         let agent_config = AgentConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -245,14 +245,13 @@ mod tests {
         let agent_config_content = format!(
             r"#
         version = 'v1'
-        ca_pem = '''{}'''
-        ca_pem_content = '''{}'''
-        #",
-            CA_PEM_PATH, CRT_PEM_CONTENT
+        ca_pem = '''{CA_PEM_PATH}'''
+        ca_pem_content = '''{CRT_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", agent_config_content).unwrap();
+        write!(tmp_config_file, "{agent_config_content}").unwrap();
 
         let agent_config = AgentConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -296,15 +295,14 @@ mod tests {
         let agent_config_content = format!(
             r"#
         version = 'v1'
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", agent_config_content).unwrap();
+        write!(tmp_config_file, "{agent_config_content}").unwrap();
 
         let mut agent_config =
             AgentConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
@@ -345,15 +343,14 @@ mod tests {
         server_url = 'https://127.0.0.1:25551'
         run_folder = '/tmp/ankaios/'
         insecure = true
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", agent_config_content).unwrap();
+        write!(tmp_config_file, "{agent_config_content}").unwrap();
 
         let agent_config_res = AgentConfig::from_file(PathBuf::from(tmp_config_file.path()));
 

--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -618,48 +618,48 @@ mod tests {
     }
 
     // [utest->swdd~agent-sends-node-resource-availability-to-server~1]
-    // #[tokio::test]
-    // async fn utest_agent_manager_sends_available_resources() {
-    //     let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
-    //         .get_lock_async()
-    //         .await;
+    #[tokio::test]
+    async fn utest_agent_manager_sends_available_resources() {
+        let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
+            .get_lock_async()
+            .await;
 
-    //     let mock_wl_state_store = MockWorkloadStateStore::default();
-    //     mock_parameter_storage_new_returns(mock_wl_state_store);
+        let mock_wl_state_store = MockWorkloadStateStore::default();
+        mock_parameter_storage_new_returns(mock_wl_state_store);
 
-    //     let (to_manager, manager_receiver) = channel(BUFFER_SIZE);
-    //     let (to_server, mut server_receiver) = channel(BUFFER_SIZE);
-    //     let (_workload_state_sender, workload_state_receiver) = channel(BUFFER_SIZE);
-    //     let mut mock_runtime_manager = RuntimeManager::default();
-    //     mock_runtime_manager.expect_handle_update_workload().never();
-    //     mock_runtime_manager.expect_forward_response().never();
-    //     mock_runtime_manager.expect_execute_workloads().never();
-    //     mock_runtime_manager.expect_handle_server_hello().never();
-    //     mock_runtime_manager
-    //         .expect_update_workloads_on_fulfilled_dependencies()
-    //         .never();
+        let (to_manager, manager_receiver) = channel(BUFFER_SIZE);
+        let (to_server, mut server_receiver) = channel(BUFFER_SIZE);
+        let (_workload_state_sender, workload_state_receiver) = channel(BUFFER_SIZE);
+        let mut mock_runtime_manager = RuntimeManager::default();
+        mock_runtime_manager.expect_handle_update_workload().never();
+        mock_runtime_manager.expect_forward_response().never();
+        mock_runtime_manager.expect_execute_workloads().never();
+        mock_runtime_manager.expect_handle_server_hello().never();
+        mock_runtime_manager
+            .expect_update_workloads_on_fulfilled_dependencies()
+            .never();
 
-    //     let mut agent_manager = AgentManager::new(
-    //         AGENT_NAME.to_string(),
-    //         manager_receiver,
-    //         mock_runtime_manager,
-    //         to_server,
-    //         workload_state_receiver,
-    //     );
+        let mut agent_manager = AgentManager::new(
+            AGENT_NAME.to_string(),
+            manager_receiver,
+            mock_runtime_manager,
+            to_server,
+            workload_state_receiver,
+        );
 
-    //     let handle = tokio::spawn(async move { agent_manager.start().await });
+        let handle = tokio::spawn(async move { agent_manager.start().await });
 
-    //     let result = server_receiver.recv().await.unwrap();
-    //     if let ToServer::AgentLoadStatus(load_status) = result {
-    //         assert_eq!(load_status.agent_name, AGENT_NAME.to_string());
-    //         assert_ne!(load_status.cpu_usage.cpu_usage, 0);
-    //     } else {
-    //         panic!("Expected AgentLoadStatus, got something else");
-    //     }
+        let result = server_receiver.recv().await.unwrap();
+        if let ToServer::AgentLoadStatus(load_status) = result {
+            assert_eq!(load_status.agent_name, AGENT_NAME.to_string());
+            assert_ne!(load_status.cpu_usage.cpu_usage, 0);
+        } else {
+            panic!("Expected AgentLoadStatus, got something else");
+        }
 
-    //     to_manager.stop().await.unwrap();
-    //     assert!(join!(handle).0.is_ok());
-    // }
+        to_manager.stop().await.unwrap();
+        assert!(join!(handle).0.is_ok());
+    }
 
     // [utest->swdd~agent-handles-logs-requests-from-server~1]
     #[tokio::test]

--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -258,10 +258,7 @@ impl AgentManager {
                 old_execution_state.transition(new_workload_state.execution_state);
         }
 
-        log::debug!(
-            "Storing and forwarding local workload state '{:?}'.",
-            new_workload_state
-        );
+        log::debug!("Storing and forwarding local workload state '{new_workload_state:?}'.");
 
         // [impl->swdd~agent-stores-workload-states-of-its-workloads~1]
         self.workload_state_store

--- a/agent/src/control_interface/authorizer.rs
+++ b/agent/src/control_interface/authorizer.rs
@@ -105,7 +105,7 @@ impl Authorizer {
                             .iter()
                             .any(|deny_rule| deny_rule.matches(instance_name.workload_name()))
                     })
-                    .map(|instance_name| format!("denied by rule for workload '{}'", instance_name))
+                    .map(|instance_name| format!("denied by rule for workload '{instance_name}'"))
                 {
                     log::info!(
                         "Deny log request '{}' it is allowed, but also denied by '{}'",
@@ -144,9 +144,7 @@ impl Authorizer {
                 reason
             } else {
                 log::info!(
-                    "Denying mask '{}' of request '{}' as no rule matches",
-                    path_string,
-                    request_id
+                    "Denying mask '{path_string}' of request '{request_id}' as no rule matches",
                 );
                 return false;
             };
@@ -156,20 +154,13 @@ impl Authorizer {
                 reason
             } else {
                 log::debug!(
-                    "Allow mask '{}' of request '{}' as '{}' is allowed",
-                    path_string,
-                    request_id,
-                    allow_reason
+                    "Allow mask '{path_string}' of request '{request_id}' as '{allow_reason}' is allowed",
                 );
                 return true;
             };
 
             log::info!(
-                "Deny mask '{}' of request '{}', also allowed by '{}', as denied by '{}'",
-                path_string,
-                request_id,
-                allow_reason,
-                deny_reason
+                "Deny mask '{path_string}' of request '{request_id}', also allowed by '{allow_reason}', as denied by '{deny_reason}'",
             );
             false
         })
@@ -256,8 +247,8 @@ mod test {
     use std::sync::Arc;
 
     use super::{
-        path_pattern::{AllowPathPattern, DenyPathPattern},
         Authorizer, LogRule, StateRule,
+        path_pattern::{AllowPathPattern, DenyPathPattern},
     };
 
     const MATCHING_PATH: &str = "matching.path";
@@ -674,18 +665,18 @@ mod test {
             authorizer.state_allow_read,
             vec![
                 Arc::new(StateRule::create(vec!["state.allow.read.mask".into()])),
-                Arc::new(StateRule::create(
-                    vec!["state.allow.read.write.mask".into()]
-                ))
+                Arc::new(StateRule::create(vec![
+                    "state.allow.read.write.mask".into()
+                ]))
             ]
         );
         assert_eq!(
             authorizer.state_allow_write,
             vec![
                 Arc::new(StateRule::create(vec!["state.allow.write.mask".into()])),
-                Arc::new(StateRule::create(
-                    vec!["state.allow.read.write.mask".into()]
-                ))
+                Arc::new(StateRule::create(vec![
+                    "state.allow.read.write.mask".into()
+                ]))
             ]
         );
         assert_eq!(

--- a/agent/src/control_interface/fifo.rs
+++ b/agent/src/control_interface/fifo.rs
@@ -14,9 +14,9 @@
 
 use std::path::PathBuf;
 
+use crate::io_utils::FileSystemError;
 #[cfg_attr(test, mockall_double::double)]
 use crate::io_utils::filesystem;
-use crate::io_utils::FileSystemError;
 
 #[derive(Debug)]
 pub struct Fifo {
@@ -26,7 +26,7 @@ pub struct Fifo {
 impl Fifo {
     pub fn new(path: PathBuf) -> Result<Self, FileSystemError> {
         if filesystem::is_fifo(&path) {
-            log::trace!("Reusing existing fifo file '{:?}'", path);
+            log::trace!("Reusing existing fifo file '{path:?}'");
             Ok(Fifo { path })
         } else {
             match filesystem::make_fifo(&path) {
@@ -43,7 +43,7 @@ impl Fifo {
 impl Drop for Fifo {
     fn drop(&mut self) {
         if let Err(err) = filesystem::remove_fifo(&self.path) {
-            log::error!("{}", err);
+            log::error!("{err}");
         }
     }
 }

--- a/agent/src/control_interface/output_pipe.rs
+++ b/agent/src/control_interface/output_pipe.rs
@@ -82,7 +82,9 @@ impl OutputPipe {
                 Err(err) if Self::receiver_gone(&err) => {
                     if retries < CONTROL_INTERFACE_MAX_RETRIES {
                         self.file = None;
-                        log::debug!("Broken pipe - the receiver is gone. Waiting for '{}'ms before trying again.", AGENT_RECONNECT_INTERVAL_MS);
+                        log::debug!(
+                            "Broken pipe - the receiver is gone. Waiting for '{AGENT_RECONNECT_INTERVAL_MS}'ms before trying again."
+                        );
                         sleep(Duration::from_millis(AGENT_RECONNECT_INTERVAL_MS)).await;
                     } else {
                         log::warn!("Failed to write to output pipe after multiple attempts");
@@ -91,7 +93,7 @@ impl OutputPipe {
                     retries += 1;
                 }
                 Err(err) => {
-                    log::warn!("Writing failed with error: {:?}", err);
+                    log::warn!("Writing failed with error: {err:?}");
                     return Err(OutputPipeError::Io(err));
                 }
             }
@@ -298,8 +300,7 @@ mod tests {
                     // We should exit here at some point, as the writing should fail after a while
                     assert!(
                         i >= 1024,
-                        "Writing timed out before we were able to write at least 64k. Iteration: {}",
-                        i
+                        "Writing timed out before we were able to write at least 64k. Iteration: {i}"
                     );
                     return;
                 }

--- a/agent/src/io_utils/dir_utils.rs
+++ b/agent/src/io_utils/dir_utils.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 use crate::io_utils::FileSystemError;
 #[cfg_attr(test, mockall_double::double)]
-use crate::io_utils::{filesystem, Directory};
+use crate::io_utils::{Directory, filesystem};
 
 use super::DEFAULT_RUN_FOLDER;
 const RUNFOLDER_SUFFIX: &str = "_io";
@@ -27,7 +27,7 @@ pub fn prepare_agent_run_directory(
     agent_name: &str,
 ) -> Result<Directory, FileSystemError> {
     let base_path = Path::new(run_folder);
-    let agent_run_folder = base_path.join(format!("{}{}", agent_name, RUNFOLDER_SUFFIX));
+    let agent_run_folder = base_path.join(format!("{agent_name}{RUNFOLDER_SUFFIX}"));
 
     // If the default base dir is used, we need to take care of its creation
     if !filesystem::exists(base_path) {
@@ -43,7 +43,6 @@ pub fn prepare_agent_run_directory(
     Directory::new(agent_run_folder)
 }
 
-
 //////////////////////////////////////////////////////////////////////////////
 //                 ########  #######    #########  #########                //
 //                    ##     ##        ##             ##                    //
@@ -54,7 +53,7 @@ pub fn prepare_agent_run_directory(
 
 #[cfg(test)]
 mod tests {
-    use super::{FileSystemError, Path, DEFAULT_RUN_FOLDER};
+    use super::{DEFAULT_RUN_FOLDER, FileSystemError, Path};
     use crate::io_utils::generate_test_directory_mock;
     use crate::io_utils::mock_filesystem;
     use crate::io_utils::prepare_agent_run_directory;

--- a/agent/src/io_utils/directory.rs
+++ b/agent/src/io_utils/directory.rs
@@ -26,7 +26,7 @@ pub struct Directory {
 impl Directory {
     pub fn new(path: PathBuf) -> Result<Self, FileSystemError> {
         if path.exists() {
-            log::trace!("Reusing existing directory '{:?}'", path);
+            log::trace!("Reusing existing directory '{path:?}'");
             return Ok(Self { path });
         }
         match filesystem::make_dir(&path) {
@@ -103,8 +103,8 @@ mod tests {
 
     use super::Directory;
 
-    use crate::io_utils::mock_filesystem;
     use crate::io_utils::FileSystemError;
+    use crate::io_utils::mock_filesystem;
 
     use mockall::predicate;
 

--- a/agent/src/runtime_connectors/cli_command.rs
+++ b/agent/src/runtime_connectors/cli_command.rs
@@ -67,15 +67,15 @@ impl<'a> CliCommand<'a> {
                 .ok_or_else(|| "Could not access commands stdin".to_string())?
                 .write_all(stdin)
                 .await
-                .map_err(|err| format!("Could write stdin data to command: '{}'", err))?;
+                .map_err(|err| format!("Could write stdin data to command: '{err}'"))?;
         }
         let result = child.wait_with_output().await.unwrap();
         if result.status.success() {
             String::from_utf8(result.stdout)
-                .map_err(|err| format!("Could not decode command's output as UTF8: '{}'", err))
+                .map_err(|err| format!("Could not decode command's output as UTF8: '{err}'"))
         } else {
             let stderr = String::from_utf8(result.stderr).unwrap_or_else(|err| {
-                format!("Could not decode command's stderr as UTF8: '{}'", err)
+                format!("Could not decode command's stderr as UTF8: '{err}'")
             });
 
             let args_with_quotes = self.get_quoted_args(); // quoted args for easy debugging of the user
@@ -92,7 +92,7 @@ impl<'a> CliCommand<'a> {
     fn get_quoted_args(&self) -> String {
         self.args
             .iter()
-            .map(|arg| format!("\"{}\"", arg))
+            .map(|arg| format!("\"{arg}\""))
             .collect::<Vec<String>>()
             .join(" ")
     }

--- a/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
+++ b/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
@@ -57,7 +57,7 @@ impl<T: GetOutputStreams + std::fmt::Debug + Send + 'static> LogFetcher for Gene
     async fn next_lines(&mut self) -> NextLinesResult {
         loop {
             match (&mut self.stdout, &mut self.stderr) {
-                (Some(ref mut stdout), Some(ref mut stderr)) => {
+                (Some(stdout), Some(stderr)) => {
                     select! {
                         lines = stdout.next_lines() => {
                             if let Some(lines) = lines {
@@ -75,14 +75,14 @@ impl<T: GetOutputStreams + std::fmt::Debug + Send + 'static> LogFetcher for Gene
                         }
                     }
                 }
-                (Some(ref mut stdout), None) => {
+                (Some(stdout), None) => {
                     if let Some(lines) = stdout.next_lines().await {
                         return NextLinesResult::Stdout(lines);
                     } else {
                         return NextLinesResult::EoF;
                     }
                 }
-                (None, Some(ref mut stderr)) => {
+                (None, Some(stderr)) => {
                     if let Some(lines) = stderr.next_lines().await {
                         return NextLinesResult::Stderr(lines);
                     } else {
@@ -168,7 +168,7 @@ pub mod test {
     use crate::runtime_connectors::{
         generic_log_fetcher::{GenericLogFetcher, GenericSingleLogFetcher},
         log_fetcher::{LogFetcher, StreamTrait},
-        podman::{podman_log_fetcher::PodmanLogFetcher, PodmanWorkloadId},
+        podman::{PodmanWorkloadId, podman_log_fetcher::PodmanLogFetcher},
         runtime_connector::LogRequestOptions,
     };
 

--- a/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
+++ b/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
@@ -116,7 +116,7 @@ impl<T: AsyncRead + std::fmt::Debug + std::marker::Unpin> GenericSingleLogFetche
                 }
             }
             Err(err) => {
-                log::warn!("Failed to read log lines: {:?}", err);
+                log::warn!("Failed to read log lines: {err:?}");
                 return None;
             }
             _ => {}
@@ -197,10 +197,7 @@ pub mod test {
         }
 
         fn error() -> Self {
-            Self::Error(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "".to_string(),
-            ))
+            Self::Error(std::io::Error::other("".to_string()))
         }
     }
 

--- a/agent/src/runtime_connectors/podman/podman_log_fetcher.rs
+++ b/agent/src/runtime_connectors/podman/podman_log_fetcher.rs
@@ -65,7 +65,7 @@ impl PodmanLogFetcher {
         let cmd = match cmd {
             Ok(cmd) => Some(cmd),
             Err(err) => {
-                log::warn!("Can not collect logs for '{}': '{}'", workload_id, err);
+                log::warn!("Can not collect logs for '{workload_id}': '{err}'");
                 None
             }
         };
@@ -94,7 +94,7 @@ impl Drop for PodmanLogFetcher {
     fn drop(&mut self) {
         if let Some(child) = &mut self.child {
             if let Err(err) = child.start_kill() {
-                log::warn!("Could not stop log collection: '{}'", err);
+                log::warn!("Could not stop log collection: '{err}'");
             }
         }
     }
@@ -142,7 +142,7 @@ mod tests {
 
     use super::PodmanLogFetcher;
     use crate::runtime_connectors::{
-        log_fetcher::GetOutputStreams, podman::PodmanWorkloadId, LogRequestOptions,
+        LogRequestOptions, log_fetcher::GetOutputStreams, podman::PodmanWorkloadId,
     };
 
     const WORKLOAD_ID: &str = "workload_id";

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -24,9 +24,9 @@ use common::{
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
+        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter, StateChecker,
         generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
-        podman_cli::PodmanStartConfig, runtime_connector::LogRequestOptions, ReusableWorkloadState,
-        RuntimeConnector, RuntimeError, RuntimeStateGetter, StateChecker,
+        podman_cli::PodmanStartConfig, runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
 };
@@ -118,9 +118,8 @@ impl PodmanRuntime {
                 )),
                 Ok(None) => {
                     return Err(RuntimeError::List(format!(
-                        "Could not get execution state for workload '{}'",
-                        instance_name
-                    )))
+                        "Could not get execution state for workload '{instance_name}'"
+                    )));
                 }
                 Err(err) => return Err(RuntimeError::List(err)),
             }
@@ -214,10 +213,9 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
                     .await
                 {
                     Ok(()) => log::debug!("The broken container has been deleted successfully"),
-                    Err(e) => log::warn!(
-                        "Failed container cleanup after failed create. Error: '{}'",
-                        e
-                    ),
+                    Err(e) => {
+                        log::warn!("Failed container cleanup after failed create. Error: '{e}'")
+                    }
                 }
 
                 // No matter if we have deleted the broken container or not, we have to report that the "workload create" failed.
@@ -237,13 +235,10 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
 
         if 1 == res.len() {
             let id = res.first().unwrap_or_unreachable();
-            log::debug!("Found an id for workload '{}': '{}'", instance_name, id);
+            log::debug!("Found an id for workload '{instance_name}': '{id}'");
             Ok(PodmanWorkloadId { id: id.to_string() })
         } else {
-            log::warn!(
-                "get_workload_id returned unexpected number of workloads {:?}",
-                res
-            );
+            log::warn!("get_workload_id returned unexpected number of workloads {res:?}");
             Err(RuntimeError::List(
                 "Unexpected number of workloads".to_string(),
             ))
@@ -309,13 +304,13 @@ mod tests {
     use std::str::FromStr;
 
     use common::objects::{
-        generate_test_workload_spec_with_param, AgentName, ExecutionState, WorkloadInstanceName,
+        AgentName, ExecutionState, WorkloadInstanceName, generate_test_workload_spec_with_param,
     };
     use mockall::Sequence;
 
     use super::PodmanCli;
     use super::PodmanRuntime;
-    use super::{PodmanStateGetter, PodmanWorkloadId, PODMAN_RUNTIME_NAME};
+    use super::{PODMAN_RUNTIME_NAME, PodmanStateGetter, PodmanWorkloadId};
     use crate::runtime_connectors::{RuntimeConnector, RuntimeError, RuntimeStateGetter};
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
 

--- a/agent/src/runtime_connectors/podman_cli.rs
+++ b/agent/src/runtime_connectors/podman_cli.rs
@@ -72,8 +72,7 @@ impl From<PodmanContainerInfo> for ContainerState {
             "unknown" => ContainerState::Unknown,
             state => {
                 log::trace!(
-                    "Mapping the container state '{}' to the container state 'Unknown'",
-                    state
+                    "Mapping the container state '{state}' to the container state 'Unknown'"
                 );
                 ContainerState::Unknown
             }
@@ -99,8 +98,7 @@ impl From<PodmanContainerInfo> for ExecutionState {
             "unknown" => ExecutionState::unknown(value.state),
             state => {
                 log::trace!(
-                    "Mapping the container state '{}' to the execution state 'ExecUnknown'",
-                    state
+                    "Mapping the container state '{state}' to the execution state 'ExecUnknown'"
                 );
                 ExecutionState::unknown(state)
             }
@@ -256,7 +254,7 @@ impl PodmanCli {
     }
 
     pub async fn list_workload_ids_by_label(key: &str, value: &str) -> Result<Vec<String>, String> {
-        log::debug!("Listing workload ids for: {}='{}'", key, value,);
+        log::debug!("Listing workload ids for: {key}='{value}'",);
         let output = CliCommand::new(PODMAN_CMD)
             .args(&[
                 "ps",
@@ -269,7 +267,7 @@ impl PodmanCli {
             .await?;
 
         let res: Vec<PodmanContainerInfo> = serde_json::from_str(&output)
-            .map_err(|err| format!("Could not parse podman output: '{}'", err))?;
+            .map_err(|err| format!("Could not parse podman output: '{err}'"))?;
 
         Ok(res.into_iter().map(|x| x.id).collect())
     }
@@ -278,7 +276,7 @@ impl PodmanCli {
         key: &str,
         value: &str,
     ) -> Result<Vec<String>, String> {
-        log::trace!("Listing workload names for: '{}'='{}'", key, value,);
+        log::trace!("Listing workload names for: '{key}'='{value}'",);
         let output = CliCommand::new(PODMAN_CMD)
             .args(&[
                 "ps",
@@ -291,7 +289,7 @@ impl PodmanCli {
             .await?;
 
         let res: Vec<PodmanContainerInfo> = serde_json::from_str(&output)
-            .map_err(|err| format!("Could not parse podman output: '{}'", err))?;
+            .map_err(|err| format!("Could not parse podman output: '{err}'"))?;
 
         let mut names: Vec<String> = Vec::new();
         for mut podman_info in res {
@@ -365,7 +363,7 @@ impl PodmanCli {
 
         args.append(&mut run_config.command_args);
 
-        log::debug!("The args are: '{:?}'", args);
+        log::debug!("The args are: '{args:?}'");
         let id = CliCommand::new(PODMAN_CMD)
             .args(&args.iter().map(|x| &**x).collect::<Vec<&str>>())
             .exec()
@@ -426,7 +424,7 @@ impl PodmanCli {
             .iter()
             .flat_map(|key| {
                 all_pod_states.get(key).cloned().unwrap_or_else(|| {
-                    log::warn!("The pod '{}' is missing.", key);
+                    log::warn!("The pod '{key}' is missing.");
                     vec![ContainerState::Unknown]
                 })
             })
@@ -439,8 +437,7 @@ impl PodmanCli {
             .exec()
             .await?;
 
-        serde_json::from_str(&output)
-            .map_err(|err| format!("Could not parse podman output:{}", err))
+        serde_json::from_str(&output).map_err(|err| format!("Could not parse podman output:{err}"))
     }
 
     pub async fn list_volumes_by_name(name: &str) -> Result<Vec<String>, String> {
@@ -482,7 +479,7 @@ impl PodmanCli {
             .await?;
 
         let res: Vec<Volume> = serde_json::from_str(&result)
-            .map_err(|err| format!("Could not decoded volume information as JSON: {}", err))?;
+            .map_err(|err| format!("Could not decoded volume information as JSON: {err}"))?;
         let res = base64::engine::general_purpose::STANDARD_NO_PAD
             .decode(
                 &res.first()
@@ -490,9 +487,9 @@ impl PodmanCli {
                     .labels
                     .data,
             )
-            .map_err(|err| format!("Could not base64 decoded volume's data label: {}", err))?;
+            .map_err(|err| format!("Could not base64 decoded volume's data label: {err}"))?;
         let res = String::from_utf8(res)
-            .map_err(|err| format!("Could not decode data stored in volume: {}", err))?;
+            .map_err(|err| format!("Could not decode data stored in volume: {err}"))?;
 
         Ok(res)
     }
@@ -1830,10 +1827,12 @@ mod tests {
                 .to_json())),
         );
 
-        assert!(PodmanCli::list_states_from_pods(&[])
-            .await
-            .unwrap()
-            .is_empty());
+        assert!(
+            PodmanCli::list_states_from_pods(&[])
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     // [utest->swdd~podmancli-container-state-cache-all-containers~1]

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime_config.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime_config.rs
@@ -41,8 +41,7 @@ impl TryFrom<&WorkloadSpec> for PodmanKubeRuntimeConfig {
         // [impl->swdd~podman-kube-rejects-workload-files~1]
         if !workload_spec.files.is_empty() {
             return Err(format!(
-                "Workload files are not supported for runtime {}. Use ConfigMaps instead.",
-                PODMAN_KUBE_RUNTIME_NAME
+                "Workload files are not supported for runtime {PODMAN_KUBE_RUNTIME_NAME}. Use ConfigMaps instead."
             ));
         }
 
@@ -68,7 +67,7 @@ mod tests {
         generate_test_workload_spec_with_rendered_files,
     };
 
-    use super::{PodmanKubeRuntimeConfig, PODMAN_KUBE_RUNTIME_NAME};
+    use super::{PODMAN_KUBE_RUNTIME_NAME, PodmanKubeRuntimeConfig};
 
     const DIFFERENT_RUNTIME_NAME: &str = "different-runtime-name";
     const AGENT_NAME: &str = "agent_x";
@@ -118,7 +117,7 @@ mod tests {
             PODMAN_KUBE_RUNTIME_NAME.to_string(),
         );
 
-        workload_spec.runtime_config = format!("manifest: {}", MANIFEST_CONTENT);
+        workload_spec.runtime_config = format!("manifest: {MANIFEST_CONTENT}");
 
         assert!(
             PodmanKubeRuntimeConfig::try_from(&workload_spec)

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -48,19 +48,19 @@ impl Display for RuntimeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RuntimeError::Create(msg) => {
-                write!(f, "{}", msg)
+                write!(f, "{msg}")
             }
             RuntimeError::Delete(msg) => {
-                write!(f, "{}", msg)
+                write!(f, "{msg}")
             }
             RuntimeError::List(msg) => {
-                write!(f, "{}", msg)
+                write!(f, "{msg}")
             }
             RuntimeError::CollectLog(msg) => {
-                write!(f, "{}", msg)
+                write!(f, "{msg}")
             }
             RuntimeError::Unsupported(msg) => {
-                write!(f, "{}", msg)
+                write!(f, "{msg}")
             }
         }
     }
@@ -187,7 +187,7 @@ pub mod test {
 
     use crate::{
         runtime_connectors::{
-            log_fetcher::LogFetcher, ReusableWorkloadState, RuntimeStateGetter, StateChecker,
+            ReusableWorkloadState, RuntimeStateGetter, StateChecker, log_fetcher::LogFetcher,
         },
         workload_state::WorkloadStateSender,
     };
@@ -334,8 +334,7 @@ pub mod test {
 
             assert!(
                 call_checker.expected_calls.is_empty(),
-                "Not all expected calls were done: {:?}",
-                call_checker
+                "Not all expected calls were done: {call_checker:?}"
             );
             assert!(
                 0 == call_checker.unexpected_call_count,
@@ -378,7 +377,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected get_reusable_running_workloads call. Expected: '{expected_call:?}'\n\nGot: {agent_name:?}");
+                    panic!(
+                        "Unexpected get_reusable_running_workloads call. Expected: '{expected_call:?}'\n\nGot: {agent_name:?}"
+                    );
                 }
             }
         }
@@ -406,7 +407,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected create_workload call. Expected: '{expected_call:?}'\n\nGot: {runtime_workload_config:?}, {control_interface_path:?}");
+                    panic!(
+                        "Unexpected create_workload call. Expected: '{expected_call:?}'\n\nGot: {runtime_workload_config:?}, {control_interface_path:?}"
+                    );
                 }
             }
         }
@@ -423,7 +426,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected get_workload_id call. Expected: '{expected_call:?}' \n\nGot: {instance_name:?}");
+                    panic!(
+                        "Unexpected get_workload_id call. Expected: '{expected_call:?}' \n\nGot: {instance_name:?}"
+                    );
                 }
             }
         }
@@ -448,7 +453,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected start_checker call. Expected: '{expected_call:?}' \n\nGot: {workload_id:?}, {runtime_workload_config:?}, {update_state_tx:?}");
+                    panic!(
+                        "Unexpected start_checker call. Expected: '{expected_call:?}' \n\nGot: {workload_id:?}, {runtime_workload_config:?}, {update_state_tx:?}"
+                    );
                 }
             }
         }
@@ -466,7 +473,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected get_logs call. Expected: '{expected_call:?}'\n\nGot: {workload_id:?}, {options:?}");
+                    panic!(
+                        "Unexpected get_logs call. Expected: '{expected_call:?}'\n\nGot: {workload_id:?}, {options:?}"
+                    );
                 }
             }
         }
@@ -480,7 +489,9 @@ pub mod test {
                 }
                 expected_call => {
                     self.unexpected_call();
-                    panic!("Unexpected delete_workload call. Expected: '{expected_call:?}'\n\nGot: {workload_id:?}");
+                    panic!(
+                        "Unexpected delete_workload call. Expected: '{expected_call:?}'\n\nGot: {workload_id:?}"
+                    );
                 }
             }
         }

--- a/agent/src/workload.rs
+++ b/agent/src/workload.rs
@@ -30,12 +30,12 @@ pub use workload_control_loop::MockWorkloadControlLoop;
 use std::{error::Error, fmt::Display};
 
 #[cfg_attr(test, mockall_double::double)]
-use crate::control_interface::control_interface_info::ControlInterfaceInfo;
-#[cfg_attr(test, mockall_double::double)]
 use crate::control_interface::ControlInterface;
+#[cfg_attr(test, mockall_double::double)]
+use crate::control_interface::control_interface_info::ControlInterfaceInfo;
 use crate::{
     control_interface::ControlInterfacePath,
-    runtime_connectors::{log_fetcher::LogFetcher, LogRequestOptions},
+    runtime_connectors::{LogRequestOptions, log_fetcher::LogFetcher},
 };
 
 use api::ank_base;
@@ -58,10 +58,10 @@ impl Display for WorkloadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             WorkloadError::Communication(msg) => {
-                write!(f, "Could not send command to workload task: '{}'", msg)
+                write!(f, "Could not send command to workload task: '{msg}'")
             }
             WorkloadError::CompleteState(msg) => {
-                write!(f, "Could not forward complete state '{}'", msg)
+                write!(f, "Could not forward complete state '{msg}'")
             }
         }
     }
@@ -139,7 +139,7 @@ impl Workload {
             ) {
                 Ok(control_interface) => Some(control_interface),
                 Err(err) => {
-                    log::warn!("Could not exchange control interface. Error: '{}'", err);
+                    log::warn!("Could not exchange control interface. Error: '{err}'");
                     None
                 }
             }
@@ -243,12 +243,12 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use super::ank_base::{self, response::ResponseContent, Response};
+    use super::ank_base::{self, Response, response::ResponseContent};
     use common::{
         from_server_interface::FromServer,
         objects::{
-            generate_test_workload_spec_with_control_interface_access,
-            generate_test_workload_spec_with_param, CompleteState,
+            CompleteState, generate_test_workload_spec_with_control_interface_access,
+            generate_test_workload_spec_with_param,
         },
         test_utils::generate_test_complete_state,
     };
@@ -256,10 +256,10 @@ mod tests {
 
     use crate::{
         control_interface::{
-            authorizer::MockAuthorizer, control_interface_info::MockControlInterfaceInfo,
-            ControlInterfacePath, MockControlInterface,
+            ControlInterfacePath, MockControlInterface, authorizer::MockAuthorizer,
+            control_interface_info::MockControlInterfaceInfo,
         },
-        runtime_connectors::{log_fetcher::MockLogFetcher, LogRequestOptions},
+        runtime_connectors::{LogRequestOptions, log_fetcher::MockLogFetcher},
         workload::{Workload, WorkloadCommand, WorkloadCommandSender, WorkloadError},
     };
 
@@ -324,8 +324,10 @@ mod tests {
             workload_command_sender.clone(),
             None,
         );
-        assert!(test_workload_with_control_interface
-            .is_control_interface_changed(&Some(MockControlInterfaceInfo::default())));
+        assert!(
+            test_workload_with_control_interface
+                .is_control_interface_changed(&Some(MockControlInterfaceInfo::default()))
+        );
     }
 
     // [utest->swdd~agent-compares-control-interface-metadata~2]
@@ -371,8 +373,10 @@ mod tests {
             Some(MockControlInterface::default()),
         );
 
-        assert!(test_workload_with_control_interface
-            .is_control_interface_changed(&Some(control_interface_info_mock)));
+        assert!(
+            test_workload_with_control_interface
+                .is_control_interface_changed(&Some(control_interface_info_mock))
+        );
     }
 
     // [utest->swdd~agent-compares-control-interface-metadata~2]
@@ -392,8 +396,10 @@ mod tests {
             Some(MockControlInterface::default()),
         );
 
-        assert!(!test_workload_with_control_interface
-            .is_control_interface_changed(&Some(control_interface_info_mock)));
+        assert!(
+            !test_workload_with_control_interface
+                .is_control_interface_changed(&Some(control_interface_info_mock))
+        );
     }
 
     // [utest->swdd~agent-control-interface-created-for-eligible-workloads~1]

--- a/agent/src/workload/workload_control_loop.rs
+++ b/agent/src/workload/workload_control_loop.rs
@@ -146,10 +146,10 @@ impl WorkloadControlLoop {
                         Some(WorkloadCommand::StartLogFetcher(log_request_options, result_sink)) =>  {
                             match Self::create_log_fetcher(&control_loop_state, &log_request_options) {
                                 Ok(logger) => {if let Err(error) = result_sink.send(logger){
-                                    log::warn!("Could not return log fetcher: '{:?}'", error);
+                                    log::warn!("Could not return log fetcher: '{error:?}'");
                                 }},
                                 Err(error) => {
-                                    log::warn!("Could not start log fetcher: '{:?}'", error);
+                                    log::warn!("Could not start log fetcher: '{error:?}'");
                                 }
                             }
                         }
@@ -253,7 +253,7 @@ impl WorkloadControlLoop {
             .retry_sender
             .retry(instance_name, retry_token)
             .await
-            .unwrap_or_else(|err| log::info!("Could not send WorkloadCommand::Retry: '{}'", err));
+            .unwrap_or_else(|err| log::info!("Could not send WorkloadCommand::Retry: '{err}'"));
         control_loop_state
     }
 
@@ -335,7 +335,7 @@ impl WorkloadControlLoop {
                         )
                         .await;
 
-                        log::error!("Failed to create workload with error: '{}'", err);
+                        log::error!("Failed to create workload with error: '{err}'");
 
                         control_loop_state
                     }
@@ -612,18 +612,14 @@ impl WorkloadControlLoop {
                 .await
                 .map_err(|err| {
                     log::warn!(
-                        "Failed to start state checker when resuming workload '{}': '{}'",
-                        workload_name,
-                        err
+                        "Failed to start state checker when resuming workload '{workload_name}': '{err}'"
                     );
                     err
                 })
                 .ok(),
             Err(err) => {
                 log::warn!(
-                    "Failed to get workload id when resuming workload '{}': '{}'",
-                    workload_name,
-                    err
+                    "Failed to get workload id when resuming workload '{workload_name}': '{err}'"
                 );
                 None
             }
@@ -640,7 +636,7 @@ impl WorkloadControlLoop {
             .await
             .unwrap_or_else(|err| match err {
                 FileSystemError::NotFoundDirectory(_) => {}
-                _ => log::warn!("Failed to delete folder: '{}'", err),
+                _ => log::warn!("Failed to delete folder: '{err}'"),
             });
     }
 
@@ -691,9 +687,9 @@ mod tests {
     use crate::io_utils::mock_filesystem_async;
     use crate::runtime_connectors::log_fetcher::MockLogFetcher;
     use crate::runtime_connectors::{LogRequestOptions, RuntimeError};
+    use crate::workload::WorkloadCommand;
     use crate::workload::retry_manager::MockRetryToken;
     use crate::workload::workload_command_channel::WorkloadCommandSender;
-    use crate::workload::WorkloadCommand;
     use crate::workload_files::{
         MockWorkloadFilesCreator, WorkloadFileCreationError, WorkloadFilesBasePath,
     };
@@ -706,11 +702,11 @@ mod tests {
     use mockall::predicate;
 
     use common::objects::{
+        ExecutionState, ExecutionStateEnum, WorkloadInstanceName,
         generate_test_rendered_workload_files, generate_test_workload_spec_with_param,
-        generate_test_workload_spec_with_rendered_files, ExecutionState, ExecutionStateEnum,
-        WorkloadInstanceName,
+        generate_test_workload_spec_with_rendered_files,
     };
-    use common::objects::{generate_test_workload_state_with_workload_spec, RestartPolicy};
+    use common::objects::{RestartPolicy, generate_test_workload_state_with_workload_spec};
 
     use tokio::{sync::mpsc, time::timeout};
 
@@ -835,12 +831,14 @@ mod tests {
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
         control_loop_state.state_checker = Some(old_mock_state_checker);
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -928,12 +926,14 @@ mod tests {
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
         control_loop_state.state_checker = Some(old_mock_state_checker);
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -1047,12 +1047,14 @@ mod tests {
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
         control_loop_state.state_checker = Some(old_mock_state_checker);
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -1155,12 +1157,14 @@ mod tests {
             .expect_new_token()
             .return_once(|| mock_retry_token);
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -1250,12 +1254,14 @@ mod tests {
             .times(2)
             .return_const(());
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -1329,12 +1335,14 @@ mod tests {
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
         control_loop_state.state_checker = Some(mock_state_checker);
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_execution_state_sequence(
             state_change_rx,
@@ -1391,12 +1399,14 @@ mod tests {
             .once()
             .return_const(());
 
-        assert!(timeout(
-            Duration::from_millis(200),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(200),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_closed());
         assert!(workload_command_receiver2.is_empty());
@@ -1473,12 +1483,14 @@ mod tests {
             .expect_new_token()
             .return_once(|| mock_retry_token);
 
-        assert!(timeout(
-            Duration::from_millis(100),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_closed());
         assert!(workload_command_receiver2.is_empty());
@@ -1551,12 +1563,14 @@ mod tests {
         workload_command_sender.resume().unwrap();
         workload_command_sender.delete().await.unwrap();
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_closed());
         assert!(workload_command_receiver2.is_empty());
@@ -1797,12 +1811,14 @@ mod tests {
             )
             .await;
 
-        assert!(timeout(
-            Duration::from_millis(100),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert_eq!(
             Ok(Some(workload_state)),
@@ -1851,12 +1867,14 @@ mod tests {
         // close the channel to panic within the workload control loop
         workload_state_forward_rx.close();
 
-        assert!(timeout(
-            Duration::from_millis(100),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_closed());
         assert!(workload_command_receiver2.is_empty());
@@ -1956,12 +1974,14 @@ mod tests {
             )
             .await;
 
-        assert!(timeout(
-            Duration::from_millis(100),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(100),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_closed());
         assert!(workload_command_receiver2.is_empty());
@@ -2371,12 +2391,14 @@ mod tests {
             .once()
             .return_once(|| retry_token);
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         let Some(WorkloadCommand::Retry(received_instance_name, _received_retry_token)) =
             workload_command_receiver2.recv().await
@@ -2479,12 +2501,14 @@ mod tests {
             .once()
             .return_once(|| retry_token);
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         let Some(WorkloadCommand::Retry(received_instance_name, _received_retry_token)) =
             workload_command_receiver2.recv().await
@@ -2564,12 +2588,14 @@ mod tests {
             .once()
             .return_const(());
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_empty());
         assert!(workload_command_receiver2.is_closed());
@@ -2637,12 +2663,14 @@ mod tests {
             .once()
             .return_const(());
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         assert!(workload_command_receiver2.is_empty());
         assert!(workload_command_receiver2.is_closed());
@@ -2720,12 +2748,14 @@ mod tests {
             .once()
             .return_const(());
 
-        assert!(timeout(
-            Duration::from_millis(150),
-            WorkloadControlLoop::run(control_loop_state)
-        )
-        .await
-        .is_ok());
+        assert!(
+            timeout(
+                Duration::from_millis(150),
+                WorkloadControlLoop::run(control_loop_state)
+            )
+            .await
+            .is_ok()
+        );
 
         let Some(WorkloadCommand::Retry(received_instance_name, _received_retry_token)) =
             workload_command_receiver2.recv().await

--- a/agent/src/workload_log_facade.rs
+++ b/agent/src/workload_log_facade.rs
@@ -17,7 +17,7 @@ use common::commands::LogsRequest;
 use common::objects::WorkloadInstanceName;
 use common::std_extensions::IllegalStateResult;
 use common::to_server_interface::{ToServerInterface, ToServerSender};
-use futures_util::{stream::FuturesUnordered, StreamExt};
+use futures_util::{StreamExt, stream::FuturesUnordered};
 use std::{future::Future, pin::Pin};
 
 use crate::agent_manager::SynchronizedSubscriptionStore;
@@ -89,7 +89,9 @@ impl WorkloadLogFacade {
                 .lock()
                 .unwrap()
                 .delete_subscription(&cloned_request_id);
-            log::debug!("Log collection for request '{}' finished. Subscription has been deleted successfully. ", cloned_request_id);
+            log::debug!(
+                "Log collection for request '{cloned_request_id}' finished. Subscription has been deleted successfully. "
+            );
         });
 
         synchronized_subscription_store
@@ -125,7 +127,7 @@ impl WorkloadLogFacade {
     ) {
         while let Some((workload_instance_name, mut receiver, log_lines)) = log_futures.next().await
         {
-            log::debug!("Got new log lines: {:?}", log_lines);
+            log::debug!("Got new log lines: {log_lines:?}");
             if let Some(log_lines) = log_lines {
                 to_server
                     .log_entries_response(
@@ -151,8 +153,7 @@ impl WorkloadLogFacade {
             } else {
                 // [impl->swdd~agent-workload-log-facade-sends-logs-stop-response~1]
                 log::debug!(
-                    "No more log lines available for workload '{}', sending logs stop response.",
-                    workload_instance_name
+                    "No more log lines available for workload '{workload_instance_name}', sending logs stop response."
                 );
                 to_server
                     .logs_stop_response(
@@ -395,8 +396,8 @@ mod tests {
     // [utest->swdd~agent-workload-log-facade-automatically-unsubscribes-log-subscriptions~1]
     // [utest->swdd~agent-workload-log-facade-sends-logs-stop-response~1]
     #[tokio::test]
-    async fn utest_workload_log_facade_unsubscribe_subscription_and_send_logs_stop_response_on_no_more_logs(
-    ) {
+    async fn utest_workload_log_facade_unsubscribe_subscription_and_send_logs_stop_response_on_no_more_logs()
+     {
         let _ = env_logger::builder().is_test(true).try_init();
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()

--- a/agent/src/workload_scheduler/scheduler.rs
+++ b/agent/src/workload_scheduler/scheduler.rs
@@ -56,7 +56,7 @@ impl WorkloadScheduler {
     where
         T: Into<String> + Display + 'static,
     {
-        log::debug!("Putting workload '{}' on waiting queue.", workload_name);
+        log::debug!("Putting workload '{workload_name}' on waiting queue.");
         self.queue.insert(workload_name.into(), pending_entry);
     }
 
@@ -335,8 +335,9 @@ impl WorkloadScheduler {
 mod tests {
     use common::{
         objects::{
-            generate_test_workload_spec, generate_test_workload_spec_with_param,
-            generate_test_workload_state_with_workload_spec, ExecutionState, WorkloadState,
+            ExecutionState, WorkloadState, generate_test_workload_spec,
+            generate_test_workload_spec_with_param,
+            generate_test_workload_state_with_workload_spec,
         },
         test_utils::generate_test_deleted_workload,
     };
@@ -405,12 +406,14 @@ mod tests {
             .await
         );
 
-        assert!(workload_scheduler.queue.contains_key(
-            pending_reusable_workload
-                .workload_spec
-                .instance_name
-                .workload_name()
-        ));
+        assert!(
+            workload_scheduler.queue.contains_key(
+                pending_reusable_workload
+                    .workload_spec
+                    .instance_name
+                    .workload_name()
+            )
+        );
 
         assert!(ready_workload_operations.is_empty());
     }
@@ -960,8 +963,8 @@ mod tests {
 
     // [utest->swdd~agent-shall-not-enqueue-update-delete-only-workload-operation~1]
     #[tokio::test]
-    async fn utest_enqueue_filtered_workload_operations_ignore_update_delete_only_workload_operations(
-    ) {
+    async fn utest_enqueue_filtered_workload_operations_ignore_update_delete_only_workload_operations()
+     {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;
@@ -989,8 +992,8 @@ mod tests {
 
     // [utest->swdd~agent-handles-update-with-fulfilled-delete~1]
     #[tokio::test]
-    async fn utest_next_workload_operations_enqueue_pending_update_create_on_delete_fulfilled_update(
-    ) {
+    async fn utest_next_workload_operations_enqueue_pending_update_create_on_delete_fulfilled_update()
+     {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;
@@ -1136,9 +1139,11 @@ mod tests {
 
         assert!(ready_workload_operations.is_empty());
 
-        assert!(workload_scheduler
-            .queue
-            .contains_key(instance_name_deleted_workload.workload_name()));
+        assert!(
+            workload_scheduler
+                .queue
+                .contains_key(instance_name_deleted_workload.workload_name())
+        );
     }
 
     // [utest->swdd~agent-keeps-workloads-with-unfulfilled-workload-dependencies-in-queue~1]
@@ -1211,9 +1216,11 @@ mod tests {
 
         assert!(ready_workload_operations.is_empty());
 
-        assert!(workload_scheduler
-            .queue
-            .contains_key(instance_name_create_workload.workload_name()));
+        assert!(
+            workload_scheduler
+                .queue
+                .contains_key(instance_name_create_workload.workload_name())
+        );
     }
 
     // [utest->swdd~agent-keeps-workloads-with-unfulfilled-workload-dependencies-in-queue~1]
@@ -1303,9 +1310,11 @@ mod tests {
 
         assert!(ready_workload_operations.is_empty());
 
-        assert!(workload_scheduler
-            .queue
-            .contains_key(instance_name.workload_name()));
+        assert!(
+            workload_scheduler
+                .queue
+                .contains_key(instance_name.workload_name())
+        );
     }
 
     // [utest->swdd~agent-keeps-workloads-with-unfulfilled-workload-dependencies-in-queue~1]
@@ -1405,15 +1414,17 @@ mod tests {
 
         assert!(ready_workload_operations.is_empty());
 
-        assert!(workload_scheduler
-            .queue
-            .contains_key(instance_name.workload_name()));
+        assert!(
+            workload_scheduler
+                .queue
+                .contains_key(instance_name.workload_name())
+        );
     }
 
     // [utest->swdd~agent-keeps-workloads-with-unfulfilled-workload-dependencies-in-queue~1]
     #[tokio::test]
-    async fn utest_next_workload_operations_no_report_pending_create_on_pending_update_create_reenqueue(
-    ) {
+    async fn utest_next_workload_operations_no_report_pending_create_on_pending_update_create_reenqueue()
+     {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC
             .get_lock_async()
             .await;

--- a/agent/src/workload_state/workload_state_store.rs
+++ b/agent/src/workload_state/workload_state_store.rs
@@ -78,8 +78,7 @@ impl MockWorkloadStateStore {
             .expect("No further call for update_workload_state expected");
         assert_eq!(
             expected_workload_state, workload_state,
-            "Expected workload state {:?}, got {:?}",
-            expected_workload_state, workload_state
+            "Expected workload state {expected_workload_state:?}, got {workload_state:?}"
         );
     }
 
@@ -245,8 +244,10 @@ mod tests {
             .states_storage
             .insert("workload_1".to_owned(), ExecutionState::running());
 
-        assert!(parameter_storage
-            .get_state_of_workload("unknown workload")
-            .is_none());
+        assert!(
+            parameter_storage
+                .get_state_of_workload("unknown workload")
+                .is_none()
+        );
     }
 }

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ank"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "The CLI of Eclipse Ankaios"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -45,8 +45,7 @@ Therefore the information shall not be written to the log, but it shall be provi
 Existing crates either do not behave as it is required or they are too complex for such task.
 
 Needs:
-
-* impl
+- impl
 
 Considered alternatives:
 

--- a/ank/src/ank_config.rs
+++ b/ank/src/ank_config.rs
@@ -13,8 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli::AnkCli;
-use common::std_extensions::UnreachableOption;
 use common::DEFAULT_SERVER_ADDRESS;
+use common::std_extensions::UnreachableOption;
 use grpc::security::read_pem_file;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fs::read_to_string;
 use std::path::PathBuf;
-use toml::{from_str, Value};
+use toml::{Value, from_str};
 
 use common::std_extensions::GracefulExitResult;
 use once_cell::sync::Lazy;
@@ -34,7 +34,7 @@ pub const DEFAULT_RESPONSE_TIMEOUT: u64 = 3000;
 
 pub static DEFAULT_ANK_CONFIG_FILE_PATH: Lazy<String> = Lazy::new(|| {
     let home_dir = env::var("HOME").unwrap_or_exit("HOME environment variable not set");
-    format!("{}/.config/ankaios/ank.conf", home_dir)
+    format!("{home_dir}/.config/ankaios/ank.conf")
 });
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -48,15 +48,15 @@ pub enum ConversionErrors {
 impl fmt::Display for ConversionErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ConversionErrors::WrongVersion(msg) => write!(f, "Wrong version: {}", msg),
+            ConversionErrors::WrongVersion(msg) => write!(f, "Wrong version: {msg}"),
             ConversionErrors::ConflictingCertificates(msg) => {
-                write!(f, "Conflicting certificates: {}", msg)
+                write!(f, "Conflicting certificates: {msg}")
             }
             ConversionErrors::InvalidAnkConfig(msg) => {
-                write!(f, "Ank Config could not have been parsed due to: {}", msg)
+                write!(f, "Ank Config could not have been parsed due to: {msg}")
             }
             ConversionErrors::InvalidCertificate(msg) => {
-                write!(f, "Certificate could not have been read due to: {}", msg)
+                write!(f, "Certificate could not have been read due to: {msg}")
             }
         }
     }
@@ -301,7 +301,7 @@ mod tests {
     use common::DEFAULT_SERVER_ADDRESS;
 
     use crate::{
-        ank_config::{get_default_response_timeout, get_default_url, ConversionErrors},
+        ank_config::{ConversionErrors, get_default_response_timeout, get_default_url},
         cli::{AnkCli, Commands, GetArgs, GetCommands},
     };
 
@@ -347,7 +347,7 @@ mod tests {
         #";
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -364,14 +364,13 @@ mod tests {
             r"#
         version = 'v1'
         [default]
-        ca_pem = '''{}'''
-        ca_pem_content = '''{}'''
-        #",
-            CA_PEM_PATH, CRT_PEM_CONTENT
+        ca_pem = '''{CA_PEM_PATH}'''
+        ca_pem_content = '''{CRT_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -426,15 +425,14 @@ mod tests {
             r"#
         version = 'v1'
         [default]
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let mut ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
         let args = AnkCli {
@@ -476,15 +474,14 @@ mod tests {
             r"#
         version = 'v1'
         [default]
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let mut ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
         let args = AnkCli {
@@ -521,7 +518,7 @@ mod tests {
         version = 'v1'
         #";
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
 
@@ -544,7 +541,7 @@ mod tests {
         [context]
         #";
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let ank_config = AnkConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -564,15 +561,14 @@ mod tests {
         [default]
         server_url = 'https://127.0.0.1:25551'
         insecure = false
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", ank_config_content).unwrap();
+        write!(tmp_config_file, "{ank_config_content}").unwrap();
 
         let ank_config_res = AnkConfig::from_file(PathBuf::from(tmp_config_file.path()));
 

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -14,7 +14,7 @@
 
 use std::{error::Error, ffi::OsStr};
 
-use clap::{command, ArgAction, CommandFactory, Parser, Subcommand, ValueHint};
+use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueHint, command};
 
 use clap_complete::{ArgValueCompleter, CompleteEnv, CompletionCandidate};
 
@@ -25,7 +25,7 @@ const ANK_SERVER_URL_ENV_KEY: &str = "ANK_SERVER_URL";
 fn state_from_command(object_field_mask: &str) -> Vec<u8> {
     std::process::Command::new("sh")
         .arg("-c")
-        .arg(format!("ank get state -o json {}", object_field_mask))
+        .arg(format!("ank get state -o json {object_field_mask}"))
         .output()
         .expect("failed to execute process")
         .stdout
@@ -101,16 +101,16 @@ fn completions_object_field_mask(state: Vec<u8>, current: &OsStr) -> Vec<Complet
     if let Some(desired_state) = state.desired_state {
         result.push(DESIRED_STATE.to_string());
         if let Some(workloads) = desired_state.workloads {
-            result.push(format!("{}.{}", DESIRED_STATE, WORKLOADS));
+            result.push(format!("{DESIRED_STATE}.{WORKLOADS}"));
             for workload_name in workloads.keys() {
-                result.push(format!("{}.{}.{}", DESIRED_STATE, WORKLOADS, workload_name));
+                result.push(format!("{DESIRED_STATE}.{WORKLOADS}.{workload_name}"));
             }
         }
         result.push(CONFIGS.to_string());
         if let Some(configs) = desired_state.configs {
-            result.push(format!("{}.{}", DESIRED_STATE, CONFIGS));
+            result.push(format!("{DESIRED_STATE}.{CONFIGS}"));
             for config_name in configs.keys() {
-                result.push(format!("{}.{}.{}", DESIRED_STATE, CONFIGS, config_name));
+                result.push(format!("{DESIRED_STATE}.{CONFIGS}.{config_name}"));
             }
         }
     }
@@ -118,9 +118,9 @@ fn completions_object_field_mask(state: Vec<u8>, current: &OsStr) -> Vec<Complet
     if let Some(workload_states) = state.workload_states {
         result.push(WORKLOAD_STATES.to_string());
         for (agent, workloads) in workload_states.into_iter() {
-            result.push(format!("{}.{}", WORKLOAD_STATES, agent));
+            result.push(format!("{WORKLOAD_STATES}.{agent}"));
             for workload_name in workloads.keys() {
-                result.push(format!("{}.{}.{}", WORKLOAD_STATES, agent, workload_name));
+                result.push(format!("{WORKLOAD_STATES}.{agent}.{workload_name}"));
             }
         }
     }

--- a/ank/src/cli_commands.rs
+++ b/ank/src/cli_commands.rs
@@ -88,7 +88,7 @@ pub fn get_input_sources(manifest_files: &[String]) -> Result<Vec<InputSourcePai
                         Err(err) => {
                             return Err(match err.kind() {
                                 std::io::ErrorKind::NotFound => {
-                                    format!("File '{}' not found!", file_path)
+                                    format!("File '{file_path}' not found!")
                                 }
                                 _ => err.to_string(),
                             });
@@ -282,7 +282,9 @@ impl CliCommands {
             output!("Apply successful. No workloads updated.");
             return Ok(());
         } else {
-            output!("Successfully applied the manifest(s).\nWaiting for workload(s) to reach desired states (press Ctrl+C to interrupt).\n");
+            output!(
+                "Successfully applied the manifest(s).\nWaiting for workload(s) to reach desired states (press Ctrl+C to interrupt).\n"
+            );
         }
 
         let field_mask_whole_complete_state = Vec::new();
@@ -371,7 +373,7 @@ mod tests {
 
     use std::io;
 
-    use super::{get_input_sources, InputSourcePair};
+    use super::{InputSourcePair, get_input_sources};
 
     mockall::lazy_static! {
         pub static ref FAKE_OPEN_MANIFEST_MOCK_RESULT_LIST: std::sync::Mutex<std::collections::VecDeque<io::Result<InputSourcePair>>>  =

--- a/ank/src/cli_commands/delete_configs.rs
+++ b/ank/src/cli_commands/delete_configs.rs
@@ -26,7 +26,7 @@ impl CliCommands {
         let update_mask = config_names
             .into_iter()
             .map(|name_of_config_to_delete| {
-                format!("{}.{}", DESIRED_STATE_CONFIGS, name_of_config_to_delete)
+                format!("{DESIRED_STATE_CONFIGS}.{name_of_config_to_delete}")
             })
             .collect();
 
@@ -39,7 +39,7 @@ impl CliCommands {
             .update_state(complete_state_update, update_mask)
             .await
             .map_err(|error| {
-                CliError::ExecutionError(format!("Failed to delete configs: {:?}", error))
+                CliError::ExecutionError(format!("Failed to delete configs: {error:?}"))
             })?;
 
         Ok(())
@@ -55,7 +55,7 @@ impl CliCommands {
 //////////////////////////////////////////////////////////////////////////////
 #[cfg(test)]
 mod tests {
-    use crate::cli_commands::{server_connection::MockServerConnection, CliCommands};
+    use crate::cli_commands::{CliCommands, server_connection::MockServerConnection};
     use crate::filtered_complete_state::FilteredCompleteState;
     use api::ank_base::UpdateStateSuccess;
     use common::objects::CompleteState;

--- a/ank/src/cli_commands/delete_workloads.rs
+++ b/ank/src/cli_commands/delete_workloads.rs
@@ -27,7 +27,7 @@ impl CliCommands {
         let update_mask = workload_names
             .into_iter()
             .map(|name_of_workload_to_delete| {
-                format!("{}.{}", DESIRED_STATE_WORKLOADS, name_of_workload_to_delete)
+                format!("{DESIRED_STATE_WORKLOADS}.{name_of_workload_to_delete}")
             })
             .collect();
 
@@ -59,7 +59,7 @@ mod tests {
     use mockall::predicate::eq;
 
     use crate::{
-        cli_commands::{server_connection::MockServerConnection, CliCommands},
+        cli_commands::{CliCommands, server_connection::MockServerConnection},
         filtered_complete_state::FilteredCompleteState,
     };
 

--- a/ank/src/cli_commands/get_logs.rs
+++ b/ank/src/cli_commands/get_logs.rs
@@ -32,7 +32,7 @@ impl CliCommands {
         self.server_connection
             .stream_logs(workload_instance_names, args)
             .await
-            .map_err(|e| CliError::ExecutionError(format!("Failed to get logs: '{:?}'", e)))
+            .map_err(|e| CliError::ExecutionError(format!("Failed to get logs: '{e:?}'")))
     }
 
     // [impl->swdd~cli-uses-workload-states-to-sample-workload-to-instance-names~1]
@@ -68,8 +68,7 @@ impl CliCommands {
                     }
                 } else {
                     return Err(CliError::ExecutionError(format!(
-                        "Workload name '{}' does not exist.",
-                        wl_name
+                        "Workload name '{wl_name}' does not exist."
                     )));
                 }
             }
@@ -98,8 +97,8 @@ mod tests {
 
     use crate::cli::LogsArgs;
     use crate::cli_commands::{
-        server_connection::{MockServerConnection, ServerConnectionError},
         CliCommands,
+        server_connection::{MockServerConnection, ServerConnectionError},
     };
     use crate::cli_error::CliError;
     use api::ank_base;
@@ -176,7 +175,7 @@ mod tests {
         };
         let result = cmd.get_logs_blocking(args).await;
 
-        assert!(result.is_ok(), "Got result {:?}", result);
+        assert!(result.is_ok(), "Got result {result:?}");
     }
 
     // [utest->swdd~cli-provides-workload-logs~1]
@@ -304,8 +303,7 @@ mod tests {
         assert_eq!(
             result,
             Err(CliError::ExecutionError(format!(
-                "Workload name '{}' does not exist.",
-                NOT_EXISTING_WORKLOAD_NAME
+                "Workload name '{NOT_EXISTING_WORKLOAD_NAME}' does not exist."
             )))
         );
     }
@@ -376,7 +374,7 @@ mod tests {
         let workload_names = vec![WORKLOAD_NAME_1.to_string()];
         let result = cmd.workload_names_to_instance_names(workload_names).await;
 
-        assert!(result.is_ok(), "Got result {:?}", result);
+        assert!(result.is_ok(), "Got result {result:?}");
         let instance_names = result.unwrap();
         let expected_instance_names: BTreeSet<WorkloadInstanceName> =
             BTreeSet::from([instance_name_wl_1_agent_a, instance_name_wl_1_agent_b]);

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -556,7 +556,7 @@ mod tests {
     use crate::{
         cli::LogsArgs,
         cli_commands::server_connection::{
-            select_log_format_function, ServerConnectionError, TEST_LOG_OUTPUT_DATA,
+            ServerConnectionError, TEST_LOG_OUTPUT_DATA, select_log_format_function,
         },
         cli_signals::MockSignalHandler,
         test_helper::MOCKALL_CONTEXT_SYNC,
@@ -692,7 +692,7 @@ mod tests {
             };
             self.join_handle.abort();
             if let Ok(message) = to_server.try_recv() {
-                panic!("Received unexpected message: {:#?}", message);
+                panic!("Received unexpected message: {message:#?}");
             }
         }
     }
@@ -1469,7 +1469,7 @@ mod tests {
         output_log_fn(vec![log_entry]);
 
         let actual_log_data = TEST_LOG_OUTPUT_DATA.take();
-        assert_eq!(actual_log_data, vec![format!("{}\n", log_message)]);
+        assert_eq!(actual_log_data, vec![format!("{log_message}\n")]);
     }
 
     // [utest->swdd~cli-outputs-logs-in-specific-format~1]
@@ -1849,8 +1849,7 @@ mod tests {
         assert_eq!(
             result,
             Err(ServerConnectionError::ExecutionError(format!(
-                "Workload '{}' is not accepted by the server to receive logs from.",
-                WORKLOAD_NAME_1
+                "Workload '{WORKLOAD_NAME_1}' is not accepted by the server to receive logs from."
             )))
         );
 

--- a/ank/src/cli_commands/set_state.rs
+++ b/ank/src/cli_commands/set_state.rs
@@ -58,14 +58,12 @@ async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<O
         "-" => {
             let stdin = io::read_to_string(reader).map_err(|error| {
                 CliError::ExecutionError(format!(
-                    "Could not read the state object from stdin.\nError: '{}'",
-                    error
+                    "Could not read the state object from stdin.\nError: '{error}'"
                 ))
             })?;
             let value: serde_yaml::Value = serde_yaml::from_str(&stdin).map_err(|error| {
                 CliError::YamlSerialization(format!(
-                    "Could not convert stdin input to yaml.\nError: '{}'",
-                    error
+                    "Could not convert stdin input to yaml.\nError: '{error}'"
                 ))
             })?;
             Ok(value.into())
@@ -74,15 +72,13 @@ async fn process_inputs<R: Read>(reader: R, state_object_file: &str) -> Result<O
             let state_object_data =
                 read_file_to_string(state_object_file.to_string()).map_err(|error| {
                     CliError::ExecutionError(format!(
-                        "Could not read the state object file '{}'.\nError: '{}'",
-                        state_object_file, error
+                        "Could not read the state object file '{state_object_file}'.\nError: '{error}'"
                     ))
                 })?;
             let value: serde_yaml::Value =
                 serde_yaml::from_str(&state_object_data).map_err(|error| {
                     CliError::YamlSerialization(format!(
-                        "Could not convert state object file to yaml.\nError: '{}'",
-                        error
+                        "Could not convert state object file to yaml.\nError: '{error}'"
                     ))
                 })?;
             Ok(value.into())
@@ -150,8 +146,8 @@ impl CliCommands {
 #[cfg(test)]
 mod tests {
     use super::{
-        create_state_with_default_workload_specs, io, overwrite_using_field_mask, process_inputs,
-        CliCommands, StoredWorkloadSpec,
+        CliCommands, StoredWorkloadSpec, create_state_with_default_workload_specs, io,
+        overwrite_using_field_mask, process_inputs,
     };
     use crate::{
         cli_commands::server_connection::MockServerConnection,
@@ -216,10 +212,12 @@ mod tests {
             complete_state.desired_state.workloads.get("nginx2"),
             Some(&StoredWorkloadSpec::default())
         );
-        assert!(!complete_state
-            .desired_state
-            .workloads
-            .contains_key("nginx3"));
+        assert!(
+            !complete_state
+                .desired_state
+                .workloads
+                .contains_key("nginx3")
+        );
     }
 
     // [utest->swdd~cli-provides-set-desired-state~1]

--- a/ank/src/cli_commands/wait_list_display.rs
+++ b/ank/src/cli_commands/wait_list_display.rs
@@ -60,7 +60,7 @@ impl Display for WaitListDisplay {
             )
             .unwrap_or_else(|_err| CliTable::new(&table_rows_with_spinner).create_default_table());
 
-        write!(f, "{}", table)
+        write!(f, "{table}")
     }
 }
 

--- a/ank/src/cli_error.rs
+++ b/ank/src/cli_error.rs
@@ -33,7 +33,7 @@ impl fmt::Display for CliError {
                 write!(f, "Could not serialize JSON object: '{message}'")
             }
             CliError::ExecutionError(message) => {
-                write!(f, "Command failed: '{}'", message)
+                write!(f, "Command failed: '{message}'")
             }
         }
     }

--- a/ank/src/filtered_complete_state.rs
+++ b/ank/src/filtered_complete_state.rs
@@ -102,7 +102,7 @@ impl FilteredAgentAttributes {
     pub fn get_cpu_usage_as_string(&mut self) -> String {
         if let Some(cpu_usage) = &self.cpu_usage {
             if let Some(cpu_usage_value) = cpu_usage.cpu_usage {
-                format!("{}%", cpu_usage_value)
+                format!("{cpu_usage_value}%")
             } else {
                 "".to_string()
             }
@@ -114,7 +114,7 @@ impl FilteredAgentAttributes {
     pub fn get_free_memory_as_string(&mut self) -> String {
         if let Some(free_memory) = &self.free_memory {
             if let Some(free_memory_value) = free_memory.free_memory {
-                format!("{}B", free_memory_value)
+                format!("{free_memory_value}B")
             } else {
                 "".to_string()
             }

--- a/ank/src/log.rs
+++ b/ank/src/log.rs
@@ -79,7 +79,7 @@ pub(crate) fn output_and_error_fn(args: fmt::Arguments<'_>) -> ! {
 }
 
 pub(crate) fn output_and_exit_fn(args: fmt::Arguments<'_>) -> ! {
-    std::println!("{}", args);
+    std::println!("{args}");
     exit(0);
 }
 
@@ -97,7 +97,7 @@ pub(crate) fn output_warn_fn(args: fmt::Arguments<'_>) {
 
 pub(crate) fn output_fn(args: fmt::Arguments<'_>) {
     if !is_quiet() {
-        std::println!("{}", args);
+        std::println!("{args}");
         *ROWS_PREV_MSG.lock().unwrap() = 0;
     }
 }
@@ -125,7 +125,7 @@ pub(crate) fn output_update_fn(args: fmt::Arguments<'_>) {
         let args = args.to_string();
 
         if !interactive() {
-            println!("{}\n", args);
+            println!("{args}\n");
             return;
         }
 

--- a/ank/src/log.rs
+++ b/ank/src/log.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    env, fmt,
+    fmt,
     io::{self, IsTerminal},
     process::exit,
     sync::Mutex,
@@ -25,8 +25,10 @@ use crossterm::{
     terminal::{self, ClearType},
 };
 
-pub const VERBOSITY_KEY: &str = "VERBOSE";
-pub const QUIET_KEY: &str = "SILENT";
+use std::sync::OnceLock;
+
+pub static IS_VERBOSE: OnceLock<bool> = OnceLock::new();
+pub static IS_QUIET: OnceLock<bool> = OnceLock::new();
 
 static ROWS_PREV_MSG: Mutex<u16> = Mutex::new(0);
 
@@ -175,10 +177,9 @@ pub(crate) fn output_update_fn(args: fmt::Arguments<'_>) {
 }
 
 fn is_verbose() -> bool {
-    matches!(env::var(VERBOSITY_KEY), Ok(verbose) if verbose.to_lowercase() == "true")
-        && !is_quiet()
+    *IS_VERBOSE.get().unwrap_or(&false) && !is_quiet()
 }
 
 fn is_quiet() -> bool {
-    matches!(env::var(QUIET_KEY), Ok(quiet) if quiet.to_lowercase() == "true")
+    *IS_QUIET.get().unwrap_or(&false)
 }

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -12,7 +12,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::env;
 use std::path::PathBuf;
 
 mod ank_config;
@@ -21,8 +20,10 @@ mod cli_commands;
 mod cli_signals;
 use ank_config::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATH};
 use cli_commands::CliCommands;
-use common::std_extensions::GracefulExitResult;
+use common::std_extensions::{GracefulExitResult, IllegalStateResult};
 use grpc::security::TLSConfig;
+
+use crate::log::{IS_QUIET, IS_VERBOSE};
 mod cli_error;
 mod filtered_complete_state;
 mod log;
@@ -35,25 +36,13 @@ fn handle_ank_config(config_path: &Option<String>, default_path: &str) -> AnkCon
     match config_path {
         Some(config_path) => {
             let config_path = PathBuf::from(config_path);
-            output_debug!(
-                "Loading server config from user provided path '{}'",
-                config_path.display()
-            );
             AnkConfig::from_file(config_path).unwrap_or_exit("Config file could not be parsed")
         }
         None => {
             let default_path = PathBuf::from(default_path.as_ref() as &std::path::Path);
             if !default_path.try_exists().unwrap_or(false) {
-                output_debug!(
-                    "No config file found at default path '{}'. Using cli arguments and environment variables only.",
-                    default_path.display()
-                );
                 AnkConfig::default()
             } else {
-                output_debug!(
-                    "Loading server config from default path '{}'",
-                    default_path.display()
-                );
                 AnkConfig::from_file(default_path).expect("Config file could not be parsed")
             }
         }
@@ -71,11 +60,8 @@ async fn main() {
 
     let cli_name = "ank-cli";
 
-    // action is thread-safe, so we can set the environment variables
-    unsafe {
-        env::set_var(log::VERBOSITY_KEY, ank_config.verbose.to_string());
-        env::set_var(log::QUIET_KEY, ank_config.quiet.to_string());
-    };
+    IS_VERBOSE.set(ank_config.verbose).unwrap_or_illegal_state();
+    IS_QUIET.set(ank_config.quiet).unwrap_or_illegal_state();
 
     output_debug!(
         "Started '{}' with the following parameters: '{:?}'",

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn utest_handle_ank_config_valid_config() {
         let mut tmp_config_file = NamedTempFile::new().expect("could not create temp file");
-        write!(tmp_config_file, "{}", VALID_ANK_CONFIG_CONTENT)
+        write!(tmp_config_file, "{VALID_ANK_CONFIG_CONTENT}")
             .expect("could not write to temp file");
 
         let ank_config = handle_ank_config(
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn utest_handle_ank_config_default_path() {
         let mut file = tempfile::NamedTempFile::new().expect("Failed to create file");
-        writeln!(file, "{}", VALID_ANK_CONFIG_CONTENT).expect("Failed to write to file");
+        writeln!(file, "{VALID_ANK_CONFIG_CONTENT}").expect("Failed to write to file");
 
         let ank_config = handle_ank_config(&None, file.path().to_str().unwrap());
 

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -44,7 +44,10 @@ fn handle_ank_config(config_path: &Option<String>, default_path: &str) -> AnkCon
         None => {
             let default_path = PathBuf::from(default_path.as_ref() as &std::path::Path);
             if !default_path.try_exists().unwrap_or(false) {
-                output_debug!("No config file found at default path '{}'. Using cli arguments and environment variables only.", default_path.display());
+                output_debug!(
+                    "No config file found at default path '{}'. Using cli arguments and environment variables only.",
+                    default_path.display()
+                );
                 AnkConfig::default()
             } else {
                 output_debug!(
@@ -67,8 +70,12 @@ async fn main() {
     ank_config.update_with_args(&args);
 
     let cli_name = "ank-cli";
-    env::set_var(log::VERBOSITY_KEY, ank_config.verbose.to_string());
-    env::set_var(log::QUIET_KEY, ank_config.quiet.to_string());
+
+    // action is thread-safe, so we can set the environment variables
+    unsafe {
+        env::set_var(log::VERBOSITY_KEY, ank_config.verbose.to_string());
+        env::set_var(log::QUIET_KEY, ank_config.quiet.to_string());
+    };
 
     output_debug!(
         "Started '{}' with the following parameters: '{:?}'",
@@ -278,7 +285,7 @@ async fn main() {
 
 #[cfg(test)]
 mod tests {
-    use crate::{ank_config::DEFAULT_ANK_CONFIG_FILE_PATH, handle_ank_config, AnkConfig};
+    use crate::{AnkConfig, ank_config::DEFAULT_ANK_CONFIG_FILE_PATH, handle_ank_config};
     use std::io::Write;
     use tempfile::NamedTempFile;
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "API definition for Eclipse Ankaios"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "common"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Common containers and utilities for Eclipse Ankaios"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/common/src/commands.rs
+++ b/common/src/commands.rs
@@ -57,7 +57,7 @@ impl From<Request> for ank_base::Request {
 
 impl Request {
     pub fn prefix_id(prefix: &str, request_id: &String) -> String {
-        format!("{}{}", prefix, request_id)
+        format!("{prefix}{request_id}")
     }
     pub fn prefix_request_id(&mut self, prefix: &str) {
         self.request_id = Self::prefix_id(prefix, &self.request_id);
@@ -270,9 +270,9 @@ mod tests {
 
     mod ank_base {
         pub use api::ank_base::{
-            request::RequestContent, CompleteState, CompleteStateRequest, ConfigMappings,
-            Dependencies, LogsCancelRequest, LogsRequest, Request, RestartPolicy, State, Tag, Tags,
-            UpdateStateRequest, Workload, WorkloadInstanceName, WorkloadMap,
+            CompleteState, CompleteStateRequest, ConfigMappings, Dependencies, LogsCancelRequest,
+            LogsRequest, Request, RestartPolicy, State, Tag, Tags, UpdateStateRequest, Workload,
+            WorkloadInstanceName, WorkloadMap, request::RequestContent,
         };
     }
 
@@ -283,9 +283,9 @@ mod tests {
                 UpdateStateRequest,
             },
             objects::{
-                generate_test_agent_map, generate_test_workload_states_map_with_data, Base64Data,
-                CompleteState, Data, ExecutionState, File, FileContent, RestartPolicy, State,
-                StoredWorkloadSpec, Tag, WorkloadInstanceName,
+                Base64Data, CompleteState, Data, ExecutionState, File, FileContent, RestartPolicy,
+                State, StoredWorkloadSpec, Tag, WorkloadInstanceName, generate_test_agent_map,
+                generate_test_workload_states_map_with_data,
             },
         };
     }
@@ -517,9 +517,7 @@ mod tests {
     }
 
     macro_rules! agent_map {
-        (ankaios) => {{
-            ankaios::generate_test_agent_map(AGENT_NAME)
-        }};
+        (ankaios) => {{ ankaios::generate_test_agent_map(AGENT_NAME) }};
         (ank_base) => {
             ankaios::generate_test_agent_map(AGENT_NAME).into()
         };

--- a/common/src/communications_error.rs
+++ b/common/src/communications_error.rs
@@ -29,7 +29,7 @@ impl fmt::Display for CommunicationMiddlewareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
             CommunicationMiddlewareError(message) => {
-                write!(f, "{}", message)
+                write!(f, "{message}")
             }
         }
     }

--- a/common/src/objects/control_interface_access.rs
+++ b/common/src/objects/control_interface_access.rs
@@ -109,10 +109,7 @@ impl AccessRightsRule {
             let prefix = &workload_name[..wildcard_pos];
             let suffix = &workload_name[wildcard_pos + 1..];
             if suffix.contains(WILDCARD_SYMBOL) {
-                Err(format!(
-                    "Expected at most one '{}' symbol.",
-                    WILDCARD_SYMBOL
-                ))
+                Err(format!("Expected at most one '{WILDCARD_SYMBOL}' symbol."))
             } else {
                 verify_workload_name_pattern(prefix)
                     .and_then(|_| verify_workload_name_pattern(suffix))
@@ -124,12 +121,7 @@ impl AccessRightsRule {
                 .and_then(|_| verify_workload_name_length(length))
                 .and_then(|_| verify_workload_name_not_empty(length))
         }
-        .map_err(|err| {
-            format!(
-                "Unsupported workload name for log rule '{}'. {}",
-                workload_name, err
-            )
-        })
+        .map_err(|err| format!("Unsupported workload name for log rule '{workload_name}'. {err}"))
     }
 }
 
@@ -277,8 +269,8 @@ pub fn generate_test_control_interface_access() -> ControlInterfaceAccess {
 #[cfg(test)]
 mod tests {
     use crate::objects::{
-        control_interface_access::LogRule, generate_test_control_interface_access,
-        AccessRightsRule, ReadWriteEnum, StateRule,
+        AccessRightsRule, ReadWriteEnum, StateRule, control_interface_access::LogRule,
+        generate_test_control_interface_access,
     };
 
     // [utest->swdd~common-access-rules-filter-mask-convention~1]
@@ -312,18 +304,26 @@ mod tests {
         const MAX_SUFFIX: &str = "123456789012345678901234567890123";
 
         assert!(log_rule_with_workload("workload_1").verify_format().is_ok());
-        assert!(log_rule_with_workload("*workload_1")
-            .verify_format()
-            .is_ok());
-        assert!(log_rule_with_workload("work*load_1")
-            .verify_format()
-            .is_ok());
-        assert!(log_rule_with_workload("workload_1*")
-            .verify_format()
-            .is_ok());
-        assert!(log_rule_with_workload(&format!("{MAX_PREFIX}{MAX_SUFFIX}"))
-            .verify_format()
-            .is_ok());
+        assert!(
+            log_rule_with_workload("*workload_1")
+                .verify_format()
+                .is_ok()
+        );
+        assert!(
+            log_rule_with_workload("work*load_1")
+                .verify_format()
+                .is_ok()
+        );
+        assert!(
+            log_rule_with_workload("workload_1*")
+                .verify_format()
+                .is_ok()
+        );
+        assert!(
+            log_rule_with_workload(&format!("{MAX_PREFIX}{MAX_SUFFIX}"))
+                .verify_format()
+                .is_ok()
+        );
         assert!(
             log_rule_with_workload(&format!("*{MAX_PREFIX}{MAX_SUFFIX}"))
                 .verify_format()
@@ -368,24 +368,36 @@ mod tests {
                 .verify_format()
                 .is_err()
         );
-        assert!(log_rule_with_workload("just.wrong")
-            .verify_format()
-            .is_err());
-        assert!(log_rule_with_workload("also@wrong")
-            .verify_format()
-            .is_err());
-        assert!(log_rule_with_workload("*also@wrong")
-            .verify_format()
-            .is_err());
-        assert!(log_rule_with_workload("al*so@wrong")
-            .verify_format()
-            .is_err());
-        assert!(log_rule_with_workload("also@wr*ong")
-            .verify_format()
-            .is_err());
-        assert!(log_rule_with_workload("also@wrong*")
-            .verify_format()
-            .is_err());
+        assert!(
+            log_rule_with_workload("just.wrong")
+                .verify_format()
+                .is_err()
+        );
+        assert!(
+            log_rule_with_workload("also@wrong")
+                .verify_format()
+                .is_err()
+        );
+        assert!(
+            log_rule_with_workload("*also@wrong")
+                .verify_format()
+                .is_err()
+        );
+        assert!(
+            log_rule_with_workload("al*so@wrong")
+                .verify_format()
+                .is_err()
+        );
+        assert!(
+            log_rule_with_workload("also@wr*ong")
+                .verify_format()
+                .is_err()
+        );
+        assert!(
+            log_rule_with_workload("also@wrong*")
+                .verify_format()
+                .is_err()
+        );
     }
 
     fn log_rule_with_workload(workload_name: &str) -> AccessRightsRule {

--- a/common/src/objects/state.rs
+++ b/common/src/objects/state.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 
 use crate::helpers::serialize_to_ordered_map;
 use crate::objects::ConfigItem;
-use crate::objects::{StoredWorkloadSpec, STR_RE_CONFIG_REFERENCES};
+use crate::objects::{STR_RE_CONFIG_REFERENCES, StoredWorkloadSpec};
 
 use api::ank_base;
 
@@ -111,8 +111,7 @@ impl State {
         for config_key in provided_state.configs.keys() {
             if !re_config_items.is_match(config_key.as_str()) {
                 return Err(format!(
-                    "Unsupported config item key. Received '{}', expected to have characters in {}",
-                    config_key, STR_RE_CONFIG_REFERENCES
+                    "Unsupported config item key. Received '{config_key}', expected to have characters in {STR_RE_CONFIG_REFERENCES}"
                 ));
             }
         }
@@ -142,7 +141,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
-        objects::{generate_test_configs, generate_test_stored_workload_spec, ConfigItem, State},
+        objects::{ConfigItem, State, generate_test_configs, generate_test_stored_workload_spec},
         test_utils::{generate_test_proto_state, generate_test_state},
     };
 

--- a/common/src/objects/stored_workload_spec.rs
+++ b/common/src/objects/stored_workload_spec.rs
@@ -21,8 +21,8 @@ use serde::{Deserialize, Serialize};
 use crate::helpers::serialize_to_ordered_map;
 
 use super::{
-    control_interface_access::ControlInterfaceAccess, file::File, AddCondition, RestartPolicy, Tag,
-    WorkloadInstanceName, WorkloadSpec,
+    AddCondition, RestartPolicy, Tag, WorkloadInstanceName, WorkloadSpec,
+    control_interface_access::ControlInterfaceAccess, file::File,
 };
 
 pub const STR_RE_CONFIG_REFERENCES: &str = r"^[a-zA-Z0-9_-]*$";
@@ -56,15 +56,13 @@ impl StoredWorkloadSpec {
         for (config_alias, referenced_config) in config_references {
             if !re_config_references.is_match(config_alias) {
                 return Err(format!(
-                    "Unsupported config alias. Received '{}', expected to have characters in {}",
-                    config_alias, STR_RE_CONFIG_REFERENCES
+                    "Unsupported config alias. Received '{config_alias}', expected to have characters in {STR_RE_CONFIG_REFERENCES}"
                 ));
             }
 
             if !re_config_references.is_match(referenced_config) {
                 return Err(format!(
-                    "Unsupported config reference key. Received '{}', expected to have characters in {}",
-                    referenced_config, STR_RE_CONFIG_REFERENCES
+                    "Unsupported config reference key. Received '{referenced_config}', expected to have characters in {STR_RE_CONFIG_REFERENCES}"
                 ));
             }
         }

--- a/common/src/objects/workload_spec.rs
+++ b/common/src/objects/workload_spec.rs
@@ -19,10 +19,10 @@ use std::collections::HashMap;
 use crate::helpers::serialize_to_ordered_map;
 use crate::objects::Tag;
 
-use super::control_interface_access::ControlInterfaceAccess;
-use super::file::File;
 use super::ExecutionState;
 use super::WorkloadInstanceName;
+use super::control_interface_access::ControlInterfaceAccess;
+use super::file::File;
 
 pub type WorkloadCollection = Vec<WorkloadSpec>;
 pub type DeletedWorkloadCollection = Vec<DeletedWorkload>;
@@ -46,16 +46,13 @@ pub fn verify_workload_name_format(workload_name: &str) -> Result<(), String> {
     verify_workload_name_pattern(workload_name)
         .and_then(|_| verify_workload_name_not_empty(length))
         .and_then(|_| verify_workload_name_length(length))
-        .map_err(|err| format!("Unsupported workload name '{}'. {}", workload_name, err))
+        .map_err(|err| format!("Unsupported workload name '{workload_name}'. {err}"))
 }
 
 pub fn verify_workload_name_pattern(workload_name: &str) -> Result<(), String> {
     let re_workloads = Regex::new(STR_RE_WORKLOAD).unwrap();
     if !re_workloads.is_match(workload_name) {
-        Err(format!(
-            "Expected to have characters in {}.",
-            ALLOWED_SYMBOLS
-        ))
+        Err(format!("Expected to have characters in {ALLOWED_SYMBOLS}."))
     } else {
         Ok(())
     }
@@ -64,8 +61,7 @@ pub fn verify_workload_name_pattern(workload_name: &str) -> Result<(), String> {
 pub fn verify_workload_name_length(length: usize) -> Result<(), String> {
     if length > MAX_CHARACTERS_WORKLOAD_NAME {
         Err(format!(
-            "Length {} exceeds the maximum limit of {} characters.",
-            length, MAX_CHARACTERS_WORKLOAD_NAME
+            "Length {length} exceeds the maximum limit of {MAX_CHARACTERS_WORKLOAD_NAME} characters."
         ))
     } else {
         Ok(())
@@ -85,8 +81,7 @@ fn verify_agent_name_format(agent_name: &str) -> Result<(), String> {
     let re_agent = Regex::new(STR_RE_AGENT).unwrap();
     if !re_agent.is_match(agent_name) {
         Err(format!(
-            "Unsupported agent name. Received '{}', expected to have characters in {}",
-            agent_name, ALLOWED_SYMBOLS
+            "Unsupported agent name. Received '{agent_name}', expected to have characters in {ALLOWED_SYMBOLS}"
         ))
     } else {
         Ok(())

--- a/common/src/objects/workload_state.rs
+++ b/common/src/objects/workload_state.rs
@@ -180,11 +180,7 @@ impl ExecutionState {
                 | ExecutionStateEnum::Failed(FailedSubstate::Lost)
                 | ExecutionStateEnum::Failed(FailedSubstate::Unknown),
             ) => {
-                log::trace!(
-                    "Skipping transition from '{}' to '{}' state.",
-                    self,
-                    incoming
-                );
+                log::trace!("Skipping transition from '{self}' to '{incoming}' state.");
                 self.clone()
             }
             _ => incoming,
@@ -574,7 +570,7 @@ mod tests {
     use api::ank_base::{self};
 
     use crate::objects::{
-        workload_state::NO_MORE_RETRIES_MSG, ExecutionState, WorkloadInstanceName, WorkloadState,
+        ExecutionState, WorkloadInstanceName, WorkloadState, workload_state::NO_MORE_RETRIES_MSG,
     };
 
     // [utest->swdd~common-workload-state-transitions~1]
@@ -702,7 +698,7 @@ mod tests {
         );
         assert_eq!(
             ank_base::ExecutionState {
-                additional_info: format!("{}: {}", NO_MORE_RETRIES_MSG, additional_info),
+                additional_info: format!("{NO_MORE_RETRIES_MSG}: {additional_info}"),
                 execution_state_enum: Some(ank_base::execution_state::ExecutionStateEnum::Pending(
                     ank_base::Pending::StartingFailed.into(),
                 )),
@@ -809,7 +805,7 @@ mod tests {
         assert_eq!(
             ExecutionState::retry_failed_no_retry(additional_info),
             ank_base::ExecutionState {
-                additional_info: format!("{}: {}", NO_MORE_RETRIES_MSG, additional_info),
+                additional_info: format!("{NO_MORE_RETRIES_MSG}: {additional_info}"),
                 execution_state_enum: Some(ank_base::execution_state::ExecutionStateEnum::Pending(
                     ank_base::Pending::StartingFailed.into(),
                 )),
@@ -915,10 +911,7 @@ mod tests {
         );
         assert_eq!(
             ExecutionState::retry_failed_no_retry(additional_info).to_string(),
-            format!(
-                "Pending(StartingFailed): '{}: {}'",
-                NO_MORE_RETRIES_MSG, additional_info
-            )
+            format!("Pending(StartingFailed): '{NO_MORE_RETRIES_MSG}: {additional_info}'")
         );
         assert_eq!(
             ExecutionState::removed().to_string(),

--- a/common/src/state_manipulation/object.rs
+++ b/common/src/state_manipulation/object.rs
@@ -18,9 +18,9 @@ use super::Path;
 use crate::objects as ankaios;
 use api::ank_base as proto;
 use serde_yaml::{
-    from_value,
+    Mapping, Value, from_value,
     mapping::{Entry::Occupied, Entry::Vacant},
-    to_value, Mapping, Value,
+    to_value,
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -150,12 +150,12 @@ fn generate_paths_from_yaml_node(
                             .unwrap()
                             .to_owned()
                     }
-                    _ => panic!("Unsupported mapping key '{:?}'", key),
+                    _ => panic!("Unsupported mapping key '{key:?}'"),
                 };
                 let new_path = if start_path.is_empty() {
                     key_str
                 } else {
-                    format!("{}.{}", start_path, key_str)
+                    format!("{start_path}.{key_str}")
                 };
 
                 if includes_mappings_and_sequences {
@@ -171,7 +171,7 @@ fn generate_paths_from_yaml_node(
         }
         Value::Sequence(sequence) => {
             for (index, value) in sequence.iter().enumerate() {
-                let new_path = format!("{}.{}", start_path, index);
+                let new_path = format!("{start_path}.{index}");
                 if includes_mappings_and_sequences {
                     paths.insert(new_path.clone());
                 }
@@ -233,7 +233,7 @@ impl Object {
         let (path_head, path_last) = path.split_last()?;
 
         self.get_as_mapping(&path_head)
-            .ok_or_else(|| format!("{:?} is not mapping", path_head))?
+            .ok_or_else(|| format!("{path_head:?} is not mapping"))?
             .remove(Value::String(path_last));
         Ok(())
     }
@@ -295,9 +295,9 @@ impl Object {
 mod tests {
     use crate::{
         objects::{
-            generate_test_agent_map_from_specs, generate_test_rendered_workload_files,
-            generate_test_workload_spec_with_rendered_files,
-            generate_test_workload_states_map_with_data, CompleteState, ExecutionState, State,
+            CompleteState, ExecutionState, State, generate_test_agent_map_from_specs,
+            generate_test_rendered_workload_files, generate_test_workload_spec_with_rendered_files,
+            generate_test_workload_states_map_with_data,
         },
         test_utils::generate_test_state_from_workloads,
     };

--- a/examples/rust_control_interface/Cargo.toml
+++ b/examples/rust_control_interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control_interface_example"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/rust_sdk_logging/Cargo.toml
+++ b/examples/rust_sdk_logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_sdk_logging"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]

--- a/grpc/Cargo.toml
+++ b/grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grpc"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "A gRPC communication middleware for Eclipse Ankaios"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/grpc/src/grpc_cli_connection.rs
+++ b/grpc/src/grpc_cli_connection.rs
@@ -23,7 +23,7 @@ use tonic::{Request, Response, Status};
 
 use crate::agent_senders_map::AgentSendersMap;
 use crate::to_server::ToServerEnum;
-use crate::to_server_proxy::{forward_from_proto_to_ankaios, GRPCToServerStreaming};
+use crate::to_server_proxy::{GRPCToServerStreaming, forward_from_proto_to_ankaios};
 use grpc_api::cli_connection_server::CliConnection;
 
 use crate::grpc_api;
@@ -98,16 +98,11 @@ impl CliConnection for GRPCCliConnection {
                     .await;
                     if result.is_err() {
                         log::debug!(
-                            "Connection to CLI (name={}) failed with {:?}.",
-                            cli_connection_name,
-                            result
+                            "Connection to CLI (name={cli_connection_name}) failed with {result:?}."
                         );
                     }
                     cli_senders.remove(&cli_connection_name);
-                    log::debug!(
-                        "Connection to CLI (name={}) has been closed.",
-                        cli_connection_name
-                    );
+                    log::debug!("Connection to CLI (name={cli_connection_name}) has been closed.");
                 });
                 // [impl->swdd~grpc-commander-connection-responds-with-from-server-channel-rx~1]
                 Ok(Response::new(Box::pin(ReceiverStream::new(new_receiver))))

--- a/grpc/src/grpc_middleware_error.rs
+++ b/grpc/src/grpc_middleware_error.rs
@@ -85,11 +85,11 @@ impl std::error::Error for GrpcMiddlewareError {}
 impl fmt::Display for GrpcMiddlewareError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            GrpcMiddlewareError::StartError(message) => write!(f, "StartError: '{}'", message),
-            GrpcMiddlewareError::ReceiveError(message) => write!(f, "ReceiveError: '{}'", message),
-            GrpcMiddlewareError::SendError(message) => write!(f, "SendError: '{}'", message),
+            GrpcMiddlewareError::StartError(message) => write!(f, "StartError: '{message}'"),
+            GrpcMiddlewareError::ReceiveError(message) => write!(f, "ReceiveError: '{message}'"),
+            GrpcMiddlewareError::SendError(message) => write!(f, "SendError: '{message}'"),
             GrpcMiddlewareError::ConversionError(message) => {
-                write!(f, "ConversionError: '{}'", message)
+                write!(f, "ConversionError: '{message}'")
             }
             GrpcMiddlewareError::ServerNotAvailable(message) => {
                 write!(f, "Could not connect to the server: '{message}'")

--- a/grpc/src/lib.rs
+++ b/grpc/src/lib.rs
@@ -58,14 +58,11 @@ pub mod security {
         ) -> Result<Option<TLSConfig>, String> {
             match (insecure, ca_pem, crt_pem, key_pem) {
                 // [impl->swdd~cli-provides-file-paths-to-communication-middleware~1]
-                (_, Some(ca_pem), Some(crt_pem), Some(key_pem)) => {
-
-                    Ok(Some(TLSConfig {
-                        ca_pem,
-                        crt_pem,
-                        key_pem,
-                    }))
-                }
+                (_, Some(ca_pem), Some(crt_pem), Some(key_pem)) => Ok(Some(TLSConfig {
+                    ca_pem,
+                    crt_pem,
+                    key_pem,
+                })),
                 // [impl->swdd~cli-establishes-insecure-communication-based-on-provided-insecure-cli-argument~1]
                 (true, None, None, None) => Ok(None),
                 // [impl->swdd~cli-fails-on-missing-file-paths-and-insecure-cli-arguments~1]
@@ -88,8 +85,7 @@ pub mod security {
 
         let mut file = File::open(path_of_pem_file).map_err(|err| {
             GrpcMiddlewareError::CertificateError(format!(
-                "Error during opening the given file {:?}: {}",
-                path_of_pem_file, err
+                "Error during opening the given file {path_of_pem_file:?}: {err}"
             ))
         })?;
 
@@ -102,8 +98,7 @@ pub mod security {
                 .metadata()
                 .map_err(|err| {
                     GrpcMiddlewareError::CertificateError(format!(
-                        "Error during getting permissions of the given file {:?}: {}",
-                        path_of_pem_file, err
+                        "Error during getting permissions of the given file {path_of_pem_file:?}: {err}"
                     ))
                 })?
                 .permissions();
@@ -118,15 +113,13 @@ pub mod security {
             let mut buffer = String::new();
             file.read_to_string(&mut buffer).map_err(|err| {
                 GrpcMiddlewareError::CertificateError(format!(
-                    "Error during reading the given file {:?}: {:?}",
-                    path_of_pem_file, err
+                    "Error during reading the given file {path_of_pem_file:?}: {err:?}"
                 ))
             })?;
             Ok(buffer)
         } else {
             Err(GrpcMiddlewareError::CertificateError(format!(
-                "The given certificate file {:?} has incorrect permissions!",
-                path_of_pem_file
+                "The given certificate file {path_of_pem_file:?} has incorrect permissions!"
             )))
         }
     }

--- a/grpc/tests/grpc_test.rs
+++ b/grpc/tests/grpc_test.rs
@@ -34,7 +34,7 @@ mod grpc_tests {
     };
     use grpc::{
         client::GRPCCommunicationsClient,
-        security::{self, read_pem_file, TLSConfig},
+        security::{self, TLSConfig, read_pem_file},
         server::GRPCCommunicationsServer,
     };
 
@@ -211,7 +211,7 @@ MC4CAQAwBQYDK2VwBCIEILwDB7W+KEw+UkzfOQA9ghy70Em4ubdS42DLkDmdmYyb
         tokio::task::JoinHandle<Result<(), CommunicationMiddlewareError>>,
     ) {
         let (to_grpc_client, grpc_client_receiver) = tokio::sync::mpsc::channel::<ToServer>(20);
-        let url = format!("http://{}", server_addr);
+        let url = format!("http://{server_addr}");
         let grpc_communications_client = match comm_type {
             CommunicationType::Cli => GRPCCommunicationsClient::new_cli_communication(
                 test_request_id.to_owned(),
@@ -254,7 +254,7 @@ MC4CAQAwBQYDK2VwBCIEILwDB7W+KEw+UkzfOQA9ghy70Em4ubdS42DLkDmdmYyb
         //
         //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-        let server_addr = format!("0.0.0.0:{}", port);
+        let server_addr = format!("0.0.0.0:{port}");
         let (to_grpc_server, grpc_server_receiver) = tokio::sync::mpsc::channel::<FromServer>(20);
         let (to_server, server_receiver) = tokio::sync::mpsc::channel::<ToServer>(20);
 
@@ -304,8 +304,8 @@ MC4CAQAwBQYDK2VwBCIEILwDB7W+KEw+UkzfOQA9ghy70Em4ubdS42DLkDmdmYyb
     // [itest->swdd~grpc-server-activate-mtls-when-certificates-and-key-provided-upon-start~1]
     // [itest->swdd~grpc-cli-activate-mtls-when-certificates-and-key-provided-upon-start~1]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)] // set worker_threads = 1 to solve the failing of the test on woodpecker
-    async fn itest_grpc_communication_client_cli_connection_grpc_server_received_request_complete_state_with_tls(
-    ) {
+    async fn itest_grpc_communication_client_cli_connection_grpc_server_received_request_complete_state_with_tls()
+     {
         let _ = env_logger::builder().is_test(true).try_init();
         let test_request_id = "test_request_id";
         let test_pem_files_package = TestPEMFilesPackage::new().unwrap();
@@ -350,8 +350,8 @@ MC4CAQAwBQYDK2VwBCIEILwDB7W+KEw+UkzfOQA9ghy70Em4ubdS42DLkDmdmYyb
     // [itest->swdd~grpc-server-deactivate-mtls-when-no-certificates-and-no-key-provided-upon-start~1]
     // [itest->swdd~grpc-cli-deactivate-mtls-when-no-certificates-and-no-key-provided-upon-start~1]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)] // set worker_threads = 1 to solve the failing of the test on woodpecker
-    async fn itest_grpc_communication_client_cli_connection_grpc_server_received_request_complete_state(
-    ) {
+    async fn itest_grpc_communication_client_cli_connection_grpc_server_received_request_complete_state()
+     {
         let test_request_id = "test_request_id";
         let (to_grpc_client, mut server_receiver, _, _) = generate_test_grpc_communication_setup(
             50051,
@@ -446,8 +446,8 @@ MC4CAQAwBQYDK2VwBCIEILwDB7W+KEw+UkzfOQA9ghy70Em4ubdS42DLkDmdmYyb
 
     // [itest->swdd~grpc-agent-activate-mtls-when-certificates-and-key-provided-upon-start~1]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)] // set worker_threads = 1 to solve the failing of the test on woodpecker
-    async fn itest_grpc_communication_client_agent_connection_grpc_server_received_agent_hello_with_tls(
-    ) {
+    async fn itest_grpc_communication_client_agent_connection_grpc_server_received_agent_hello_with_tls()
+     {
         let _ = env_logger::builder().is_test(true).try_init();
         let test_agent_name = "test_agent_name";
         let test_pem_files_package = TestPEMFilesPackage::new().unwrap();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ank-server"
 version = "0.6.0"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Eclipse Ankaios server component"
 documentation = "https://eclipse-ankaios.github.io/ankaios"

--- a/server/src/ankaios_server/config_renderer.rs
+++ b/server/src/ankaios_server/config_renderer.rs
@@ -35,13 +35,12 @@ impl fmt::Display for ConfigRenderError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConfigRenderError::Field(field, reason) => {
-                write!(f, "Failed to render field '{}': '{}'", field, reason)
+                write!(f, "Failed to render field '{field}': '{reason}'")
             }
             ConfigRenderError::NotExistingConfigKey(config_key) => {
                 write!(
                     f,
-                    "Workload references config key '{}' that does not exist",
-                    config_key
+                    "Workload references config key '{config_key}' that does not exist"
                 )
             }
         }
@@ -55,7 +54,7 @@ impl ConfigRenderError {
     pub fn for_files(mount_point: &str) -> impl Fn(RenderError) -> Self + '_ {
         move |err| {
             ConfigRenderError::Field(
-                format!("files with mount point {}", mount_point),
+                format!("files with mount point {mount_point}"),
                 err.to_string(),
             )
         }
@@ -92,24 +91,19 @@ impl ConfigRenderer {
         for (workload_name, stored_workload) in workloads {
             let workload_spec = if stored_workload.configs.is_empty() {
                 log::debug!(
-                    "Skipping to render workload '{}' as no config is assigned to the workload",
-                    workload_name
+                    "Skipping to render workload '{workload_name}' as no config is assigned to the workload"
                 );
                 WorkloadSpec::from((workload_name.to_owned(), stored_workload.clone()))
             } else {
                 let wl_config_map =
                     self.create_config_map_for_workload(stored_workload, configs)?;
-                log::debug!(
-                    "Rendering workload '{}' with config '{:?}'",
-                    workload_name,
-                    wl_config_map
-                );
+                log::debug!("Rendering workload '{workload_name}' with config '{wl_config_map:?}'");
                 self.render_workload_fields(workload_name, stored_workload, &wl_config_map)?
             };
 
             rendered_workloads.insert(workload_name.clone(), workload_spec);
         }
-        log::trace!("Rendered CompleteState: {:?}", rendered_workloads);
+        log::trace!("Rendered CompleteState: {rendered_workloads:?}");
         Ok(rendered_workloads)
     }
 
@@ -223,12 +217,11 @@ mod tests {
     use std::collections::HashMap;
 
     use common::objects::{
-        generate_test_configs, generate_test_rendered_workload_files,
-        generate_test_stored_workload_spec_with_config,
+        Base64Data, ConfigItem, Data, File, FileContent, generate_test_configs,
+        generate_test_rendered_workload_files, generate_test_stored_workload_spec_with_config,
         generate_test_stored_workload_spec_with_files,
         generate_test_workload_spec_with_rendered_files,
-        generate_test_workload_spec_with_runtime_config, Base64Data, ConfigItem, Data, File,
-        FileContent,
+        generate_test_workload_spec_with_runtime_config,
     };
 
     const WORKLOAD_NAME_1: &str = "workload_1";

--- a/server/src/ankaios_server/cycle_check.rs
+++ b/server/src/ankaios_server/cycle_check.rs
@@ -27,10 +27,7 @@ use std::collections::{HashSet, VecDeque};
 ///   if [`None`] the search is started from all workloads of the state
 ///
 pub fn dfs(state: &State, start_nodes: Option<Vec<&str>>) -> Option<String> {
-    log::trace!(
-        "Execute cyclic dependency check with start_nodes = {:?}",
-        start_nodes
-    );
+    log::trace!("Execute cyclic dependency check with start_nodes = {start_nodes:?}");
 
     /* The stack is used to push the neighbors of a workload inside the dependency graph
     that needs to be visited next and to terminate the search. If a workload is not already visited,
@@ -67,16 +64,16 @@ pub fn dfs(state: &State, start_nodes: Option<Vec<&str>>) -> Option<String> {
             continue;
         }
 
-        log::trace!("searching for workload = '{}'", workload_name);
+        log::trace!("searching for workload = '{workload_name}'");
         stack.push_front(workload_name);
         while let Some(head) = stack.front() {
             if let Some(workload_spec) = state.workloads.get(*head) {
                 if !visited.contains(head) {
-                    log::trace!("visit '{}'", head);
+                    log::trace!("visit '{head}'");
                     visited.insert(head);
                     path.push_back(head);
                 } else {
-                    log::trace!("remove '{}' from path", head);
+                    log::trace!("remove '{head}' from path");
                     path.pop_back();
                     stack.pop_front();
                 }
@@ -96,10 +93,7 @@ pub fn dfs(state: &State, start_nodes: Option<Vec<&str>>) -> Option<String> {
                 }
             } else {
                 // [impl->swdd~cycle-detection-ignores-non-existing-workloads~1]
-                log::trace!(
-                    "workload '{}' is skipped because it is not part of the state.",
-                    head
-                );
+                log::trace!("workload '{head}' is skipped because it is not part of the state.");
                 stack.pop_front();
             }
         }
@@ -118,7 +112,7 @@ pub fn dfs(state: &State, start_nodes: Option<Vec<&str>>) -> Option<String> {
 mod tests {
     use super::*;
     use common::{
-        objects::{generate_test_stored_workload_spec, AddCondition},
+        objects::{AddCondition, generate_test_stored_workload_spec},
         test_utils::generate_test_complete_state,
     };
     use std::{collections::HashSet, ops::Deref};
@@ -145,10 +139,7 @@ mod tests {
             assert!(
                 expected_nodes_part_of_a_cycle.contains(&workload_part_of_cycle.deref()),
                 "{}",
-                format!(
-                    "expected workload '{}' is not part of a cycle",
-                    workload_part_of_cycle
-                )
+                format!("expected workload '{workload_part_of_cycle}' is not part of a cycle")
             );
 
             actual.insert(workload_part_of_cycle);
@@ -175,8 +166,7 @@ mod tests {
                 result.is_none(),
                 "{}",
                 format!(
-                    "expected no cycle, but cycle detected, workload '{:?}' is part of cycle.",
-                    result
+                    "expected no cycle, but cycle detected, workload '{result:?}' is part of cycle."
                 )
             );
         }

--- a/server/src/ankaios_server/log_campaign_store.rs
+++ b/server/src/ankaios_server/log_campaign_store.rs
@@ -73,10 +73,10 @@ impl Display for RequestId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             RequestId::CliRequestId(cli_request_id) => {
-                write!(f, "CLI request Id: {}", cli_request_id)
+                write!(f, "CLI request Id: {cli_request_id}")
             }
             RequestId::AgentRequestId(agent_request_id) => {
-                write!(f, "agent request Id: {}", agent_request_id)
+                write!(f, "agent request Id: {agent_request_id}")
             }
         }
     }
@@ -144,7 +144,7 @@ impl LogCampaignStore {
         log_providers: &Vec<WorkloadInstanceName>,
     ) {
         let request_id: RequestId = input_request_id.into();
-        log::debug!("Insert log campaign '{}'", request_id);
+        log::debug!("Insert log campaign '{request_id}'");
 
         match request_id {
             RequestId::CliRequestId(cli_request_id) => {
@@ -227,7 +227,7 @@ impl LogCampaignStore {
 
     pub fn remove_logs_request_id(&mut self, input_request_id: &LogCollectorRequestId) {
         let request_id: RequestId = input_request_id.into();
-        log::debug!("Remove log campaign '{}'", request_id);
+        log::debug!("Remove log campaign '{request_id}'");
 
         self.remove_request_from_log_providers_store(input_request_id);
 
@@ -247,10 +247,7 @@ impl LogCampaignStore {
         &mut self,
         workload_name: &WorkloadName,
     ) -> HashSet<LogCollectorRequestId> {
-        log::debug!(
-            "Removing collector campaign for workload '{}'",
-            workload_name
-        );
+        log::debug!("Removing collector campaign for workload '{workload_name}'");
 
         let removed_request_ids = self.workload_name_request_id_store.remove(workload_name);
         if let Some(removed_request_ids) = &removed_request_ids {
@@ -440,11 +437,10 @@ mod tests {
         );
 
         let extra_part = "@extra@parts.with_strange#format";
-        let agent_request_id =
-            super::RequestId::from(format!("{}{}", REQUEST_ID_AGENT_A, extra_part));
+        let agent_request_id = super::RequestId::from(format!("{REQUEST_ID_AGENT_A}{extra_part}"));
         assert!(
             matches!(agent_request_id, super::RequestId::AgentRequestId(super::AgentRequestId { agent_name, workload_name, request_uuid })
-            if agent_name == AGENT_A && workload_name == WORKLOAD_1_NAME && request_uuid == format!("request_id{}", extra_part))
+            if agent_name == AGENT_A && workload_name == WORKLOAD_1_NAME && request_uuid == format!("request_id{extra_part}"))
         );
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -25,8 +25,8 @@ use common::communications_server::CommunicationsServer;
 use common::objects::State;
 use common::std_extensions::GracefulExitResult;
 
-use ankaios_server::{create_from_server_channel, create_to_server_channel, AnkaiosServer};
-use server_config::{ServerConfig, DEFAULT_SERVER_CONFIG_FILE_PATH};
+use ankaios_server::{AnkaiosServer, create_from_server_channel, create_to_server_channel};
+use server_config::{DEFAULT_SERVER_CONFIG_FILE_PATH, ServerConfig};
 
 use grpc::{security::TLSConfig, server::GRPCCommunicationsServer};
 
@@ -43,7 +43,10 @@ fn handle_sever_config(config_path: &Option<String>, default_path: &str) -> Serv
         None => {
             let default_path = PathBuf::from(default_path);
             if !default_path.try_exists().unwrap_or(false) {
-                log::debug!("No config file found at default path '{}'. Using cli arguments and environment variables only.", default_path.display());
+                log::debug!(
+                    "No config file found at default path '{}'. Using cli arguments and environment variables only.",
+                    default_path.display()
+                );
                 ServerConfig::default()
             } else {
                 log::info!(
@@ -107,7 +110,7 @@ async fn main() {
         &server_config.crt_pem_content,
         &server_config.key_pem_content,
     ) {
-        log::warn!("{}", err_message);
+        log::warn!("{err_message}");
     }
 
     // [impl->swdd~server-establishes-insecure-communication-based-on-provided-insecure-cli-argument~1]
@@ -150,12 +153,9 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use crate::{
-        handle_sever_config, server_config::DEFAULT_SERVER_CONFIG_FILE_PATH, ServerConfig,
+        ServerConfig, handle_sever_config, server_config::DEFAULT_SERVER_CONFIG_FILE_PATH,
     };
-    use std::{
-        io::Write,
-        net::SocketAddr,
-    };
+    use std::{io::Write, net::SocketAddr};
     use tempfile::NamedTempFile;
 
     const VALID_SERVER_CONFIG_CONTENT: &str = r"#
@@ -168,8 +168,7 @@ mod tests {
     #[test]
     fn utest_handle_server_config_valid_config() {
         let mut tmp_config = NamedTempFile::new().expect("could not create temp file");
-        write!(tmp_config, "{}", VALID_SERVER_CONFIG_CONTENT)
-            .expect("could not write to temp file");
+        write!(tmp_config, "{VALID_SERVER_CONFIG_CONTENT}").expect("could not write to temp file");
 
         let server_config = handle_sever_config(
             &Some(tmp_config.into_temp_path().to_str().unwrap().to_string()),
@@ -190,7 +189,7 @@ mod tests {
     #[test]
     fn utest_handle_server_config_default_path() {
         let mut file = tempfile::NamedTempFile::new().expect("Failed to create file");
-        writeln!(file, "{}", VALID_SERVER_CONFIG_CONTENT).expect("Failed to write to file");
+        writeln!(file, "{VALID_SERVER_CONFIG_CONTENT}").expect("Failed to write to file");
 
         let server_config = handle_sever_config(&None, file.path().to_str().unwrap());
 

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -13,8 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli::Arguments;
-use common::std_extensions::{UnreachableOption, UnreachableResult};
 use common::DEFAULT_SOCKET_ADDRESS;
+use common::std_extensions::{UnreachableOption, UnreachableResult};
 use grpc::security::read_pem_file;
 
 use serde::{Deserialize, Deserializer};
@@ -40,20 +40,16 @@ impl fmt::Display for ConversionErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConversionErrors::WrongVersion(msg) => {
-                write!(f, "Wrong version: {}", msg)
+                write!(f, "Wrong version: {msg}")
             }
             ConversionErrors::ConflictingCertificates(msg) => {
-                write!(f, "Conflicting certificates: {}", msg)
+                write!(f, "Conflicting certificates: {msg}")
             }
             ConversionErrors::InvalidServerConfig(msg) => {
-                write!(
-                    f,
-                    "Server Config could not have been parsed due to: {}",
-                    msg
-                )
+                write!(f, "Server Config could not have been parsed due to: {msg}")
             }
             ConversionErrors::InvalidCertificate(msg) => {
-                write!(f, "Certificate could not have been read due to: {}", msg)
+                write!(f, "Certificate could not have been read due to: {msg}")
             }
         }
     }
@@ -196,8 +192,8 @@ mod tests {
 
     use crate::{cli::Arguments, server_config::ConversionErrors};
 
-    use super::ServerConfig;
     use super::DEFAULT_SERVER_CONFIG_FILE_PATH;
+    use super::ServerConfig;
 
     const STARTUP_MANIFEST_PATH: &str = "some_path_to_config/config.yaml";
     const TEST_SOCKET_ADDRESS: &str = "127.0.0.1:3333";
@@ -232,7 +228,7 @@ mod tests {
         #";
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", server_config_content).unwrap();
+        write!(tmp_config_file, "{server_config_content}").unwrap();
 
         let server_config = ServerConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -248,14 +244,13 @@ mod tests {
         let server_config_content = format!(
             r"#
         version = 'v1'
-        ca_pem = '''{}'''
-        ca_pem_content = '''{}'''
-        #",
-            CA_PEM_PATH, CRT_PEM_CONTENT
+        ca_pem = '''{CA_PEM_PATH}'''
+        ca_pem_content = '''{CRT_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", server_config_content).unwrap();
+        write!(tmp_config_file, "{server_config_content}").unwrap();
 
         let server_config = ServerConfig::from_file(PathBuf::from(tmp_config_file.path()));
 
@@ -303,15 +298,14 @@ mod tests {
         let server_config_content = format!(
             r"#
         version = 'v1'
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", server_config_content).unwrap();
+        write!(tmp_config_file, "{server_config_content}").unwrap();
 
         let mut server_config =
             ServerConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
@@ -350,15 +344,14 @@ mod tests {
         startup_manifest = '/workspaces/ankaios/server/resources/startConfig.yaml'
         address = '127.0.0.1:25551'
         insecure = true
-        ca_pem_content = '''{}'''
-        crt_pem_content = '''{}'''
-        key_pem_content = '''{}'''
-        #",
-            CA_PEM_CONTENT, CRT_PEM_CONTENT, KEY_PEM_CONTENT
+        ca_pem_content = '''{CA_PEM_CONTENT}'''
+        crt_pem_content = '''{CRT_PEM_CONTENT}'''
+        key_pem_content = '''{KEY_PEM_CONTENT}'''
+        #"
         );
 
         let mut tmp_config_file = NamedTempFile::new().unwrap();
-        write!(tmp_config_file, "{}", server_config_content).unwrap();
+        write!(tmp_config_file, "{server_config_content}").unwrap();
 
         let server_config_res = ServerConfig::from_file(PathBuf::from(tmp_config_file.path()));
 

--- a/tests/resources/control_interface_tester/Cargo.toml
+++ b/tests/resources/control_interface_tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "control_interface_tester"
-edition = "2021"
+edition = "2024"
 license = "Apache-2.0"
 description = "Application using the Control Interface used for system tests"
 


### PR DESCRIPTION
Issues: #482 

<!--  Description of the change in case no issue is mentioned -->

**Rust edition 2024 fixes:**
- ref mut fixes
- Replace `env::set_var` in ank cli with safe alternative (`std::sync::OnceLock`)

**Devcontainer base tools updates:**
- Rust update to 1.88
- oft update to 4.2.0
- just update to 1.42.4

**Fixed clippy warnings:**
- replace all format strings to use the variable in-place

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
