### PR TITLE
Improve stests event handling and timeouts

### DIFF
--- a/tests/resources/ankaios_library.py
+++ b/tests/resources/ankaios_library.py
@@ -1096,9 +1096,9 @@ def listen_for_events_with_timeout(field_mask: str, log_output_file: str, ank_bi
 
 
         if insecure:
-            cmd = [ank_path, '--insecure', 'get', 'events', '-o', 'json']
+            cmd = [ank_path, '--insecure', 'get', 'events', '--include-current-state', '-o', 'json']
         else:
-            cmd = [ank_path, 'get', 'events', '-o', 'json']
+            cmd = [ank_path, 'get', 'events', '--include-current-state', '-o', 'json']
         if field_mask:
             cmd.append(field_mask)
 
@@ -1134,22 +1134,22 @@ def listen_for_events_with_timeout(field_mask: str, log_output_file: str, ank_bi
                         pass
                 else:
                     stderr = process.stderr.read()
-                    if "could not connect to ankaios server" in stderr.lower():
-                        # when the server is not yet available, restart the process until the timeout is reached
-                        process.terminate()
+                    log_file_handle.write(f"Event listener process exited (stderr: {stderr!r}). Restarting within timeout.\n")
+                    # Reap the dead process, then restart regardless of exit reason.
+                    # On reconnect, --include-current-state ensures any state change that
+                    # occurred during the downtime window is immediately emitted.
+                    try:
                         process.wait(timeout=2)
-
-                        process = subprocess.Popen(
-                            cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            text=True,
-                            bufsize=1
-                        )
-                        log_file_handle.write("Restarted event listener process. This might happen and does not indicate a test failure.\n")
-                    else:
-                        log_file_handle.write(f"Event listener process terminated: {stderr}\n")
-                        break
+                    except Exception:
+                        pass
+                    time.sleep(0.5)
+                    process = subprocess.Popen(
+                        cmd,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        bufsize=1
+                    )
 
 
             log_file_handle.write(f"Event waiting timed out after {timeout}s, first_event_received={first_event_received}\n")
@@ -1200,7 +1200,7 @@ def workload_has_execution_state(workload_name: str, agent_name: str, expected_s
     timeout_float = float(timeout)
     start_time = get_time_secs()
 
-    while (get_time_secs() - start_time) < float(timeout_float):
+    while True:
         for event in EVENT_BUFFER:
             complete_state: dict = event.get('completeState', {})
             workload_states: dict = complete_state.get('workloadStates', {})
@@ -1228,8 +1228,8 @@ def workload_has_execution_state(workload_name: str, agent_name: str, expected_s
                     return True
 
         remaining_time = timeout_float - (get_time_secs() - start_time)
-        if remaining_time > 0:
-            EVENTS_RECEIVED.wait(timeout=remaining_time)
-        else: break
+        if remaining_time <= 0:
+            break
+        EVENTS_RECEIVED.wait(timeout=remaining_time)
 
     return False

--- a/tests/stests/control_interface/control_interface.robot
+++ b/tests/stests/control_interface/control_interface.robot
@@ -155,7 +155,7 @@ Test target path from control interface access is limited to the designated pod 
     And Ankaios server is started with manifest "${CONFIGS_DIR}/multi_container_podman_kube.yaml"
     And the CLI listens for workload states
     And Ankaios agent is started with name "${agent_name}"
-    And the workload "${workload_name}" shall have the execution state "Running(Ok)" on agent "${agent_name}"
+    And the workload "${workload_name}" shall have the execution state "Running(Ok)" on agent "${agent_name}" within "30" seconds
     And the mount point for the control interface has been generated for ${agent_name}
     # Asserts
     Then verify multi container control interface access    simple
@@ -168,7 +168,7 @@ Test target path from control interface access is limited to the designated depl
     And Ankaios server is started with manifest "${CONFIGS_DIR}/multi_container_podman_kube_deployment.yaml"
     And the CLI listens for workload states
     And Ankaios agent is started with name "${agent_name}"
-    And the workload "simple" shall have the execution state "Running(Ok)" on agent "${agent_name}"
+    And the workload "simple" shall have the execution state "Running(Ok)" on agent "${agent_name}" within "60" seconds
     And the mount point for the control interface has been generated for ${agent_name}
     # Asserts
     Then verify multi container control interface access    simple    container_A    pod_A-pod


### PR DESCRIPTION
# Description

Some stests fail sporadically, there are usually 2, which fail more often, and some others, which are related to podman kube.
This PR improves the event handling and increases the timeout to those 2 tests which usually take longer than initially assumed.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
