### PR TITLE
Add llmstxt to docs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
 
 ARG USERNAME=vscode
 

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -30,6 +30,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     git \
     zsh \
     curl \
+    unzip \
     iputils-ping \
     sudo \
     # java for plantuml
@@ -154,7 +155,8 @@ RUN curl -sL https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5
 USER ${USERNAME}
 
 # Install cargo cli tools
-RUN cargo install cargo-llvm-cov --locked; \
+RUN rustup component add llvm-tools-preview \
+    && cargo install cargo-llvm-cov --locked; \
     cargo install cargo-deb --locked; \
     cargo install cargo-nextest --locked; \
     cargo install cargo-deny --locked; \

--- a/.devcontainer/Dockerfile.base
+++ b/.devcontainer/Dockerfile.base
@@ -142,7 +142,7 @@ RUN curl -sL https://github.com/plantuml/plantuml/releases/download/v1.2024.0/pl
 COPY plantuml /usr/local/bin
 
 # MkDocs Material
-RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip install mkdocs-material pillow cairosvg mike mkdocs-htmlproofer-plugin robotframework==7.0.1 markdown==3.10.0
+RUN PIP_BREAK_SYSTEM_PACKAGES=1 pip install mkdocs-material pillow cairosvg mike mkdocs-htmlproofer-plugin mkdocs-llmstxt robotframework==7.0.1 markdown==3.10.0
 
 # protoc-gen-doc
 RUN curl -sL https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.5.1/protoc-gen-doc_1.5.1_linux_${TARGETARCH}.tar.gz | tar xz --directory=/usr/local/bin protoc-gen-doc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Vendor all dependencies locally
@@ -40,7 +40,7 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,7 +98,7 @@ jobs:
     needs: vendor
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -143,7 +143,7 @@ jobs:
     needs: vendor
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -165,7 +165,7 @@ jobs:
     needs: vendor
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --privileged
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -191,7 +191,7 @@ jobs:
     needs: vendor
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -215,7 +215,7 @@ jobs:
     needs: vendor
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -233,7 +233,7 @@ jobs:
     name: Build man pages
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
       options: --user root
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/check-req-tracing.yml
+++ b/.github/workflows/check-req-tracing.yml
@@ -8,7 +8,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Compare requirement tracing reports

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
     if: ${{ needs.documentation_changes.outputs.documentation == 'true' || github.ref_name == 'main' || github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0
+      image: ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare commit to branch gh-pages

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -87,7 +87,7 @@ plugins:
         404: ['https://crates.io/crates/symphony']
   - llmstxt:
       full_output: llms-full.txt
-      base_url: !ENV [DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/1.0.0']
+      base_url: !ENV [DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/latest']
       markdown_description: |
         Eclipse Ankaios is a lightweight workload orchestrator for embedded and automotive edge devices.
         It manages containerized workloads across one server and multiple agents running on resource-constrained hardware.

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -85,6 +85,35 @@ plugins:
         - reference/_ankaios.proto.md
       raise_error_excludes:
         404: ['https://crates.io/crates/symphony']
+  - llmstxt:
+      full_output: llms-full.txt
+      base_url: !ENV [DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/1.0.0']
+      markdown_description: |
+        Eclipse Ankaios is a lightweight workload orchestrator for embedded and automotive edge devices.
+        It manages containerized workloads across one server and multiple agents running on resource-constrained hardware.
+        Use this documentation to understand the architecture, configure manifests, interact with the Control Interface, and contribute to the project.
+      sections:
+        Overview:
+          - index.md
+          - architecture.md
+        Usage:
+          - usage/installation.md
+          - usage/quickstart.md
+          - "usage/tutorial-*.md"
+          - usage/awesome-ankaios.md
+          - usage/mtls-setup.md
+          - usage/shell-completion.md
+          - "usage/manifest/*.md"
+        Reference:
+          - "reference/*.md"
+          - "reference/**/*.md"
+        Upgrading:
+          - "usage/upgrading/*.md"
+        Contributing:
+          - "development/*.md"
+          - "development/**/*.md"
+        Support:
+          - support.md
 
 extra:
   version:

--- a/tests/resources/control_interface_tester/Dockerfile
+++ b/tests/resources/control_interface_tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/eclipse-ankaios/devcontainer-base:1.1.0 AS compile
+FROM ghcr.io/eclipse-ankaios/devcontainer-base:1.2.0 AS compile
 
 ARG WORKSPACE_DIR=/workspaces/build
 

--- a/tools/generate_docs.sh
+++ b/tools/generate_docs.sh
@@ -59,8 +59,8 @@ if [[ "$1" = serve ]]; then
 elif [[ "$1" = build ]]; then
     mkdocs build --config-file "$target_dir/mkdocs.yml" -d html
 elif [[ "$1" = deploy ]]; then
-    mike deploy --push --config-file "$target_dir/mkdocs.yml" main
+    DOCS_VERSION_URL="https://eclipse-ankaios.github.io/ankaios/main" mike deploy --push --config-file "$target_dir/mkdocs.yml" main
 elif [[ "$1" = deploy-release && ! (-z "$2") ]]; then
     echo "Deploying documentation version $2"
-    mike deploy --update-aliases --push --config-file "$target_dir/mkdocs.yml" "$2" latest
+    DOCS_VERSION_URL="https://eclipse-ankaios.github.io/ankaios/$2" mike deploy --update-aliases --push --config-file "$target_dir/mkdocs.yml" "$2" latest
 fi

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -65,6 +65,10 @@ for pkg in $packages; do
    sed -i "/\[package\]/,/\[/{s/version = \"[^\"]*\"/version = \"$version\"/}" "$package_config"
 done
 
+mkdocs_config="$base_dir/doc/mkdocs.yml"
+log_update "$mkdocs_config"
+sed -i "s|DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/[^']*'|DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/$version'|" "$mkdocs_config"
+
 # Update the version of the examples
 examples=$(find "$base_dir/examples" -type d \( -name \*_control_interface -o -name python_sdk_\* -o -name rust_sdk_\* \) -printf "%f\n")
 for example in $examples; do

--- a/tools/update_version.sh
+++ b/tools/update_version.sh
@@ -65,10 +65,6 @@ for pkg in $packages; do
    sed -i "/\[package\]/,/\[/{s/version = \"[^\"]*\"/version = \"$version\"/}" "$package_config"
 done
 
-mkdocs_config="$base_dir/doc/mkdocs.yml"
-log_update "$mkdocs_config"
-sed -i "s|DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/[^']*'|DOCS_VERSION_URL, 'https://eclipse-ankaios.github.io/ankaios/$version'|" "$mkdocs_config"
-
 # Update the version of the examples
 examples=$(find "$base_dir/examples" -type d \( -name \*_control_interface -o -name python_sdk_\* -o -name rust_sdk_\* \) -printf "%f\n")
 for example in $examples; do


### PR DESCRIPTION
# Description

The documentation is optimized for human navigation but difficult for LLMs and AI agents to consume reliably. Agents retrieving information about Ankaios typically depend on web search, which cannot guarantee coverage or correctness.

The [llms.txt standard](https://llmstxt.org/) addresses this by defining two files served alongside the documentation:
- `llms.txt` — a lightweight page index with section groupings and URLs, allowing agents to discover what is available before fetching specific pages;
- `llms-full.txt` — the entire documentation concatenated into a single Markdown file, suitable for direct ingestion by agents and RAG pipelines.

This PR adds the [mkdocs-llmstxt](https://github.com/pawamoy/mkdocs-llmstxt) plugin to generate both files automatically on every build. All documentation pages are included and the files are served at the root of each versioned deployment, compatible with the existing `mike` setup.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
