### PR TITLE
Set specific rust analyzer version to fix toolchain warning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
             "extensions": [
                 "vadimcn.vscode-lldb",
                 "mutantdino.resourcemonitor",
-                "rust-lang.rust-analyzer",
+                "rust-lang.rust-analyzer@0.3.2702",
                 "tamasfe.even-better-toml",
                 "timonwong.shellcheck",
                 "eamodio.gitlens",


### PR DESCRIPTION
The PR fixes the unsupported toolchain warning in the rust analyzer because of the bumped up minimum version to rust 1.90. We have 1.88.

A fixed rust analyzer version solves the issue.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
