### PR TITLE
Split swdd requirements for agent resource monitoring

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -160,6 +160,10 @@ The `LogFetching` unit is providing common functionalities and the common interf
 
 The `SubscriptionStore` is responsible for holding local log subscriptions. A local to the agent log subscription is the collection of logs from one or more workload running in the agent for a specific log campaign running on the Ankaios server. The `SubscriptionStore` not only holds metadata about the collection, but also allows stopping the log fetching when a subscription entry is deleted.
 
+### ResourceMonitor
+
+The `ResourceMonitor` is responsible for providing resource availability metrics like CPU usage or free memory of the agent's node. Those metrics are useful to schedule workloads based on the current available resources.
+
 ### External Libraries
 
 #### Communication Middleware
@@ -3007,13 +3011,32 @@ Needs:
 
 Status: approved
 
-At an interval of 2 seconds, the AgentManager measures the global CPU usage and the available free memory and sends them to the Ankaios server via an `AgentLoadStatus` message.
+At an interval of 2 seconds, the AgentManager shall:
+* request the ResourceMonitor to provide the resource metrics for the agent's node
+* send the metrics to the Ankaios server via an `AgentLoadStatus` message
 
 Rationale:
 Available resources must be available in the cluster in order to enable dynamic scheduling, e.g., done by a workload.
 
 Tags:
 - AgentManager
+- ResourceMonitor
+
+Needs:
+- impl
+- utest
+
+#### ResourceMonitor provides resource metrics
+`swdd~agent-provides-resource-metrics~1`
+
+Status: approved
+
+When the ResourceMonitor is requested to provide metrics about the resource availability, the ResourceMonitor shall provide the following measured resource metrics:
+* global CPU usage in percentage
+* available free memory in bytes
+
+Tags:
+- ResourceMonitor
 
 Needs:
 - impl

--- a/agent/src/resource_monitor.rs
+++ b/agent/src/resource_monitor.rs
@@ -30,6 +30,7 @@ pub struct ResourceMonitor {
 }
 
 #[cfg_attr(test, automock)]
+// [impl->swdd~agent-provides-resource-metrics~1]
 impl ResourceMonitor {
     pub fn new() -> Self {
         let refresh_kind = RefreshKind::nothing()
@@ -60,6 +61,7 @@ impl ResourceMonitor {
 //////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
+// [utest->swdd~agent-provides-resource-metrics~1]
 mod tests {
 
     pub struct MockSystem {


### PR DESCRIPTION
Split of requirements because of the changes in #566

The unit test were refactored to use mocks instead of real system calls and this has required to pull the resource monitor implementation into a separate file.

This PR splits the requirements and links them to the implementation and tests.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
