### PR TITLE
Fix incorrect rustc host command

### DIFF
--- a/tools/debian/build_src_pkg.sh
+++ b/tools/debian/build_src_pkg.sh
@@ -141,7 +141,7 @@ export RUSTC = /usr/bin/rustc-1.89
 export CARGO = /usr/bin/cargo-1.89
 export CARGO_HOME = $(CURDIR)/debian/.cargo
 
-RUST_HOST := $(shell $(RUSTC) --print host)
+RUST_HOST := $(shell $(RUSTC) --print host-tuple)
 
 %:
 	dh $@


### PR DESCRIPTION
# Description

The debian generate src script has a bug. This PR fixes it.
The fixed version can be seen in my fork: https://github.com/GabyUnalaq/ankaios/actions/runs/24684204777

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
