### PR TITLE
Fix debian publishing condition and src package upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,26 @@ jobs:
   debian-packages:
     name: Build and publish Debian packages
     needs: release
+    if: ${{ !contains(github.ref_name, '-') }}
     permissions:
       contents: read
     uses: ./.github/workflows/debian_build.yml
     secrets: inherit
+  upload-debian-source:
+    name: Upload Debian source package to release
+    needs: debian-packages
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Debian source package
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: debian-source-package
+          path: dist/src/
+      - name: Upload Debian source package to release
+        run: |
+          tar -czf ankaios-debian-source-${{ github.ref_name }}.tar.gz -C dist/src .
+          gh release upload ${{ github.ref_name }} ankaios-debian-source-${{ github.ref_name }}.tar.gz
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Description

This PR fixes 2 issues:
- The debian package gets built and published on all releases. It should be only on big releases, not on "pre" and release candidates;
- The debian source package is prepared and uploaded as an artifact, but it wasn't uploaded as a release artifact as well.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
