### PR TITLE
Add containerd doc changes

### DIFF
--- a/doc/docs/development/build.md
+++ b/doc/docs/development/build.md
@@ -2,7 +2,7 @@
 
 ## Dev container
 
-The repo provides a Visual Studio Code [dev container](https://code.visualstudio.com/docs/devcontainers/containers) which includes all necessary tools to build all components and the documentation. It also contains Podman, which is needed to run the system tests for Ankaios. In case you want to extend the dev container see [extending the dev container](extending-dev-container.md).
+The repo provides a Visual Studio Code [dev container](https://code.visualstudio.com/docs/devcontainers/containers) which includes all necessary tools to build all components and the documentation. It also contains the supported container runtimes, which are needed to run the system tests for Ankaios. In case you want to extend the dev container see [extending the dev container](extending-dev-container.md).
 
 ### Prerequisites
 

--- a/doc/docs/development/system-tests.md
+++ b/doc/docs/development/system-tests.md
@@ -139,7 +139,7 @@ Test Ankaios Podman stops retries after reaching the retry attempt limit
 
 !!! warning
     The system tests will delete all Podman containers, pods and volume.
-    We recomment to only execute the system tests in the dev container.
+    We recommend to only execute the system tests in the dev container.
 
 A shell script is provided for the easy execution of the system tests. The script does the following:
 

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -21,8 +21,8 @@ Eclipse Ankaios provides workload and container orchestration for automotive
 High Performance Computing Platforms (HPCs). While it can be used for various
 fields of applications, it is developed from scratch for automotive use cases
 and provides a slim, yet powerful solution to manage containerized applications.
-It supports various container runtimes with Podman as the first one, but other
-container runtimes and even native applications can be supported. Eclipse
+It supports various container runtimes like Podman and Containerd, but support for other
+container runtimes and even native applications can be added easily. Eclipse
 Ankaios is independent of existing communication frameworks like SOME/IP, DDS,
 or REST API.
 

--- a/doc/docs/reference/complete-state.md
+++ b/doc/docs/reference/complete-state.md
@@ -4,7 +4,7 @@
 
 The complete state data structure [CompleteState](./_ankaios.proto.md#completestate) is used for building a request to Ankaios server to change or receive the state of the Ankaios system. It contains the `desiredState` which describes the state of the Ankaios system the user wants to have, the `workloadStates` which gives the information about the execution state of all the workloads and the `agents` field containing the names of the Ankaios agents that are currently connected to the Ankaios server. By using of [CompleteState](./_ankaios.proto.md#completestate) in conjunction with the object field mask specific parts of the Ankaios state could be retrieved or updated.
 
-Example: `ank -k get state` returns the complete state of Ankaios system:
+Example: `ank -k get state` returns the complete state of Ankaios system with runtimes `podman`, `containerd` and `podman-kube`:
 
 !!! Note
 
@@ -61,7 +61,7 @@ desiredState:
         value: Ankaios team
       dependencies: {}
       restartPolicy: ALWAYS
-      runtime: podman
+      runtime: containerd
       runtimeConfig: |
         image: alpine:latest
         commandOptions: [ "--entrypoint", "/bin/sh" ]

--- a/doc/docs/reference/control-interface.md
+++ b/doc/docs/reference/control-interface.md
@@ -5,7 +5,7 @@ The [control interface](./control-interface.md) allows the [workload](glossary.m
 !!! note
 
     The control interface is currently only available for workloads using the
-    `podman` runtime and not for the `podman-kube` runtime.
+    `podman` and `containerd` runtime and not for the `podman-kube` runtime.
 
 ## Overview
 

--- a/doc/docs/reference/glossary.md
+++ b/doc/docs/reference/glossary.md
@@ -12,7 +12,7 @@ The base an which a workload can be started. For OCI container this is a contain
 
 ## Workload
 
-A functionality that the Ankaios orchestrator can manage (e.g. start, stop). A workload could be packed inside an OCI [container](#container) (e.g. [Podman container](#podman-container)) or could also be just a native program ([native workload](#native-workload)). Ankaios is build to be extensible for different workload types by adding support for other [runtimes](#runtime).
+A functionality that the Ankaios orchestrator can manage (e.g. start, stop). A workload could be packed inside an OCI [container](#container) (e.g. [Podman container](#podman-container) or [Containerd container](#containerd-container)) or could also be just a native program ([native workload](#native-workload)). Ankaios is build to be extensible for different workload types by adding support for other [runtimes](#runtime).
 
 ## Container
 
@@ -21,6 +21,10 @@ A container is a lightweight, standalone, executable software package that inclu
 ## Podman container
 
 A Podman container refers to a [container](#container) managed by [Podman](https://docs.podman.io/en/latest/), which is an open-source container engine similar to Docker. [Podman](https://docs.podman.io/en/latest/) aims to provide a simple and secure container management solution for developers and system administrators.
+
+## Containerd container
+
+A Containerd container refers to a [container](#container) managed by [Containerd](https://github.com/containerd/containerd), which is an open-source daemon-based container engine.
 
 ## Native workload
 

--- a/doc/docs/reference/startup-configuration.md
+++ b/doc/docs/reference/startup-configuration.md
@@ -12,11 +12,11 @@ The startup manifest is composed of a list of workload specifications within the
 A workload specification must contain the following information:
 
 * `workload name`_(via field key)_, specify the workload name to identify the workload in the Ankaios system.
-* `runtime`, specify the type of the runtime. Currently supported values are `podman` and `podman-kube`.
+* `runtime`, specify the type of the runtime. Currently supported values are `podman`, `containerd` and `podman-kube`.
 * `agent`, specify the name of the owning agent which is going to execute the workload. Supports templated strings.
 * `restartPolicy`, specify how the workload should be restarted upon exiting.
 * `tags`, specify a list of `key` `value`  pairs.
-* `runtimeConfig`, specify as a _string_ the configuration for the [runtime](./glossary.md#runtime) whose configuration structure is specific for each runtime, e.g., for `podman` runtime the [PodmanRuntimeConfig](#podmanruntimeconfig) is used. Supports templated strings.
+* `runtimeConfig`, specify as a _string_ the configuration for the [runtime](./glossary.md#runtime) whose configuration structure is specific for each runtime, e.g., for `podman` runtime the [PodmanRuntimeConfig](#podmanruntimeconfig) and for `containerd` the [ContainerdRuntimeConfig](#containerdruntimeconfig) is used. Supports templated strings.
 * `configs`: assign configuration items defined in the state's `configs` field to the workload
 * `files`: map workload files to a workload, see [here](../usage/manifest/workload-files.md) for details
 * `controlInterfaceAccess`, specify the access rights of the workload for the control interface.
@@ -81,6 +81,32 @@ it would translate to the following runtime configuration:
 
 ```yaml
 generalOptions: ["--events-backend", "file"]
+image: docker.io/alpine:latest
+commandOptions: ["--env", "VAR=able"]
+commandArgs: ["echo", "Hello!"]
+```
+
+### ContainerdRuntimeConfig
+
+The runtime configuration for the `containerd` runtime is specified as follows:
+
+```yaml
+generalOptions: [<comma>, <separated>, <options>]
+image: <registry>/<image name>:<version>
+commandOptions: [<comma>, <separated>, <options>]
+commandArgs: [<comma>, <separated>, <arguments>]
+```
+
+where each attribute is passed directly to `nerdctl run`.
+
+If we take as an example the `podman run` command:
+
+```nerdctl --snapshotter native run --env VAR=able docker.io/alpine:latest echo Hello!```
+
+it would translate to the following runtime configuration:
+
+```yaml
+generalOptions: ["--snapshotter", "native"]
 image: docker.io/alpine:latest
 commandOptions: ["--env", "VAR=able"]
 commandArgs: ["echo", "Hello!"]

--- a/doc/docs/usage/installation.md
+++ b/doc/docs/usage/installation.md
@@ -18,6 +18,12 @@ The minimum system requirements are (tested with [EB corbos Linux – built on U
 | CPU      | 1 core  |
 | RAM      | 256 MB  |
 
+## Container runtime
+
+Ankaios supports multiple container runtimes. Depending on which runtime is to be used, only certain container runtimes or all supported runtimes can be installed using the following instructions.
+
+### Podman
+
 [Podman](https://podman.io) needs to be installed as this is used as
 container runtime
 (see [Podman installation instructions](https://podman.io/docs/installation)).
@@ -33,6 +39,15 @@ For using the `podman` runtime, Podman version 3.4.2 is sufficient but the
     mkdir -p /etc/containers/containers.conf.d
     printf '[CONTAINERS]\napparmor_profile=""\n' > /etc/containers/containers.conf.d/disable-apparmor.conf
     ```
+
+### Containerd
+
+Follow the [containerd installation instructions](https://github.com/containerd/containerd/blob/main/docs/getting-started.md#installing-containerd) to install the containerd daemon.
+
+Ankaios uses the `nerdctl` command-line interface (CLI) to manage containers with the containerd runtime. Install a compatible version of the `nerdctl` CLI for the containerd runtime, or install the full `nerdctl` package, including dependencies such as containerd, runc, and CNI. Note that if you are not using the version distributed by your package manager, you must check the platform compatibility of containerd. Download and install the `nerdctl` package from the [official nerdctl releases](https://github.com/containerd/nerdctl/releases).
+
+!!! note
+    AppArmor shall be disabled on Ubuntu 24.04 in the same way as for the Podman runtime mentioned above.
 
 ## Installation methods
 

--- a/doc/docs/usage/quickstart.md
+++ b/doc/docs/usage/quickstart.md
@@ -101,13 +101,14 @@ WORKLOAD NAME   AGENT     RUNTIME   EXECUTION STATE   ADDITIONAL INFO
 nginx           agent_A   podman    Running(Ok)
 ```
 
-Ankaios also supports adding and removing workloads dynamically.
+Ankaios also supports adding and removing workloads dynamically. The following command assumes that the `containerd` runtime is installed according to the [installation instructions](installation.md).
+
 To add another workload call:
 
 ```shell
 ank -k run workload \
 helloworld \
---runtime podman \
+--runtime containerd \
 --agent agent_A \
 --config 'image: docker.io/busybox:1.36
 commandOptions: [ "-e", "MESSAGE=Hello World"]
@@ -115,8 +116,14 @@ commandArgs: [ "sh", "-c", "echo $MESSAGE"]'
 ```
 
 We can check the state again with `ank -k get state` and see, that the workload
-`helloworld` has been added to `desiredState.workloads` and the execution
-state is available in `workloadStates`.
+`helloworld` with runtime `containerd` has been added to `desiredState.workloads` and the execution
+state is available in `workloadStates`:
+
+```text
+WORKLOAD NAME   AGENT     RUNTIME      EXECUTION STATE   ADDITIONAL INFO
+helloworld      agent_A   containerd   Succeeded(Ok)
+nginx           agent_A   podman       Running(Ok)
+```
 
 As the workload had a one time job its state is `Succeeded(Ok)` and we can
 delete it from the state again with:


### PR DESCRIPTION
Issues: #430 

<!--  Description of the change in case no issue is mentioned -->

The PR contains documentation changes for the newly introduced runtime `containerd` in PR #561.
The `quickstart.md` was enhanced to contain a containerd workload in such a way that the default part with podman and the installation script of Ankaios is not broken.

Properly, this PR needs to be merged after the impl PR was merged.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
