### PR TITLE
Ignore proc-macro-error2 advisory warning for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,5 +25,13 @@ license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 }
 ]
 
+[advisories]
+ignore = [
+    # proc-macro-error2 is used by tabled_derive (dependency of tabled).
+    # The advisory confirms no safe upgrade is available as of the latest tabled release.
+    # A fix is already available in tabled, but the release would be delayed: https://github.com/zhiburt/tabled/pull/584#issuecomment-4778335205
+    { id = "RUSTSEC-2026-0173", reason = "tabled_derive depends on proc-macro-error2 and no safe upgrade is available upstream" },
+]
+
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
The proc-macro-error2 crate is not maintained anymore and triggers a security advisory. For now there is no security problem with the crate and a solution in tabled is already deployed, but not released yet (see comment in code).

This PR adds a temporary workaround that ignores this specific issue for now until a new tabled version is released.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
