### PR TITLE
Implement response timeout in ank-cli

### DIFF
--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -307,6 +307,45 @@ Tags:
 Needs:
 - impl
 
+#### CLI supports cli argument for response timeout
+`swdd~cli-supports-cli-argument-for-response-timeout~1`
+
+Status: approved
+
+When the user runs the Ankaios CLI, the Ankaios CLI shall support the cli argument `--response-timeout` with a value in milliseconds to specify the timeout for waiting for a response from the Ankaios server.
+
+Comment:
+The default response timeout is 3000 milliseconds.
+
+Rationale:
+The CLI shall not wait indefinitely for a response from the Ankaios server.
+
+Tags:
+- Cli
+- CliCommands
+
+Needs:
+- impl
+
+#### CLI throws a connection timeout error on response timeout
+`swdd~cli-throws-connection-timeout-error-on-response-timeout~1`
+
+Status: approved
+
+While waiting for a response from the Ankaios server and the response timeout is reached, the Ankaios CLI shall:
+* exit with a non zero exit code
+* output an error message containing the timeout reached message
+
+Rationale:
+The CLI shall not wait indefinitely for a response from the Ankaios server.
+
+Tags:
+- ServerConnection
+
+Needs:
+- impl
+- utest
+
 ### `ank get state`
 
 ![Get desired state](plantuml/seq_get_state.svg)

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -178,7 +178,11 @@ pub struct AnkCli {
     #[arg(short = 's', long = "server-url", required=false, env = ANK_SERVER_URL_ENV_KEY)]
     /// The url to Ankaios server.
     pub server_url: Option<String>,
-    #[arg(long = "response-timeout", required = false, default_value = "3000")]
+    #[arg(
+        long = "response-timeout",
+        required = false,
+        default_missing_value = "3000"
+    )]
     /// The timeout in milliseconds to wait for a response.
     pub response_timeout_ms: Option<u64>,
     #[arg(short = 'v', long = "verbose", action=ArgAction::Set, num_args=0, default_missing_value="true")]

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -162,6 +162,7 @@ fn object_field_mask_completer(current: &OsStr) -> Vec<CompletionCandidate> {
 // [impl->swdd~cli-supports-server-url-cli-argument~1]
 // [impl->swdd~cli-supports-pem-file-paths-as-cli-arguments~1]
 // [impl->swdd~cli-supports-cli-argument-for-insecure-communication~1]
+// [impl->swdd~cli-supports-cli-argument-for-response-timeout~1]
 #[derive(Parser, Debug)] // requires `derive` feature
 #[command(name = "ank")]
 #[command(bin_name = "ank")]
@@ -177,7 +178,7 @@ pub struct AnkCli {
     #[arg(short = 's', long = "server-url", required=false, env = ANK_SERVER_URL_ENV_KEY)]
     /// The url to Ankaios server.
     pub server_url: Option<String>,
-    #[arg(long = "response-timeout", required = false)]
+    #[arg(long = "response-timeout", required = false, default_value = "3000")]
     /// The timeout in milliseconds to wait for a response.
     pub response_timeout_ms: Option<u64>,
     #[arg(short = 'v', long = "verbose", action=ArgAction::Set, num_args=0, default_missing_value="true")]

--- a/ank/src/cli_commands.rs
+++ b/ank/src/cli_commands.rs
@@ -42,8 +42,8 @@ mod run_workload;
 mod set_state;
 
 use ankaios_api::ank_base::{
-    CompleteState, ExecutionStateEnumSpec, Workload, WorkloadInstanceNameSpec,
-    WorkloadState, WorkloadStatesMap,
+    CompleteState, ExecutionStateEnumSpec, Workload, WorkloadInstanceNameSpec, WorkloadState,
+    WorkloadStatesMap,
 };
 use common::{
     communications_error::CommunicationMiddlewareError, from_server_interface::FromServer,
@@ -170,8 +170,6 @@ impl TryFrom<WorkloadStatesMap> for WorkloadInfos {
 
 // The CLI commands are implemented in the modules included above. The rest are the common function.
 pub struct CliCommands {
-    // Left here for the future use.
-    _response_timeout_ms: u64,
     no_wait: bool,
     server_connection: ServerConnection,
 }
@@ -185,12 +183,12 @@ impl CliCommands {
         tls_config: Option<TLSConfig>,
     ) -> Result<Self, CommunicationMiddlewareError> {
         Ok(Self {
-            _response_timeout_ms: response_timeout_ms,
             no_wait,
             server_connection: ServerConnection::new(
                 cli_name.as_str(),
                 server_url.clone(),
                 tls_config,
+                response_timeout_ms,
             )?,
         })
     }

--- a/ank/src/cli_commands/apply_manifests.rs
+++ b/ank/src/cli_commands/apply_manifests.rs
@@ -166,12 +166,12 @@ pub fn generate_state_obj_and_filter_masks_from_manifests(
     manifests: &mut [InputSourcePair],
     apply_args: &ApplyArgs,
 ) -> Result<Option<(CompleteState, Vec<String>)>, String> {
-    let mut req_obj: Object = State{
+    let mut req_obj: Object = State {
         api_version: CURRENT_API_VERSION.to_string(),
         ..Default::default()
-    }.try_into().map_err(|err| {
-        format!("Could not create initial empty state object from State: {err}")
-    })?;
+    }
+    .try_into()
+    .map_err(|err| format!("Could not create initial empty state object from State: {err}"))?;
     let mut req_paths: Vec<Path> = Vec::new();
     for manifest in manifests.iter_mut() {
         let (cur_obj, mut cur_workload_paths) = parse_manifest(manifest)?;
@@ -251,7 +251,8 @@ mod tests {
     };
 
     use ankaios_api::ank_base::{
-        CompleteState, ExecutionStateSpec, Response, ResponseContent, StateSpec, UpdateStateSuccess, WorkloadInstanceNameSpec, WorkloadStateSpec
+        CompleteState, ExecutionStateSpec, Response, ResponseContent, StateSpec,
+        UpdateStateSuccess, WorkloadInstanceNameSpec, WorkloadStateSpec,
     };
     use ankaios_api::test_utils::{
         fixtures, generate_test_state_from_workloads, generate_test_workload_named,
@@ -847,7 +848,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -970,7 +970,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -1008,8 +1007,6 @@ mod tests {
         let mut manifest_data = String::new();
         let _ = manifest_content.clone().read_to_string(&mut manifest_data);
 
-
-
         let updated_state = CompleteState {
             desired_state: serde_yaml::from_str(&manifest_data).unwrap(),
             ..Default::default()
@@ -1037,7 +1034,6 @@ mod tests {
             .never();
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: true,
             server_connection: mock_server_connection,
         };
@@ -1084,7 +1080,6 @@ mod tests {
             .never();
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -1193,7 +1188,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/delete_configs.rs
+++ b/ank/src/cli_commands/delete_configs.rs
@@ -58,7 +58,6 @@ mod tests {
     use crate::cli_commands::{CliCommands, server_connection::MockServerConnection};
 
     use ankaios_api::ank_base::{CompleteState, UpdateStateSuccess};
-    use ankaios_api::test_utils::fixtures;
     use mockall::predicate::eq;
 
     const CONFIG_1: &str = "config_1";
@@ -94,7 +93,6 @@ mod tests {
             .returning(|_| Ok(CompleteState::default()));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -133,7 +131,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/delete_workloads.rs
+++ b/ank/src/cli_commands/delete_workloads.rs
@@ -53,10 +53,7 @@ mod tests {
     use crate::cli_commands::{CliCommands, server_connection::MockServerConnection};
 
     use ankaios_api::{
-        ank_base::{
-            CompleteState, ExecutionStateSpec, UpdateStateSuccess,
-            WorkloadStateSpec,
-        },
+        ank_base::{CompleteState, ExecutionStateSpec, UpdateStateSuccess, WorkloadStateSpec},
         test_utils::fixtures,
     };
     use common::{commands::UpdateWorkloadState, from_server_interface::FromServer};
@@ -142,7 +139,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -183,7 +179,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_agents.rs
+++ b/ank/src/cli_commands/get_agents.rs
@@ -159,7 +159,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -198,7 +197,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -227,7 +225,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -259,7 +256,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -298,7 +294,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -337,7 +332,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_configs.rs
+++ b/ank/src/cli_commands/get_configs.rs
@@ -76,7 +76,7 @@ mod tests {
     };
 
     use ankaios_api::ank_base::CompleteState;
-    use ankaios_api::test_utils::{fixtures, generate_test_complete_state_with_configs};
+    use ankaios_api::test_utils::generate_test_complete_state_with_configs;
 
     const CONFIG_1: &str = "config_1";
     const CONFIG_2: &str = "config_2";
@@ -105,7 +105,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -130,7 +129,6 @@ mod tests {
             .return_once(|_| Ok(CompleteState::default()));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -159,7 +157,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_events.rs
+++ b/ank/src/cli_commands/get_events.rs
@@ -227,7 +227,6 @@ mod tests {
             .returning(|_| Ok(None));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -255,7 +254,6 @@ mod tests {
             .returning(|_| Ok(None));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -292,7 +290,6 @@ mod tests {
             .returning(|_| Ok(None));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -320,7 +317,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -353,7 +349,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -466,7 +461,6 @@ mod tests {
             .returning(|_| Ok(None));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -607,7 +601,6 @@ mod tests {
             .returning(|_| Ok(None));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_logs.rs
+++ b/ank/src/cli_commands/get_logs.rs
@@ -178,7 +178,6 @@ mod tests {
             .return_once(|_, _| Ok(()));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -212,7 +211,6 @@ mod tests {
         mock_server_connection.expect_stream_logs().never();
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -262,7 +260,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -294,7 +291,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -319,7 +315,6 @@ mod tests {
             .return_once(|_| Ok(CompleteState::default()));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -365,7 +360,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_state.rs
+++ b/ank/src/cli_commands/get_state.rs
@@ -115,7 +115,6 @@ mod tests {
             })
             .return_once(|_| Ok(test_data_clone));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -137,7 +136,6 @@ mod tests {
             .return_once(|_| Ok(cloned_test_data));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: 0,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -169,7 +167,6 @@ mod tests {
             .return_once(|_| Ok(test_data_clone));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -218,7 +215,6 @@ mod tests {
             .return_once(|_| Ok(test_data_clone));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -257,7 +253,6 @@ mod tests {
             })
             .return_once(|_| Ok(test_data_clone));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/get_workloads.rs
+++ b/ank/src/cli_commands/get_workloads.rs
@@ -255,7 +255,6 @@ mod tests {
             })
             .return_once(|_| Ok(CompleteState::from(generate_test_complete_state(vec![]))));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -288,7 +287,6 @@ mod tests {
             .return_once(|_| Ok(CompleteState::from(test_data)));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -320,7 +318,6 @@ mod tests {
             })
             .return_once(|_| Ok(CompleteState::from(test_data)));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -352,7 +349,6 @@ mod tests {
             })
             .return_once(|_| Ok(CompleteState::from(test_data)));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -384,7 +380,6 @@ mod tests {
             })
             .return_once(|_| Ok(CompleteState::from(test_data)));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -420,7 +415,6 @@ mod tests {
             })
             .return_once(|_| Ok(CompleteState::from(test_data)));
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -451,7 +445,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -526,7 +519,6 @@ mod tests {
             .return_once(|| Err(ServerConnectionError::ExecutionError("Stop".into())));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server,
         };
@@ -596,7 +588,6 @@ mod tests {
 
         let mock_server_connection = MockServerConnection::default();
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };
@@ -674,7 +665,6 @@ mod tests {
 
         let mock_server_connection = MockServerConnection::default();
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/run_workload.rs
+++ b/ank/src/cli_commands/run_workload.rs
@@ -168,7 +168,6 @@ mod tests {
             });
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: false,
             server_connection: mock_server_connection,
         };

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -89,7 +89,7 @@ pub fn generate_test_complete_state_request_details(
 }
 
 // [impl->swdd~cli-throws-connection-timeout-error-on-response-timeout~1]
-async fn run_with_timeout<T>(
+async fn run_until_timeout<T>(
     future: impl std::future::Future<Output = Result<T, ServerConnectionError>>,
     timeout_duration: Duration,
 ) -> Result<T, ServerConnectionError> {
@@ -193,7 +193,7 @@ impl ServerConnection {
             }
         };
 
-        run_with_timeout(poll_complete_state_response, self.response_timeout_ms).await
+        run_until_timeout(poll_complete_state_response, self.response_timeout_ms).await
     }
 
     pub async fn update_state(
@@ -239,7 +239,7 @@ impl ServerConnection {
             }
         };
 
-        run_with_timeout(poll_update_state_success, self.response_timeout_ms).await
+        run_until_timeout(poll_update_state_success, self.response_timeout_ms).await
     }
 
     pub async fn read_next_update_workload_state(
@@ -322,7 +322,7 @@ impl ServerConnection {
         request_id: String,
     ) -> Result<LogsRequestAccepted, ServerConnectionError> {
         let response_timeout_ms = self.response_timeout_ms;
-        run_with_timeout(
+        run_until_timeout(
             self.poll_logs_request_accepted_response(request_id),
             response_timeout_ms,
         )

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -97,7 +97,7 @@ async fn run_until_timeout<T>(
         Ok(Ok(result)) => Ok(result),
         Ok(Err(err)) => Err(err),
         Err(_) => Err(ServerConnectionError::ExecutionError(format!(
-            "Operation timed out after '{:?}'",
+            "Command timed out after '{:?}'",
             timeout_duration
         ))),
     }
@@ -1118,7 +1118,13 @@ mod tests {
             )
             .await;
 
-        assert!(result.is_err());
+        assert_eq!(
+            result,
+            Err(ServerConnectionError::ExecutionError(format!(
+                "Command timed out after '{:?}'",
+                server_connection.response_timeout_ms
+            )))
+        );
         checker.check_communication();
     }
 

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -1111,6 +1111,7 @@ mod tests {
         let (_to_client, from_server) = mpsc::channel(1);
         server_connection.from_server = from_server;
 
+        server_connection.response_timeout_ms = Duration::from_millis(100);
         let result = server_connection
             .update_state(
                 complete_state(fixtures::WORKLOAD_NAMES[0]),

--- a/ank/src/cli_commands/server_connection.rs
+++ b/ank/src/cli_commands/server_connection.rs
@@ -40,13 +40,13 @@ use {common::std_extensions::IllegalStateResult, std::io::Write};
 use mockall::automock;
 
 const BUFFER_SIZE: usize = 20;
-const WAIT_TIME_MS: Duration = Duration::from_millis(3000);
 
 pub struct ServerConnection {
     to_server: ToServerSender,
     from_server: FromServerReceiver,
     task: JoinHandle<()>,
     missed_from_server_messages: Vec<FromServer>,
+    response_timeout_ms: Duration,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -88,6 +88,21 @@ pub fn generate_test_complete_state_request_details(
     }
 }
 
+// [impl->swdd~cli-throws-connection-timeout-error-on-response-timeout~1]
+async fn run_with_timeout<T>(
+    future: impl std::future::Future<Output = Result<T, ServerConnectionError>>,
+    timeout_duration: Duration,
+) -> Result<T, ServerConnectionError> {
+    match timeout(timeout_duration, future).await {
+        Ok(Ok(result)) => Ok(result),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(ServerConnectionError::ExecutionError(format!(
+            "Operation timed out after '{:?}'",
+            timeout_duration
+        ))),
+    }
+}
+
 #[cfg_attr(test, automock)]
 impl ServerConnection {
     // [impl->swdd~server-handle-cli-communication~1]
@@ -98,6 +113,7 @@ impl ServerConnection {
         cli_name: &str,
         server_url: String,
         tls_config: Option<TLSConfig>,
+        response_timeout_ms: u64,
     ) -> Result<Self, CommunicationMiddlewareError> {
         let mut grpc_communications_client = GRPCCommunicationsClient::new_cli_communication(
             cli_name.to_owned(),
@@ -122,6 +138,7 @@ impl ServerConnection {
             from_server: cli_receiver,
             task,
             missed_from_server_messages: Vec::new(),
+            response_timeout_ms: Duration::from_millis(response_timeout_ms),
         })
     }
 
@@ -163,7 +180,11 @@ impl ServerConnection {
                         output_debug!("Received from server: {res:?} ");
                         return Ok(res.complete_state.unwrap_or_default());
                     }
-                    None => return Err("Channel preliminary closed."),
+                    None => {
+                        return Err(ServerConnectionError::ExecutionError(
+                            "Channel preliminary closed.".to_owned(),
+                        ));
+                    }
                     Some(message) => {
                         // [impl->swdd~cli-stores-unexpected-message~1]
                         self.missed_from_server_messages.push(message);
@@ -171,15 +192,8 @@ impl ServerConnection {
                 }
             }
         };
-        match timeout(WAIT_TIME_MS, poll_complete_state_response).await {
-            Ok(Ok(res)) => Ok(res),
-            Ok(Err(err)) => Err(ServerConnectionError::ExecutionError(format!(
-                "Failed to get complete state.\nError: {err}"
-            ))),
-            Err(_) => Err(ServerConnectionError::ExecutionError(format!(
-                "Failed to get complete state in time (timeout={WAIT_TIME_MS:?})."
-            ))),
-        }
+
+        run_with_timeout(poll_complete_state_response, self.response_timeout_ms).await
     }
 
     pub async fn update_state(
@@ -224,19 +238,8 @@ impl ServerConnection {
                 }
             }
         };
-        match timeout(WAIT_TIME_MS, poll_update_state_success).await {
-            Ok(Ok(res)) => {
-                output_debug!("Got update success: {:?}", res);
-                Ok(res)
-            }
-            Ok(Err(err)) => {
-                output_debug!("Update failed: {:?}", err);
-                Err(err)
-            }
-            Err(_) => Err(ServerConnectionError::ExecutionError(format!(
-                "Failed to get complete state in time (timeout={WAIT_TIME_MS:?})."
-            ))),
-        }
+
+        run_with_timeout(poll_update_state_success, self.response_timeout_ms).await
     }
 
     pub async fn read_next_update_workload_state(
@@ -318,16 +321,12 @@ impl ServerConnection {
         &mut self,
         request_id: String,
     ) -> Result<LogsRequestAccepted, ServerConnectionError> {
-        timeout(
-            WAIT_TIME_MS,
+        let response_timeout_ms = self.response_timeout_ms;
+        run_with_timeout(
             self.poll_logs_request_accepted_response(request_id),
+            response_timeout_ms,
         )
         .await
-        .unwrap_or_else(|_| {
-            Err(ServerConnectionError::ExecutionError(format!(
-                "Failed to get LogsRequestAccepted response in time (timeout={WAIT_TIME_MS:?})."
-            )))
-        })
     }
 
     async fn poll_logs_request_accepted_response(
@@ -662,9 +661,12 @@ mod tests {
     };
 
     use std::collections::{BTreeSet, HashMap};
-    use tokio::sync::{
-        mpsc::{self, Receiver},
-        oneshot,
+    use tokio::{
+        sync::{
+            mpsc::{self, Receiver},
+            oneshot,
+        },
+        time::Duration,
     };
 
     const OTHER_REQUEST: &str = "other_request";
@@ -737,6 +739,7 @@ mod tests {
                     from_server: cli_receiver,
                     task: tokio::spawn(async {}),
                     missed_from_server_messages: Vec::new(),
+                    response_timeout_ms: Duration::from_millis(fixtures::RESPONSE_TIMEOUT_MS),
                 },
             )
         }
@@ -1092,6 +1095,7 @@ mod tests {
         checker.check_communication();
     }
 
+    // [utest->swdd~cli-throws-connection-timeout-error-on-response-timeout~1]
     #[tokio::test]
     async fn utest_update_state_fails_response_timeout() {
         let mut sim = CommunicationSimulator::default();
@@ -1406,6 +1410,7 @@ mod tests {
             from_server: cli_receiver,
             task: tokio::spawn(async {}),
             missed_from_server_messages: Vec::new(),
+            response_timeout_ms: Duration::from_millis(fixtures::RESPONSE_TIMEOUT_MS),
         };
 
         let result = server_connection

--- a/ank/src/cli_commands/set_state.rs
+++ b/ank/src/cli_commands/set_state.rs
@@ -104,7 +104,6 @@ mod tests {
     use ankaios_api::ank_base::{
         CompleteState, RestartPolicy, State, UpdateStateSuccess, Workload, WorkloadMap,
     };
-    use ankaios_api::test_utils::fixtures;
     use mockall::predicate::eq;
     use serde_yaml::Value;
     use std::{collections::HashMap, io::Cursor};
@@ -200,7 +199,6 @@ mod tests {
             .return_once(|_, _| Ok(UpdateStateSuccess::default()));
 
         let mut cmd = CliCommands {
-            _response_timeout_ms: fixtures::RESPONSE_TIMEOUT_MS,
             no_wait: true,
             server_connection: mock_server_connection,
         };


### PR DESCRIPTION
Issues: #708 

- Implements the timeout parameter of the ank-cli
- assumes 3 sec timeout as default if no timeout parameter is set via cli
- unifies timeout handling in a function with generalized error messages (the user knows the command that was run...)
- adds two swdd requirements, one for the cli parameter, the other one for handling the timeout reached state
- links the timeout handling swdd to the function and an existing unit test with a more strict assertion

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
