### PR TITLE
Publish man pages as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,8 +238,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: |
-          just build
-          tools/generate_man_pages.sh ./target/x86_64-unknown-linux-musl/debug dist
+          just build-release
+          tools/generate_man_pages.sh ./target/x86_64-unknown-linux-musl/release dist
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: man-pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,3 +228,20 @@ jobs:
         with:
           name: requirement-tracing-report
           path: dist/
+
+  man_pages:
+    name: Build man pages
+    needs: build_linux_amd64
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.0.1
+      options: --user root
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - run: |
+          just build
+          tools/generate_man_pages.sh ./target/x86_64-unknown-linux-musl/debug dist
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: requirement-tracing-report
+          path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -242,5 +242,5 @@ jobs:
           tools/generate_man_pages.sh ./target/x86_64-unknown-linux-musl/debug dist
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: requirement-tracing-report
+          name: man-pages
           path: dist/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,7 +231,6 @@ jobs:
 
   man_pages:
     name: Build man pages
-    needs: build_linux_amd64
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/eclipse-ankaios/devcontainer-base:1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
     name: Build man pages
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.0.1
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
         with:
           name: robot-tests-result
           path: dist/test-results/robot
+      - name: Download man pages
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: man-pages
+          path: dist/
       - name: Download vendored source
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           ank_base.proto \
           control_api.proto \
           ankaios_configs.tar.gz \
+	  man-pages.tar.gz \
           linux-amd64/ankaios-linux-amd64.tar.gz \
           linux-amd64/ankaios-linux-amd64.tar.gz.sha512sum.txt \
           linux-arm64/ankaios-linux-arm64.tar.gz \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           ank_base.proto \
           control_api.proto \
           ankaios_configs.tar.gz \
-	  man-pages.tar.gz \
+          man-pages.tar.gz \
           linux-amd64/ankaios-linux-amd64.tar.gz \
           linux-amd64/ankaios-linux-amd64.tar.gz.sha512sum.txt \
           linux-arm64/ankaios-linux-arm64.tar.gz \

--- a/tools/create_configs.sh
+++ b/tools/create_configs.sh
@@ -7,13 +7,15 @@ CONFIG_FILES_NAME_BASE="ankaios_configs"
 SERVER_CONFIG_FILE="${ROOT_DIR}/server/config/ank-server.conf"
 AGENT_CONFIG_FILE="${ROOT_DIR}/agent/config/ank-agent.conf"
 ANK_CONFIG_FILE="${ROOT_DIR}/ank/config/ank.conf"
+STATE_FILE="${ROOT_DIR}/server/config/state.yaml"
 DIST_DIR="${ROOT_DIR}/dist"
 
 cd "${DIST_DIR}"
 tar -cvzf "${CONFIG_FILES_NAME_BASE}".tar.gz \
     -C "$(dirname "$SERVER_CONFIG_FILE")" "$(basename "$SERVER_CONFIG_FILE")" \
     -C "$(dirname "$AGENT_CONFIG_FILE")" "$(basename "$AGENT_CONFIG_FILE")" \
-    -C "$(dirname "$ANK_CONFIG_FILE")" "$(basename "$ANK_CONFIG_FILE")"
+    -C "$(dirname "$ANK_CONFIG_FILE")" "$(basename "$ANK_CONFIG_FILE")" \
+    -C "$(dirname "$STATE_FILE")" "$(basename "$STATE_FILE")"
 
 echo "Creating checksums"
 sha512sum "${CONFIG_FILES_NAME_BASE}".tar.gz > "${CONFIG_FILES_NAME_BASE}".tar.gz.sha512sum.txt

--- a/tools/create_release.sh
+++ b/tools/create_release.sh
@@ -14,6 +14,9 @@ echo "ROOT_DIR: $ROOT_DIR"
 echo "Exporting config files"
 "${SCRIPT_DIR}"/create_configs.sh
 
+echo "Exporting man pages"
+tar -cvzf "${DIST_DIR}/"man-pages.tar.gz --directory="${DIST_DIR}" $(cd "${DIST_DIR}"; echo man?)
+
 echo "Exporting coverage report"
 tar -cvzf "${DIST_DIR}/"coverage-report.tar.gz --directory="${DIST_DIR}/coverage" $(ls "${DIST_DIR}/coverage")
 (cd "${DIST_DIR}/coverage" && zip -r "${DIST_DIR}/"coverage-report.zip .)


### PR DESCRIPTION
The man pages can be used to build install Ankaios with documentation, without the need of downloading the whole repository.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
