### PR TITLE
Fix stest after merging main to event feature branch

### DIFF
--- a/tests/stests/agents/update_agents.robot
+++ b/tests/stests/agents/update_agents.robot
@@ -26,7 +26,6 @@ ${agent_name}       agent_A
 
 # [stest->swdd~server-state-updates-agent-tags~1]
 Test Ankaios updates only agent tags through state updates
-    [Tags]    only
     [Setup]           Run Keywords    Setup Ankaios for Control Interface test
 
     # Preconditions: Start server and agent with initial tags


### PR DESCRIPTION
There is just an stest failing because of using a not existing keyword of the stests after merging main into the event feature branch.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
