### PR TITLE
Change to filterMasks in server example manifest

### DIFF
--- a/server/resources/startConfig.yaml
+++ b/server/resources/startConfig.yaml
@@ -18,7 +18,7 @@ workloads:
       allowRules:
       - type: StateRule
         operation: Read
-        filterMask:
+        filterMasks:
         - desiredState
     runtimeConfig: |
       image: alpine:latest


### PR DESCRIPTION
Issues: #620 

Fix the missing migration from singular to plural for `filterMasks` inside the example Ankaios manifest. Without a fix with the current main branch the `ank apply` fails.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
