### PR TITLE
Fix deprecated proto extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
                 "ms-python.python",
                 "ms-python.vscode-pylance",
                 "yzhang.markdown-all-in-one",
-                "zxh404.vscode-proto3",
+                "drblury.protobuf-vsc",
                 "bierner.markdown-preview-github-styles",
                 "hediet.vscode-drawio",
                 "redhat.vscode-yaml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,9 @@
         "tag:yaml.org,2002:python/name:materialx.emoji.twemoji",
         "tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format"
     ],
-    "plantuml.jar": "/usr/local/bin/plantuml.jar"
+    "plantuml.jar": "/usr/local/bin/plantuml.jar",
+    "protobuf.diagnostics.namingConventions": false,
+    "protobuf.includes": [
+        "/workspaces/ankaios/ankaios_api/proto"
+    ]
 }

--- a/ankaios_api/proto/ank_base.proto
+++ b/ankaios_api/proto/ank_base.proto
@@ -421,7 +421,7 @@ message LogRule {
  */
 enum ReadWriteEnum {
   RW_NOTHING = 0; // Allow nothing
-  RW_READ = 1;  // Allow read
+  RW_READ = 1; // Allow read
   RW_WRITE = 2; // Allow write
   RW_READ_WRITE = 5; // Allow read and write
 }


### PR DESCRIPTION
# Description

The proto3 extension that we were using is deprecated. This PR fixes this, by changing the extension.

With this extension, the proto3 linter works as expected (so I had to disable the naming conventions lint).

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
