### PR TITLE
Remove duplicate from_map_to_vec function

### DIFF
--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -429,31 +429,6 @@ mod tests {
             .collect()
     }
 
-    fn from_map_to_vec(value: WorkloadStatesMapSpec) -> Vec<WorkloadStateSpec> {
-        value
-            .agent_state_map
-            .into_iter()
-            .flat_map(|(agent_name, name_state_map)| {
-                name_state_map.wl_name_state_map.into_iter().flat_map(
-                    move |(wl_name, id_state_map)| {
-                        let agent_name = agent_name.clone();
-                        id_state_map
-                            .id_state_map
-                            .into_iter()
-                            .map(move |(wl_id, exec_state)| WorkloadStateSpec {
-                                instance_name: WorkloadInstanceNameSpec::new(
-                                    agent_name.clone(),
-                                    wl_name.clone(),
-                                    wl_id,
-                                ),
-                                execution_state: exec_state,
-                            })
-                    },
-                )
-            })
-            .collect()
-    }
-
     // [utest->swdd~server-provides-interface-get-complete-state~2]
     // [utest->swdd~server-filters-get-complete-state-result~2]
     #[test]


### PR DESCRIPTION
# Description

Remove duplicate `from_map_to_vec` function.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
