### PR TITLE
Support multiple default config file paths in ank-cli

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -200,13 +200,13 @@ The following diagram shows the startup sequence of the Ankaios Agent:
 
 Status: approved
 
-The Ankaios agent shall accept configuration files read at startup using the Common library that specify the general startup configuration of the agent with a lower precedence than environment variables and command line arguments.
+The Ankaios agent shall accept a configuration file read at startup using the Common library that specify the general startup configuration of the agent with a lower precedence than environment variables and command line arguments.
 
 Rationale:
-Agent configuration files allow a reproducible execution of the agent with lower effort.
+An Agent configuration file allows a reproducible execution of the agent with lower effort.
 
 Comment:
-The Ankaios agent expects the configuration files per default in the standard location `/etc/ankaios/ank-agent.conf`.
+The Ankaios agent expects the configuration file per default in the standard location `/etc/ankaios/ank-agent.conf`.
 
 Needs:
 - impl

--- a/agent/src/agent_config.rs
+++ b/agent/src/agent_config.rs
@@ -26,7 +26,7 @@ use std::fs::read_to_string;
 use std::path::PathBuf;
 use toml::from_str;
 
-pub const DEFAULT_AGENT_CONFIG_FILE_PATH: &str = "/etc/ankaios/ank-agent.conf";
+pub const DEFAULT_AGENT_CONFIG_FILE_PATH: [&str; 1] = ["/etc/ankaios/ank-agent.conf"];
 
 pub fn get_default_url() -> String {
     DEFAULT_SERVER_ADDRESS.to_string()

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -135,7 +135,7 @@ async fn main() {
 
     // [impl->swdd~agent-loads-config-file~2]
     let mut agent_config: AgentConfig =
-        handle_config(&args.config_path, DEFAULT_AGENT_CONFIG_FILE_PATH);
+        handle_config(&args.config_path, &DEFAULT_AGENT_CONFIG_FILE_PATH);
 
     agent_config.update_with_args(&args);
 

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -146,7 +146,7 @@ Rationale:
 Ankaios CLI configuration files allow a reproducible execution of the CLI with lower effort.
 
 Comment:
-The Ankaios CLI expects the configuration files per default in the standard locations [`$HOME/.config/ankaios/ank.conf`, `/etc/ankaios/ank.conf`] with first existing file taking precedence over the other.
+The Ankaios CLI expects the configuration file per default in the standard locations [`$HOME/.config/ankaios/ank.conf`, `/etc/ankaios/ank.conf`] with first existing file taking precedence over the other.
 
 Needs:
 - impl

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -140,10 +140,10 @@ Implementation of each command is detailed in the next sub-chapters.
 
 Status: approved
 
-The Ankaios CLI shall accept configuration files read at startup using the Common library helper that specify the general startup configuration of the CLI with a lower precedence than environment variables and command line arguments.
+The Ankaios CLI shall accept a configuration file read at startup using the Common library helper that specify the general startup configuration of the CLI with a lower precedence than environment variables and command line arguments.
 
 Rationale:
-Ankaios CLI configuration files allow a reproducible execution of the CLI with lower effort.
+An Ankaios CLI configuration file allows a reproducible execution of the CLI with lower effort.
 
 Comment:
 The Ankaios CLI expects the configuration file per default in the standard locations [`$HOME/.config/ankaios/ank.conf`, `/etc/ankaios/ank.conf`] with first existing file taking precedence over the other.

--- a/ank/doc/swdesign/README.md
+++ b/ank/doc/swdesign/README.md
@@ -146,7 +146,7 @@ Rationale:
 Ankaios CLI configuration files allow a reproducible execution of the CLI with lower effort.
 
 Comment:
-The Ankaios CLI expects the configuration files per default in the standard location `$HOME/.config/ankaios/ank.conf`.
+The Ankaios CLI expects the configuration files per default in the standard locations [`$HOME/.config/ankaios/ank.conf`, `/etc/ankaios/ank.conf`] with first existing file taking precedence over the other.
 
 Needs:
 - impl

--- a/ank/src/ank_config.rs
+++ b/ank/src/ank_config.rs
@@ -32,10 +32,17 @@ use std::path::PathBuf;
 
 pub const DEFAULT_CONFIG: &str = "default";
 pub const DEFAULT_RESPONSE_TIMEOUT: u64 = 3000;
-
-pub static DEFAULT_ANK_CONFIG_FILE_PATH: Lazy<String> = Lazy::new(|| {
+pub static DEFAULT_ANK_CONFIG_USER_FILE_PATH: Lazy<String> = Lazy::new(|| {
     let home_dir = env::var("HOME").unwrap_or_exit("HOME environment variable not set");
     format!("{home_dir}/.config/ankaios/ank.conf")
+});
+pub const DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH: &str = "/etc/ankaios/ank.conf";
+
+pub static DEFAULT_ANK_CONFIG_FILE_PATHS: Lazy<Vec<&str>> = Lazy::new(|| {
+    vec![
+        DEFAULT_ANK_CONFIG_USER_FILE_PATH.as_str(),
+        DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH,
+    ]
 });
 
 fn get_default_response_timeout() -> u64 {
@@ -272,7 +279,7 @@ impl AnkConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATH};
+    use super::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATHS};
     use crate::{
         ank_config::{get_default_response_timeout, get_default_url},
         cli::{AnkCli, Commands, GetArgs, GetCommands},
@@ -366,7 +373,7 @@ mod tests {
                 }),
             }),
             server_url: Some(TEST_SERVER_URL.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATH.to_string()),
+            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
             response_timeout_ms: Some(5000),
             insecure: Some(false),
             verbose: Some(true),
@@ -418,7 +425,7 @@ mod tests {
                 }),
             }),
             server_url: Some(DEFAULT_SERVER_ADDRESS.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATH.to_string()),
+            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
             response_timeout_ms: Some(5000),
             insecure: Some(false),
             verbose: Some(true),
@@ -473,7 +480,7 @@ mod tests {
                 }),
             }),
             server_url: Some(DEFAULT_SERVER_ADDRESS.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATH.to_string()),
+            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
             response_timeout_ms: Some(5000),
             insecure: None,
             verbose: None,

--- a/ank/src/cli.rs
+++ b/ank/src/cli.rs
@@ -172,7 +172,7 @@ pub struct AnkCli {
     pub command: Commands,
     #[arg(required = false, short = 'x', long = "ank-config", value_hint = ValueHint::FilePath)]
     /// The path to the server config file.
-    /// The default path is $HOME/.config/ankaios/ank.conf
+    /// The default paths are $HOME/.config/ankaios/ank.conf and /etc/ankaios/ank.conf with first existing file taking precedence over the other.
     pub config_path: Option<String>,
     #[arg(short = 's', long = "server-url", required=false, env = ANK_SERVER_URL_ENV_KEY)]
     /// The url to Ankaios server.

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -20,7 +20,7 @@ mod cli_signals;
 mod log;
 
 use crate::log::{IS_QUIET, IS_VERBOSE};
-use ank_config::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATH};
+use ank_config::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATHS};
 use cli_commands::CliCommands;
 use common::config::handle_config;
 use common::std_extensions::{GracefulExitResult, IllegalStateResult};
@@ -35,7 +35,8 @@ async fn main() {
     let args = cli::parse();
 
     // [impl->swdd~cli-loads-config-file~2]
-    let mut ank_config: AnkConfig = handle_config(&args.config_path, &DEFAULT_ANK_CONFIG_FILE_PATH);
+    let mut ank_config: AnkConfig =
+        handle_config(&args.config_path, &DEFAULT_ANK_CONFIG_FILE_PATHS);
     ank_config.update_with_args(&args);
 
     let cli_name = "ank-cli";

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -49,7 +49,26 @@ impl fmt::Display for ConversionErrors {
     }
 }
 
-pub fn handle_config<T: ConfigFile>(config_path: &Option<String>, default_path: &str) -> T {
+/// Handles the configuration file loading.
+///
+/// This function attempts to load the configuration from the provided `config_path`.
+/// If no path is provided, it will iterate over the `default_paths` and load the first
+/// existing configuration file. If no configuration file is found, it will return the
+/// default configuration.
+///
+/// # Type Parameters
+///
+/// * `T`: The type of the configuration file. Must implement `ConfigFile`.
+///
+/// # Arguments
+///
+/// * `config_path`: An optional path to the configuration file.
+/// * `default_paths`: A slice of default paths to search for the configuration file.
+///
+/// # Returns
+///
+/// The loaded configuration of type `T`.
+pub fn handle_config<T: ConfigFile>(config_path: &Option<String>, default_paths: &[&str]) -> T {
     match config_path {
         Some(config_path) => {
             let config_path = PathBuf::from(config_path);
@@ -60,20 +79,23 @@ pub fn handle_config<T: ConfigFile>(config_path: &Option<String>, default_path: 
             T::from_file(config_path).unwrap_or_exit("Config file could not be parsed")
         }
         None => {
-            let default_path = PathBuf::from(default_path);
-            if !default_path.try_exists().unwrap_or(false) {
-                log::debug!(
-                    "No config file found at default path '{}'. Using cli arguments and environment variables only.",
-                    default_path.display()
-                );
-                T::default()
-            } else {
-                log::info!(
-                    "Loading config from default path '{}'",
-                    default_path.display()
-                );
-                T::from_file(default_path).unwrap_or_exit("Config file could not be parsed")
+            for path in default_paths {
+                let default_path = PathBuf::from(path);
+                if default_path.try_exists().unwrap_or(false) {
+                    log::info!(
+                        "Loading config from default path '{}'",
+                        default_path.display()
+                    );
+                    return T::from_file(default_path)
+                        .unwrap_or_exit("Config file could not be parsed");
+                }
             }
+
+            log::debug!(
+                "No config file found at default paths '{:?}'. Continue with default config.",
+                default_paths,
+            );
+            T::default()
         }
     }
 }
@@ -162,7 +184,7 @@ mod tests {
 
         let test_config: TestConfig = handle_config(
             &Some(tmp_config.into_temp_path().to_str().unwrap().to_string()),
-            "/a/very/invalid/path/to/config/file",
+            &["/a/very/invalid/path/to/config/file"],
         );
 
         assert_eq!(test_config.test_string, "test_value");
@@ -170,19 +192,50 @@ mod tests {
     }
 
     #[test]
-    fn utest_handle_config_default_path() {
+    fn utest_handle_config_default_paths() {
         let mut file = NamedTempFile::new().expect("Failed to create file");
         writeln!(file, "{VALID_TEST_CONFIG_CONTENT}").expect("Failed to write to file");
 
-        let test_config: TestConfig = handle_config(&None, file.path().to_str().unwrap());
+        let test_config: TestConfig = handle_config(&None, &[file.path().to_str().unwrap()]);
 
         assert_eq!(test_config.test_string, "test_value");
         assert!(test_config.test_bool);
     }
 
     #[test]
+    fn utest_handle_config_default_paths_first_path_taking_precedence_over_the_other() {
+        // Config file 1
+        let mut default_file_1 = NamedTempFile::new().expect("Failed to create file");
+        writeln!(default_file_1, "{VALID_TEST_CONFIG_CONTENT}").expect("Failed to write to file");
+
+        // Config file 2 with different content
+        const CHANGED_TEST_VALUE: &str = "different_test_value";
+        let mut default_file_2 = NamedTempFile::new().expect("Failed to create file");
+        let other_config_content =
+            VALID_TEST_CONFIG_CONTENT.replace("test_value", CHANGED_TEST_VALUE);
+        writeln!(default_file_2, "{other_config_content}").expect("Failed to write to file");
+
+        let file_path_1 = default_file_1.path().to_str().unwrap().to_owned();
+        let file_path_2 = default_file_2.path().to_str().unwrap().to_owned();
+
+        let test_config: TestConfig = handle_config(&None, &[&file_path_1, &file_path_2]);
+
+        assert_eq!(test_config.test_string, "test_value");
+        assert!(test_config.test_bool);
+
+        // config file 1 is deleted, so config file 2 should be loaded
+        drop(default_file_1);
+
+        let test_config: TestConfig = handle_config(&None, &[&file_path_1, &file_path_2]);
+
+        assert_eq!(test_config.test_string, CHANGED_TEST_VALUE);
+        assert!(test_config.test_bool);
+    }
+
+    #[test]
     fn utest_handle_config_default() {
-        let test_config: TestConfig = handle_config(&None, "/a/very/invalid/path/to/config/file");
+        let test_config: TestConfig =
+            handle_config(&None, &["/a/very/invalid/path/to/config/file"]);
 
         assert_eq!(test_config, TestConfig::default());
     }

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -56,18 +56,9 @@ impl fmt::Display for ConversionErrors {
 /// existing configuration file. If no configuration file is found, it will return the
 /// default configuration.
 ///
-/// # Type Parameters
+/// ## Returns
 ///
-/// * `T`: The type of the configuration file. Must implement `ConfigFile`.
-///
-/// # Arguments
-///
-/// * `config_path`: An optional path to the configuration file.
-/// * `default_paths`: A slice of default paths to search for the configuration file.
-///
-/// # Returns
-///
-/// The loaded configuration of type `T`.
+/// The loaded configuration.
 pub fn handle_config<T: ConfigFile>(config_path: &Option<String>, default_paths: &[&str]) -> T {
     match config_path {
         Some(config_path) => {

--- a/doc/docs/reference/config-files.md
+++ b/doc/docs/reference/config-files.md
@@ -14,7 +14,7 @@ The Ankaios configuration files are per default loaded from the following locati
 
 - **Server Configuration**: `/etc/ankaios/ank-server.conf`
 - **Agent Configuration**: `/etc/ankaios/ank-agent.conf`
-- **CLI Configuration**: `$HOME/.config/ankaios/ank.conf`
+- **CLI Configuration**: `$HOME/.config/ankaios/ank.conf`, `/etc/ankaios/ank.conf` (first path has higher priority)
 
 ## Configuration File Structure
 

--- a/server/doc/swdesign/README.md
+++ b/server/doc/swdesign/README.md
@@ -108,13 +108,13 @@ The following diagram shows the startup sequence of the Ankaios Server:
 
 Status: approved
 
-The Ankaios server shall accept configuration files read at startup using the Common library that specify the general startup configuration of the server with a lower precedence than environment variables and command line arguments.
+The Ankaios server shall accept a configuration file read at startup using the Common library that specify the general startup configuration of the server with a lower precedence than environment variables and command line arguments.
 
 Rationale:
-Server configuration files allow a reproducible execution of the server with lower effort.
+A Server configuration file allows a reproducible execution of the server with lower effort.
 
 Comment:
-The Ankaios server expects the configuration files per default in the standard location `/etc/ankaios/ank-server.conf`.
+The Ankaios server expects the configuration file per default in the standard location `/etc/ankaios/ank-server.conf`.
 
 Tags:
 - ServerState

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
 
     // [impl->swdd~server-loads-config-file~2]
     let mut server_config: ServerConfig =
-        handle_config(&args.config_path, DEFAULT_SERVER_CONFIG_FILE_PATH);
+        handle_config(&args.config_path, &DEFAULT_SERVER_CONFIG_FILE_PATH);
 
     server_config.update_with_args(&args);
 

--- a/server/src/server_config.rs
+++ b/server/src/server_config.rs
@@ -24,7 +24,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use toml::from_str;
 
-pub const DEFAULT_SERVER_CONFIG_FILE_PATH: &str = "/etc/ankaios/ank-server.conf";
+pub const DEFAULT_SERVER_CONFIG_FILE_PATH: [&str; 1] = ["/etc/ankaios/ank-server.conf"];
 
 pub fn get_default_address() -> SocketAddr {
     DEFAULT_SOCKET_ADDRESS.parse().unwrap_or_unreachable()
@@ -236,7 +236,7 @@ mod tests {
         let mut server_config = ServerConfig::default();
         let args = Arguments {
             manifest_path: Some(STARTUP_MANIFEST_PATH.to_string()),
-            config_path: Some(DEFAULT_SERVER_CONFIG_FILE_PATH.to_string()),
+            config_path: Some(DEFAULT_SERVER_CONFIG_FILE_PATH[0].to_string()),
             addr: TEST_SOCKET_ADDRESS.parse::<SocketAddr>().ok(),
             insecure: Some(false),
             ca_pem: Some(fixtures::CA_PEM_PATH.to_string()),
@@ -291,7 +291,7 @@ mod tests {
             ServerConfig::from_file(PathBuf::from(tmp_config_file.path())).unwrap();
         let args = Arguments {
             manifest_path: Some(STARTUP_MANIFEST_PATH.to_string()),
-            config_path: Some(DEFAULT_SERVER_CONFIG_FILE_PATH.to_string()),
+            config_path: Some(DEFAULT_SERVER_CONFIG_FILE_PATH[0].to_string()),
             addr: TEST_SOCKET_ADDRESS.parse::<SocketAddr>().ok(),
             insecure: Some(false),
             ca_pem: None,


### PR DESCRIPTION
Issues: #707 

Changes to support `$HOME/.config/ankaios/ank.conf` and `/etc/ankaios/ank.conf` as default config paths for the ank-cli:

- introduces an array for supporting multiple default config file paths
- extends a swdd
- extends an utest for loading multiple default configs with first path taking precedence over the other
- updates the config file documentation to include now the two default paths for the ank-cli

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
