### PR TITLE
Allow wrapped base64 input in configs

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -1945,11 +1945,16 @@ Needs:
 - utest
 
 #### WorkloadFilesCreator decodes base64 to binary
-`swdd~workload-files-creator-decodes-base64-to-binary~1`
+`swdd~workload-files-creator-decodes-base64-to-binary~2`
 
 Status: approved
 
-When the WorkloadFilesCreator is requested to write a workload file with content type binary, the WorkloadFilesCreator shall decode the base64 content to a collection of bytes which is written to the file.
+When the WorkloadFilesCreator is requested to write a workload file with content type binary, the WorkloadFilesCreator shall:
+* remove all newlines and whitespaces in case of the base64 content is wrapped
+* decode the base64 content to a collection of bytes which is written to the file.
+
+Rationale:
+Base64 encoding tools may encode with wrapping the base64 content at a certain amount of characters.
 
 Tags:
 - WorkloadFilesCreator


### PR DESCRIPTION
Issues: #582 

<!--  Description of the change in case no issue is mentioned -->
The PR allows wrapped base64 input because some base64 encoding tools output wrapped base64 content if a certain amount of characters is exceeded.

This keeps also the Ankaios manifest cleaner than having a long one-liner base64 content.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
