### PR TITLE
Update tabled (to fix cargo deny warnings)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -1068,12 +1068,6 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1764,9 +1758,9 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "papergrid"
-version = "0.13.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
@@ -2008,7 +2002,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -2575,25 +2569,26 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.17.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
  "tabled_derive",
+ "testing_table",
 ]
 
 [[package]]
 name = "tabled_derive"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2614,6 +2609,15 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -3482,7 +3486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -3493,7 +3497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1.41", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
-tabled = "0.17"
+tabled = "0.21"
 tempfile = "3.17"
 toml = "0.9"
 uuid = { version = "1.7.0", features = ["v4"] }

--- a/ank/src/cli_commands/cli_table.rs
+++ b/ank/src/cli_commands/cli_table.rs
@@ -23,7 +23,7 @@ fn terminal_width() -> usize {
 use common::std_extensions::UnreachableOption;
 use tabled::{
     Table, Tabled,
-    grid::config::Entity,
+    grid::config::Position,
     settings::{Modify, Padding, Style, Width, object::Columns},
 };
 
@@ -89,7 +89,7 @@ where
         let available_column_width = self.column_width_for_terminal(column_position)?;
 
         self.table.with(
-            Modify::new(Columns::single(column_position)).with(Width::wrap(available_column_width)),
+            Modify::new(Columns::one(column_position)).with(Width::wrap(available_column_width)),
         );
         Ok(self.table.to_string())
     }
@@ -104,7 +104,7 @@ where
 
         let available_column_width = self.column_width_for_terminal(column_position)?;
         self.table.with(
-            Modify::new(Columns::single(column_position)).with(
+            Modify::new(Columns::one(column_position)).with(
                 Width::truncate(available_column_width).suffix(Self::TRUNCATED_COLUMN_SUFFIX),
             ),
         );
@@ -121,7 +121,7 @@ where
         let first_column_default_padding = self
             .table
             .get_config()
-            .get_padding(Entity::Column(Self::FIRST_COLUMN_POS));
+            .get_padding(Position::new(0, Self::FIRST_COLUMN_POS));
 
         /* Set the left padding of the first and the right padding of the last column to zero
         to align the table content to the full terminal width for better output quality. */
@@ -136,7 +136,7 @@ where
         let last_column_default_padding = self
             .table
             .get_config()
-            .get_padding(Entity::Column(last_column_pos));
+            .get_padding(Position::new(0, last_column_pos));
 
         self.table
             .with(Modify::new(Columns::last()).with(Padding::new(


### PR DESCRIPTION
There is currently an unmaintained advisory warning for proc-macro-error2 that triggers a build break.
The problem is coming from tabled and is not resolved yet: 
https://github.com/zhiburt/tabled/issues/583

To update to a newer version, I already prepared the code to be compatible with 0.21.

Once the fix is out, we must push another commit here to update.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
