### PR TITLE
Fix sporadic failing unit test in agent_manager.rs

### DIFF
--- a/agent/src/agent_manager.rs
+++ b/agent/src/agent_manager.rs
@@ -580,11 +580,16 @@ mod tests {
             .once()
             .return_const(());
 
+        let mut mock_resource_monitor = MockResourceMonitor::default();
+        mock_resource_monitor
+            .expect_sample_resource_usage()
+            .returning(|| (CpuUsage::new(50.0), FreeMemory { free_memory: 1024 }));
+
         let mock_resource_monitor_context = MockResourceMonitor::new_context();
         mock_resource_monitor_context
             .expect()
             .once()
-            .return_once(MockResourceMonitor::default);
+            .return_once(|| mock_resource_monitor);
 
         let mut agent_manager = AgentManager::new(
             AGENT_NAME.to_string(),


### PR DESCRIPTION
Depending on timing, utest_agent_manager_receives_own_workload_states can fail if the ResourceMonitor is not mocked.


# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
