### PR TITLE
Fix control interface examples containerd cleanup

### DIFF
--- a/examples/cleanup.sh
+++ b/examples/cleanup.sh
@@ -18,7 +18,7 @@ fi
 # Cleanup containerd
 if pgrep -x "containerd" > /dev/null; then
     echo "Cleaning up containerd ..."
-    nerdctl stop "$(nerdctl ps -a -q)" >/dev/null 2>&1
-    nerdctl rm "$(nerdctl ps -a -q)" >/dev/null 2>&1
+    nerdctl ps -aq | xargs -r nerdctl stop >/dev/null 2>&1
+    nerdctl ps -aq | xargs -r nerdctl rm >/dev/null 2>&1
     echo "done."
 fi


### PR DESCRIPTION
In PR #569 the warning for the sub shell commands in the cleanup were fixed, but this leads to a missing cleanup for containerd  for the control interface examples because the nerdctl command expects the container ids exactly in the "word splitting" format of the warning.

This PR removes the warnings and also reverts back to a working containerd cleanup.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
