### PR TITLE
Cleanup runtime interface

### DIFF
--- a/agent/src/generic_polling_state_checker.rs
+++ b/agent/src/generic_polling_state_checker.rs
@@ -31,18 +31,16 @@ pub struct GenericPollingStateChecker {
     task_handle: JoinHandle<()>,
 }
 
-#[async_trait]
-impl<WorkloadId> StateChecker<WorkloadId> for GenericPollingStateChecker
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    // [impl->swdd~agent-provides-generic-state-checker-implementation~1]
-    fn start_checker(
+impl GenericPollingStateChecker {
+    pub fn start_checker<WorkloadId>(
         workload_named: &WorkloadNamed,
         workload_id: WorkloadId,
         workload_state_sender: WorkloadStateSender,
         state_getter: impl RuntimeStateGetter<WorkloadId>,
-    ) -> Self {
+    ) -> Self
+    where
+        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
+    {
         let workload_named = workload_named.clone();
         let workload_name = workload_named.instance_name.workload_name().to_owned();
         let task_handle = tokio::spawn(async move {
@@ -80,8 +78,11 @@ where
             task_handle,
         }
     }
+}
 
-    async fn stop_checker(self) {
+#[async_trait]
+impl StateChecker for GenericPollingStateChecker {
+    async fn stop_checker(self: Box<Self>) {
         drop(self);
     }
 }
@@ -106,7 +107,7 @@ mod tests {
     use super::STATUS_CHECK_INTERVAL_MS;
     use crate::{
         generic_polling_state_checker::GenericPollingStateChecker,
-        runtime_connectors::{MockRuntimeStateGetter, StateChecker},
+        runtime_connectors::MockRuntimeStateGetter,
     };
 
     use ankaios_api::ank_base::ExecutionStateSpec;
@@ -169,7 +170,9 @@ mod tests {
             if !generic_state_state_checker.task_handle.is_finished() {
                 tokio::time::sleep(Duration::from_millis(1)).await;
             }
-        }).await.expect("The state checker task did not finish within the expected time.");
+        })
+        .await
+        .expect("The state checker task did not finish within the expected time.");
 
         assert!(generic_state_state_checker.task_handle.is_finished());
         assert!(

--- a/agent/src/generic_polling_state_checker.rs
+++ b/agent/src/generic_polling_state_checker.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    runtime_connectors::{RuntimeStateGetter, StateChecker},
+    runtime_connectors::{RuntimeStateGetter, RuntimeWorkloadId, StateChecker},
     workload_state::{WorkloadStateSender, WorkloadStateSenderInterface},
 };
 use ankaios_api::ank_base::{ExecutionStateEnumSpec, ExecutionStateSpec, WorkloadNamed};
@@ -32,15 +32,12 @@ pub struct GenericPollingStateChecker {
 }
 
 impl GenericPollingStateChecker {
-    pub fn start_checker<WorkloadId>(
+    pub fn start_checker(
         workload_named: &WorkloadNamed,
-        workload_id: WorkloadId,
+        workload_id: RuntimeWorkloadId,
         workload_state_sender: WorkloadStateSender,
-        state_getter: impl RuntimeStateGetter<WorkloadId>,
-    ) -> Self
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+        state_getter: impl RuntimeStateGetter,
+    ) -> Self {
         let workload_named = workload_named.clone();
         let workload_name = workload_named.instance_name.workload_name().to_owned();
         let task_handle = tokio::spawn(async move {
@@ -105,6 +102,7 @@ impl Drop for GenericPollingStateChecker {
 #[cfg(test)]
 mod tests {
     use super::STATUS_CHECK_INTERVAL_MS;
+    use crate::runtime_connectors::RuntimeWorkloadId;
     use crate::{
         generic_polling_state_checker::GenericPollingStateChecker,
         runtime_connectors::MockRuntimeStateGetter,
@@ -132,12 +130,12 @@ mod tests {
             .expect_get_state()
             .times(2)
             .in_sequence(&mut mock_sequence)
-            .returning(|_: &String| Box::pin(async { ExecutionStateSpec::running() }));
+            .returning(|_: &RuntimeWorkloadId| Box::pin(async { ExecutionStateSpec::running() }));
         mock_runtime_getter
             .expect_get_state()
             .once()
             .in_sequence(&mut mock_sequence)
-            .return_once(|_: &String| Box::pin(async { ExecutionStateSpec::removed() }));
+            .return_once(|_: &RuntimeWorkloadId| Box::pin(async { ExecutionStateSpec::removed() }));
 
         let (state_sender, mut state_receiver) = tokio::sync::mpsc::channel(20);
 
@@ -145,7 +143,7 @@ mod tests {
 
         let generic_state_state_checker = GenericPollingStateChecker::start_checker(
             &workload,
-            fixtures::WORKLOAD_IDS[0].to_string(),
+            fixtures::WORKLOAD_IDS[0].to_string().into(),
             state_sender.clone(),
             mock_runtime_getter,
         );

--- a/agent/src/generic_polling_state_checker.rs
+++ b/agent/src/generic_polling_state_checker.rs
@@ -19,7 +19,7 @@ use crate::{
 use ankaios_api::ank_base::{ExecutionStateEnumSpec, ExecutionStateSpec, WorkloadNamed};
 
 use async_trait::async_trait;
-use std::{str::FromStr, time::Duration};
+use std::time::Duration;
 use tokio::{task::JoinHandle, time};
 
 // [impl->swdd~agent-provides-generic-state-checker-implementation~1]

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -49,7 +49,6 @@ use common::{
     to_server_interface::ToServer,
 };
 
-use generic_polling_state_checker::GenericPollingStateChecker;
 use runtime_connectors::{
     GenericRuntimeFacade, RuntimeConnector, RuntimeFacade, SUPPORTED_RUNTIMES,
     containerd::{self, ContainerdRuntime, ContainerdWorkloadId},
@@ -119,10 +118,10 @@ macro_rules! register_runtime {
     ($map:expr, $runtime_instance:expr, $workload_id_type:ty, $run_path:expr) => {{
         let runtime = Box::new($runtime_instance);
         let runtime_name = runtime.name();
-        let podman_facade = Box::new(GenericRuntimeFacade::<
-            $workload_id_type,
-            GenericPollingStateChecker,
-        >::new(runtime, $run_path));
+        let podman_facade = Box::new(GenericRuntimeFacade::<$workload_id_type>::new(
+            runtime,
+            $run_path,
+        ));
         $map.insert(runtime_name, podman_facade);
     }};
 }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -157,8 +157,11 @@ async fn main() {
         validate_runtimes(&agent_config.runtimes).unwrap_or_exit("Invalid runtime configuration");
 
     let mut available_runtimes = ([
+        // [impl->swdd~agent-supports-podman~2]
         Box::new(PodmanRuntime {}),
+        // [impl->swdd~agent-supports-podman-kube-runtime~1]
         Box::new(PodmanKubeRuntime::default()),
+        // [impl->swdd~agent-supports-containerd~1]
         Box::new(ContainerdRuntime {}),
     ] as [Box<dyn OwnableRuntime>; 3])
         .into_iter()

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -33,6 +33,7 @@ mod workload_state;
 
 mod io_utils;
 
+use crate::runtime_connectors::OwnableRuntime;
 #[cfg_attr(test, mockall_double::double)]
 use crate::runtime_manager::RuntimeManager;
 
@@ -50,10 +51,8 @@ use common::{
 };
 
 use runtime_connectors::{
-    GenericRuntimeFacade, RuntimeConnector, RuntimeFacade, SUPPORTED_RUNTIMES,
-    containerd::{self, ContainerdRuntime},
-    podman::{self, PodmanRuntime},
-    podman_kube::{self, PodmanKubeRuntime},
+    GenericRuntimeFacade, RuntimeFacade, SUPPORTED_RUNTIMES, containerd::ContainerdRuntime,
+    podman::PodmanRuntime, podman_kube::PodmanKubeRuntime,
 };
 
 use grpc::client::GRPCCommunicationsClient;
@@ -114,15 +113,6 @@ pub fn validate_runtimes(config_runtimes: &Option<Vec<String>>) -> Result<Vec<&s
     }
 }
 
-macro_rules! register_runtime {
-    ($map:expr, $runtime_instance:expr, $run_path:expr) => {{
-        let runtime = Box::new($runtime_instance);
-        let runtime_name = runtime.name();
-        let podman_facade = Box::new(GenericRuntimeFacade::new(runtime, $run_path));
-        $map.insert(runtime_name, podman_facade);
-    }};
-}
-
 #[tokio::main]
 async fn main() {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
@@ -165,35 +155,26 @@ async fn main() {
     // [impl->swdd~agent-allows-enabled-runtimes~1]
     let runtimes_to_register: Vec<&str> =
         validate_runtimes(&agent_config.runtimes).unwrap_or_exit("Invalid runtime configuration");
+
+    let mut available_runtimes = ([
+        Box::new(PodmanRuntime {}),
+        Box::new(PodmanKubeRuntime::default()),
+        Box::new(ContainerdRuntime {}),
+    ] as [Box<dyn OwnableRuntime>; 3])
+        .into_iter()
+        .map(|r| {
+            (
+                r.name(),
+                GenericRuntimeFacade::new(r, run_directory.get_path()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
     for runtime_name in runtimes_to_register {
-        match runtime_name {
-            podman::NAME => {
-                // [impl->swdd~agent-supports-podman~2]
-                register_runtime!(
-                    runtime_facade_map,
-                    PodmanRuntime {},
-                    run_directory.get_path()
-                );
-            }
-            podman_kube::NAME => {
-                // [impl->swdd~agent-supports-podman-kube-runtime~1]
-                register_runtime!(
-                    runtime_facade_map,
-                    PodmanKubeRuntime::default(),
-                    run_directory.get_path()
-                );
-            }
-            containerd::NAME => {
-                // [impl->swdd~agent-supports-containerd~1]
-                register_runtime!(
-                    runtime_facade_map,
-                    ContainerdRuntime {},
-                    run_directory.get_path()
-                );
-            }
-            _ => {
-                log::error!("Unexpected runtime name to register: {runtime_name}");
-            }
+        if let Some(runtime) = available_runtimes.remove(runtime_name) {
+            runtime_facade_map.insert(runtime_name.to_string(), Box::new(runtime));
+        } else {
+            log::error!("Unexpected runtime name to register: {runtime_name}");
         }
     }
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -51,9 +51,9 @@ use common::{
 
 use runtime_connectors::{
     GenericRuntimeFacade, RuntimeConnector, RuntimeFacade, SUPPORTED_RUNTIMES,
-    containerd::{self, ContainerdRuntime, ContainerdWorkloadId},
-    podman::{self, PodmanRuntime, PodmanWorkloadId},
-    podman_kube::{self, PodmanKubeRuntime, PodmanKubeWorkloadId},
+    containerd::{self, ContainerdRuntime},
+    podman::{self, PodmanRuntime},
+    podman_kube::{self, PodmanKubeRuntime},
 };
 
 use grpc::client::GRPCCommunicationsClient;
@@ -115,13 +115,10 @@ pub fn validate_runtimes(config_runtimes: &Option<Vec<String>>) -> Result<Vec<&s
 }
 
 macro_rules! register_runtime {
-    ($map:expr, $runtime_instance:expr, $workload_id_type:ty, $run_path:expr) => {{
+    ($map:expr, $runtime_instance:expr, $run_path:expr) => {{
         let runtime = Box::new($runtime_instance);
         let runtime_name = runtime.name();
-        let podman_facade = Box::new(GenericRuntimeFacade::<$workload_id_type>::new(
-            runtime,
-            $run_path,
-        ));
+        let podman_facade = Box::new(GenericRuntimeFacade::new(runtime, $run_path));
         $map.insert(runtime_name, podman_facade);
     }};
 }
@@ -136,7 +133,8 @@ async fn main() {
     let mut agent_config: AgentConfig =
         handle_config(&args.config_path, &DEFAULT_AGENT_CONFIG_FILE_PATH);
 
-    agent_config.update_with_args(&args)
+    agent_config
+        .update_with_args(&args)
         .unwrap_or_exit("Failed to load certificate files!");
 
     validate_agent_name(&agent_config.name)
@@ -174,7 +172,6 @@ async fn main() {
                 register_runtime!(
                     runtime_facade_map,
                     PodmanRuntime {},
-                    PodmanWorkloadId,
                     run_directory.get_path()
                 );
             }
@@ -182,8 +179,7 @@ async fn main() {
                 // [impl->swdd~agent-supports-podman-kube-runtime~1]
                 register_runtime!(
                     runtime_facade_map,
-                    PodmanKubeRuntime {},
-                    PodmanKubeWorkloadId,
+                    PodmanKubeRuntime::default(),
                     run_directory.get_path()
                 );
             }
@@ -192,7 +188,6 @@ async fn main() {
                 register_runtime!(
                     runtime_facade_map,
                     ContainerdRuntime {},
-                    ContainerdWorkloadId,
                     run_directory.get_path()
                 );
             }

--- a/agent/src/runtime_connectors/containerd/containerd_log_fetcher.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_log_fetcher.rs
@@ -13,8 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::log_fetcher::{GetOutputStreams, StreamTrait};
-use super::ContainerdWorkloadId;
-use crate::runtime_connectors::runtime_connector::LogRequestOptions;
+use crate::runtime_connectors::{LogRequestOptions, RuntimeWorkloadId};
 
 use std::process::Stdio;
 #[cfg(test)]
@@ -35,7 +34,7 @@ pub struct ContainerdLogFetcher {
 }
 
 impl ContainerdLogFetcher {
-    pub fn new(workload_id: &ContainerdWorkloadId, options: &LogRequestOptions) -> Self {
+    pub fn new(workload_id: &RuntimeWorkloadId, options: &LogRequestOptions) -> Self {
         let mut args = Vec::with_capacity(9);
         args.push("logs");
         if options.follow {
@@ -55,7 +54,7 @@ impl ContainerdLogFetcher {
             args.push("--tail");
             args.push(_tail.as_str());
         }
-        args.push(&workload_id.id);
+        args.push(workload_id.as_ref());
         let cmd = Command::new(NERDCTL_CMD)
             .args(args)
             .stdout(Stdio::piped())
@@ -128,7 +127,7 @@ impl GetOutputStreams for ContainerdLogFetcher {
 mod tests {
     use super::{ContainerdLogFetcher, NERDCTL_CMD};
     use crate::runtime_connectors::{
-        LogRequestOptions, containerd::ContainerdWorkloadId, log_fetcher::GetOutputStreams,
+        LogRequestOptions, RuntimeWorkloadId, log_fetcher::GetOutputStreams,
     };
 
     use std::process::Stdio;
@@ -211,9 +210,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = true;
         let mut log_fetcher = ContainerdLogFetcher::new(
-            &ContainerdWorkloadId {
-                id: WORKLOAD_ID.into(),
-            },
+            &RuntimeWorkloadId::from(WORKLOAD_ID),
             &LogRequestOptions {
                 follow: false,
                 tail: None,
@@ -243,9 +240,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = true;
         let mut log_fetcher = ContainerdLogFetcher::new(
-            &ContainerdWorkloadId {
-                id: WORKLOAD_ID.into(),
-            },
+            &RuntimeWorkloadId::from(WORKLOAD_ID),
             &LogRequestOptions {
                 follow: true,
                 tail: Some(10),
@@ -274,9 +269,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = false;
         let log_fetcher = ContainerdLogFetcher::new(
-            &ContainerdWorkloadId {
-                id: WORKLOAD_ID.into(),
-            },
+            &RuntimeWorkloadId::from(WORKLOAD_ID),
             &LogRequestOptions {
                 follow: false,
                 tail: None,
@@ -296,9 +289,7 @@ mod tests {
 
         *CAN_KILL.lock().unwrap() = true;
         let log_fetcher = ContainerdLogFetcher::new(
-            &ContainerdWorkloadId {
-                id: WORKLOAD_ID.into(),
-            },
+            &RuntimeWorkloadId::from(WORKLOAD_ID),
             &LogRequestOptions {
                 follow: true,
                 tail: None,
@@ -319,9 +310,7 @@ mod tests {
         *CAN_SPAWN.lock().unwrap() = true;
         *CAN_KILL.lock().unwrap() = false;
         let log_fetcher = ContainerdLogFetcher::new(
-            &ContainerdWorkloadId {
-                id: WORKLOAD_ID.into(),
-            },
+            &RuntimeWorkloadId::from(WORKLOAD_ID),
             &LogRequestOptions {
                 follow: true,
                 tail: None,

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -47,7 +47,7 @@ pub struct ContainerdStateGetter {}
 
 #[async_trait]
 // [impl->swdd~containerd-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<RuntimeWorkloadId> for ContainerdStateGetter {
+impl RuntimeStateGetter for ContainerdStateGetter {
     async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
         log::trace!("Getting the state for the workload '{}'", workload_id);
 

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -16,7 +16,7 @@ use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
         ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
-        StateCheckerHandle, containerd::nerdctl_cli::NerdctlStartConfig,
+        RuntimeWorkloadId, StateCheckerHandle, containerd::nerdctl_cli::NerdctlStartConfig,
         generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
         runtime_connector::LogRequestOptions,
     },
@@ -30,7 +30,7 @@ use common::std_extensions::UnreachableOption;
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall_double::double;
-use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf};
 
 // [impl->swdd~containerd-uses-nerdctl-cli~1]
 use super::containerd_runtime_config::ContainerdRuntimeConfig;
@@ -45,34 +45,17 @@ pub struct ContainerdRuntime {}
 #[derive(Debug, Clone)]
 pub struct ContainerdStateGetter {}
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct ContainerdWorkloadId {
-    pub id: String,
-}
-
-impl Display for ContainerdWorkloadId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id.to_owned())
-    }
-}
-
-impl FromStr for ContainerdWorkloadId {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ContainerdWorkloadId { id: s.to_string() })
-    }
-}
-
 #[async_trait]
 // [impl->swdd~containerd-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<ContainerdWorkloadId> for ContainerdStateGetter {
-    async fn get_state(&self, workload_id: &ContainerdWorkloadId) -> ExecutionStateSpec {
-        log::trace!("Getting the state for the workload '{}'", workload_id.id);
+impl RuntimeStateGetter<RuntimeWorkloadId> for ContainerdStateGetter {
+    async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
+        log::trace!("Getting the state for the workload '{}'", workload_id);
 
         // [impl->swdd~containerd-state-getter-returns-unknown-state~1]
         // [impl->swdd~containerd-state-getter-uses-nerdctlcli~1]
         // [impl->swdd~containerd-state-getter-returns-lost-state~1]
-        let exec_state = match NerdctlCli::list_states_by_id(workload_id.id.as_str()).await {
+        let exec_state = match NerdctlCli::list_states_by_id(workload_id.to_string().as_str()).await
+        {
             Ok(state) => {
                 if let Some(state) = state {
                     state
@@ -83,7 +66,7 @@ impl RuntimeStateGetter<ContainerdWorkloadId> for ContainerdStateGetter {
             Err(err) => {
                 log::warn!(
                     "Could not get state of workload '{}': '{}'. Returning unknown.",
-                    workload_id.id,
+                    workload_id,
                     err
                 );
                 ExecutionStateSpec::unknown("Error getting state from Nerdctl.")
@@ -93,7 +76,7 @@ impl RuntimeStateGetter<ContainerdWorkloadId> for ContainerdStateGetter {
         log::trace!(
             "Returning the state '{}' for the workload '{}'",
             exec_state,
-            workload_id.id
+            workload_id
         );
         exec_state
     }
@@ -106,12 +89,12 @@ impl ContainerdRuntime {
     ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
         let mut workload_states = Vec::<ReusableWorkloadState>::default();
         for instance_name in workload_instance_names {
-            let workload_id = &self.get_workload_id(instance_name).await?.id;
-            match NerdctlCli::list_states_by_id(workload_id).await {
+            let workload_id = self.get_workload_id(instance_name).await?.to_string();
+            match NerdctlCli::list_states_by_id(&workload_id).await {
                 Ok(Some(execution_state)) => workload_states.push(ReusableWorkloadState::new(
                     instance_name.clone(),
                     execution_state,
-                    Some(workload_id.to_string()),
+                    Some(workload_id),
                 )),
                 Ok(None) => {
                     return Err(RuntimeError::List(format!(
@@ -127,7 +110,7 @@ impl ContainerdRuntime {
 
 #[async_trait]
 // [impl->swdd~containerd-implements-runtime-connector~1]
-impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
+impl RuntimeConnector for ContainerdRuntime {
     // [impl->swdd~containerd-name-returns-containerd~1]
     fn name(&self) -> String {
         CONTAINERD_RUNTIME_NAME.to_string()
@@ -157,11 +140,11 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
     async fn create_workload(
         &self,
         workload_named: WorkloadNamed,
-        reusable_workload_id: Option<ContainerdWorkloadId>,
+        reusable_workload_id: Option<RuntimeWorkloadId>,
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(ContainerdWorkloadId, StateCheckerHandle), RuntimeError> {
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
         let workload_cfg = ContainerdRuntimeConfig::try_from(&workload_named.workload)
             .map_err(RuntimeError::Unsupported)?;
 
@@ -169,7 +152,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
             Some(workload_id) => {
                 let start_config = NerdctlStartConfig {
                     general_options: workload_cfg.general_options,
-                    container_id: workload_id.id,
+                    container_id: workload_id.to_string(),
                 };
                 NerdctlCli::nerdctl_start(start_config, &workload_named.instance_name.to_string())
                     .await
@@ -194,7 +177,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
                     workload_id
                 );
 
-                let nerdctl_workload_id = ContainerdWorkloadId { id: workload_id };
+                let nerdctl_workload_id = RuntimeWorkloadId::from(workload_id);
                 let state_checker = self
                     .start_checker(&nerdctl_workload_id, workload_named, update_state_tx)
                     .await?;
@@ -223,7 +206,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
     async fn get_workload_id(
         &self,
         instance_name: &WorkloadInstanceNameSpec,
-    ) -> Result<ContainerdWorkloadId, RuntimeError> {
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
         // [impl->swdd~containerd-get-workload-id-uses-label~1]
         let res =
             NerdctlCli::list_container_ids_by_label("name", instance_name.to_string().as_str())
@@ -235,7 +218,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
         if LENGTH_FOR_VALID_ID == res.len() {
             let id = res.first().unwrap_or_unreachable();
             log::debug!("Found an id for workload '{instance_name}': '{id}'");
-            Ok(ContainerdWorkloadId { id: id.to_string() })
+            Ok(RuntimeWorkloadId::from(id.to_string()))
         } else {
             log::warn!("get_workload_id returned unexpected number of workloads {res:?}");
             Err(RuntimeError::List(
@@ -247,7 +230,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
     // [impl->swdd~containerd-start-checker-starts-containerd-state-checker~1]
     async fn start_checker(
         &self,
-        workload_id: &ContainerdWorkloadId,
+        workload_id: &RuntimeWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
     ) -> Result<StateCheckerHandle, RuntimeError> {
@@ -257,7 +240,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
         log::debug!(
             "Starting the checker for the workload '{}' with internal id '{}'",
             workload_named.instance_name,
-            workload_id.id
+            workload_id
         );
         let checker = GenericPollingStateChecker::start_checker(
             &workload_named,
@@ -270,7 +253,7 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
 
     fn get_log_fetcher(
         &self,
-        workload_id: ContainerdWorkloadId,
+        workload_id: RuntimeWorkloadId,
         options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
         let nerdctl_log_fetcher =
@@ -280,12 +263,9 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
     }
 
     // [impl->swdd~containerd-delete-workload-stops-and-removes-workload~1]
-    async fn delete_workload(
-        &self,
-        workload_id: &ContainerdWorkloadId,
-    ) -> Result<(), RuntimeError> {
-        log::debug!("Deleting workload with id '{}'", workload_id.id);
-        NerdctlCli::remove_workloads_by_id(&workload_id.id)
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
+        log::debug!("Deleting workload with id '{}'", workload_id);
+        NerdctlCli::remove_workloads_by_id(&workload_id.to_string())
             .await
             .map_err(|err| RuntimeError::Delete(err.to_string()))
     }
@@ -302,10 +282,10 @@ impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
 // [utest->swdd~agent-functions-required-by-runtime-connector~1]
 #[cfg(test)]
 mod tests {
-    use super::{ContainerdRuntime, ContainerdStateGetter, ContainerdWorkloadId, NerdctlCli};
+    use super::{ContainerdRuntime, ContainerdStateGetter, NerdctlCli};
     use crate::runtime_connectors::containerd::containerd_runtime::CONTAINERD_RUNTIME_NAME;
     use crate::runtime_connectors::{
-        LogRequestOptions, RuntimeConnector, RuntimeError, RuntimeStateGetter,
+        LogRequestOptions, RuntimeConnector, RuntimeError, RuntimeStateGetter, RuntimeWorkloadId,
     };
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
 
@@ -315,7 +295,6 @@ mod tests {
 
     use mockall::Sequence;
     use std::path::PathBuf;
-    use std::str::FromStr;
 
     fn generate_test_containerd_workload() -> WorkloadNamed {
         generate_test_workload_named_with_params(
@@ -455,7 +434,10 @@ mod tests {
         let (workload_id, _checker) = res.unwrap();
 
         // [utest->swdd~containerd-create-workload-returns-workload-id~1]
-        assert_eq!(workload_id.id, fixtures::WORKLOAD_IDS[0].to_string());
+        assert_eq!(
+            workload_id.to_string(),
+            fixtures::WORKLOAD_IDS[0].to_string()
+        );
     }
 
     // [utest->swdd~containerd-create-workload-starts-existing-workload~1]
@@ -479,7 +461,9 @@ mod tests {
         let res = containerd_runtime
             .create_workload(
                 workload_named,
-                Some(ContainerdWorkloadId::from_str(fixtures::WORKLOAD_IDS[0]).unwrap()),
+                Some(RuntimeWorkloadId::from(
+                    fixtures::WORKLOAD_IDS[0].to_string(),
+                )),
                 Some(PathBuf::from(fixtures::RUN_FOLDER)),
                 state_change_tx,
                 Default::default(),
@@ -489,7 +473,7 @@ mod tests {
         let (workload_id, _checker) = res.unwrap();
 
         // [utest->swdd~containerd-create-workload-returns-workload-id~1]
-        assert_eq!(workload_id.id, fixtures::WORKLOAD_IDS[0]);
+        assert_eq!(workload_id.to_string(), fixtures::WORKLOAD_IDS[0]);
     }
 
     // [utest->swdd~containerd-state-getter-reset-cache~1]
@@ -550,9 +534,9 @@ mod tests {
 
         let state_getter = ContainerdStateGetter {};
         let execution_state = state_getter
-            .get_state(&ContainerdWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            })
+            .get_state(&RuntimeWorkloadId::from(
+                fixtures::WORKLOAD_IDS[0].to_string(),
+            ))
             .await;
 
         assert_eq!(execution_state, ExecutionStateSpec::running());
@@ -667,9 +651,9 @@ mod tests {
 
         assert_eq!(
             res,
-            Ok(ContainerdWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into()
-            })
+            Ok(RuntimeWorkloadId::from(
+                fixtures::WORKLOAD_IDS[0].to_string()
+            ))
         )
     }
 
@@ -722,9 +706,7 @@ mod tests {
             .expect()
             .return_const(Ok(Some(ExecutionStateSpec::running())));
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::running());
@@ -738,9 +720,7 @@ mod tests {
         let context = NerdctlCli::list_states_by_id_context();
         context.expect().return_const(Ok(None));
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::lost())
@@ -754,9 +734,7 @@ mod tests {
         let context = NerdctlCli::list_states_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(
@@ -773,9 +751,7 @@ mod tests {
         let context = NerdctlCli::remove_workloads_by_id_context();
         context.expect().return_const(Ok(()));
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
 
         let containerd_runtime = ContainerdRuntime {};
         let res = containerd_runtime.delete_workload(&workload_id).await;
@@ -790,9 +766,7 @@ mod tests {
         let context = NerdctlCli::remove_workloads_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
 
         let containerd_runtime = ContainerdRuntime {};
         let res = containerd_runtime.delete_workload(&workload_id).await;
@@ -803,9 +777,7 @@ mod tests {
     async fn utest_get_log_fetcher() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
 
-        let workload_id = ContainerdWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
 
         let log_request = LogRequestOptions {
             follow: false,

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -15,9 +15,10 @@
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
-        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter, StateChecker,
-        containerd::nerdctl_cli::NerdctlStartConfig, generic_log_fetcher::GenericLogFetcher,
-        log_fetcher::LogFetcher, runtime_connector::LogRequestOptions,
+        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
+        StateCheckerHandle, containerd::nerdctl_cli::NerdctlStartConfig,
+        generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
+        runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
 };
@@ -126,7 +127,7 @@ impl ContainerdRuntime {
 
 #[async_trait]
 // [impl->swdd~containerd-implements-runtime-connector~1]
-impl RuntimeConnector<ContainerdWorkloadId, GenericPollingStateChecker> for ContainerdRuntime {
+impl RuntimeConnector<ContainerdWorkloadId> for ContainerdRuntime {
     // [impl->swdd~containerd-name-returns-containerd~1]
     fn name(&self) -> String {
         CONTAINERD_RUNTIME_NAME.to_string()
@@ -160,7 +161,7 @@ impl RuntimeConnector<ContainerdWorkloadId, GenericPollingStateChecker> for Cont
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(ContainerdWorkloadId, GenericPollingStateChecker), RuntimeError> {
+    ) -> Result<(ContainerdWorkloadId, StateCheckerHandle), RuntimeError> {
         let workload_cfg = ContainerdRuntimeConfig::try_from(&workload_named.workload)
             .map_err(RuntimeError::Unsupported)?;
 
@@ -249,7 +250,7 @@ impl RuntimeConnector<ContainerdWorkloadId, GenericPollingStateChecker> for Cont
         workload_id: &ContainerdWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
-    ) -> Result<GenericPollingStateChecker, RuntimeError> {
+    ) -> Result<StateCheckerHandle, RuntimeError> {
         // [impl->swdd~containerd-state-getter-reset-cache~1]
         NerdctlCli::reset_ps_cache().await;
 
@@ -264,7 +265,7 @@ impl RuntimeConnector<ContainerdWorkloadId, GenericPollingStateChecker> for Cont
             update_state_tx,
             ContainerdStateGetter {},
         );
-        Ok(checker)
+        Ok(Box::new(checker))
     }
 
     fn get_log_fetcher(

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -152,7 +152,7 @@ impl RuntimeConnector for ContainerdRuntime {
             Some(workload_id) => {
                 let start_config = NerdctlStartConfig {
                     general_options: workload_cfg.general_options,
-                    container_id: workload_id.to_string(),
+                    container_id: workload_id.into(),
                 };
                 NerdctlCli::nerdctl_start(start_config, &workload_named.instance_name.to_string())
                     .await
@@ -218,7 +218,7 @@ impl RuntimeConnector for ContainerdRuntime {
         if LENGTH_FOR_VALID_ID == res.len() {
             let id = res.first().unwrap_or_unreachable();
             log::debug!("Found an id for workload '{instance_name}': '{id}'");
-            Ok(RuntimeWorkloadId::from(id.to_string()))
+            Ok(RuntimeWorkloadId::from(id.as_ref()))
         } else {
             log::warn!("get_workload_id returned unexpected number of workloads {res:?}");
             Err(RuntimeError::List(
@@ -461,9 +461,7 @@ mod tests {
         let res = containerd_runtime
             .create_workload(
                 workload_named,
-                Some(RuntimeWorkloadId::from(
-                    fixtures::WORKLOAD_IDS[0].to_string(),
-                )),
+                Some(RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0])),
                 Some(PathBuf::from(fixtures::RUN_FOLDER)),
                 state_change_tx,
                 Default::default(),
@@ -534,9 +532,7 @@ mod tests {
 
         let state_getter = ContainerdStateGetter {};
         let execution_state = state_getter
-            .get_state(&RuntimeWorkloadId::from(
-                fixtures::WORKLOAD_IDS[0].to_string(),
-            ))
+            .get_state(&RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]))
             .await;
 
         assert_eq!(execution_state, ExecutionStateSpec::running());
@@ -649,12 +645,7 @@ mod tests {
         let containerd_runtime = ContainerdRuntime {};
         let res = containerd_runtime.get_workload_id(&workload_name).await;
 
-        assert_eq!(
-            res,
-            Ok(RuntimeWorkloadId::from(
-                fixtures::WORKLOAD_IDS[0].to_string()
-            ))
-        )
+        assert_eq!(res, Ok(RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0])))
     }
 
     #[tokio::test]
@@ -706,7 +697,7 @@ mod tests {
             .expect()
             .return_const(Ok(Some(ExecutionStateSpec::running())));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::running());
@@ -720,7 +711,7 @@ mod tests {
         let context = NerdctlCli::list_states_by_id_context();
         context.expect().return_const(Ok(None));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::lost())
@@ -734,7 +725,7 @@ mod tests {
         let context = NerdctlCli::list_states_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
         let checker = ContainerdStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(
@@ -751,7 +742,7 @@ mod tests {
         let context = NerdctlCli::remove_workloads_by_id_context();
         context.expect().return_const(Ok(()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
 
         let containerd_runtime = ContainerdRuntime {};
         let res = containerd_runtime.delete_workload(&workload_id).await;
@@ -766,7 +757,7 @@ mod tests {
         let context = NerdctlCli::remove_workloads_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
 
         let containerd_runtime = ContainerdRuntime {};
         let res = containerd_runtime.delete_workload(&workload_id).await;
@@ -777,7 +768,7 @@ mod tests {
     async fn utest_get_log_fetcher() {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
 
         let log_request = LogRequestOptions {
             follow: false,

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -265,7 +265,7 @@ impl RuntimeConnector for ContainerdRuntime {
     // [impl->swdd~containerd-delete-workload-stops-and-removes-workload~1]
     async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
         log::debug!("Deleting workload with id '{}'", workload_id);
-        NerdctlCli::remove_workloads_by_id(&workload_id.to_string())
+        NerdctlCli::remove_workloads_by_id(workload_id.as_ref())
             .await
             .map_err(|err| RuntimeError::Delete(err.to_string()))
     }

--- a/agent/src/runtime_connectors/containerd/mod.rs
+++ b/agent/src/runtime_connectors/containerd/mod.rs
@@ -16,6 +16,4 @@ pub(crate) mod containerd_log_fetcher;
 mod containerd_runtime;
 mod containerd_runtime_config;
 mod nerdctl_cli;
-pub use containerd_runtime::{
-    CONTAINERD_RUNTIME_NAME as NAME, ContainerdRuntime, ContainerdWorkloadId,
-};
+pub use containerd_runtime::{CONTAINERD_RUNTIME_NAME as NAME, ContainerdRuntime};

--- a/agent/src/runtime_connectors/dummy_state_checker.rs
+++ b/agent/src/runtime_connectors/dummy_state_checker.rs
@@ -12,37 +12,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{RuntimeStateGetter, StateChecker};
-use crate::workload_state::WorkloadStateSender;
-use ankaios_api::ank_base::WorkloadNamed;
-
+use super::StateChecker;
 use async_trait::async_trait;
-use std::str::FromStr;
 
 // [impl->swdd~agent-skips-unknown-runtime~2]
-pub struct DummyStateChecker<WorkloadId>(std::marker::PhantomData<WorkloadId>);
+pub struct DummyStateChecker;
 
-impl<WorkloadId> DummyStateChecker<WorkloadId> {
+impl DummyStateChecker {
     pub fn new() -> Self {
-        Self(std::marker::PhantomData)
+        Self
     }
 }
 
 // [impl->swdd~agent-skips-unknown-runtime~2]
 #[async_trait]
-impl<WorkloadId> StateChecker<WorkloadId> for DummyStateChecker<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    fn start_checker(
-        _workload_named: &WorkloadNamed,
-        _workload_id: WorkloadId,
-        _manager_interface: WorkloadStateSender,
-        _state_getter: impl RuntimeStateGetter<WorkloadId>,
-    ) -> Self {
-        Self(std::marker::PhantomData)
-    }
-    async fn stop_checker(self) {}
+impl StateChecker for DummyStateChecker {
+    async fn stop_checker(self: Box<Self>) {}
 }
 //////////////////////////////////////////////////////////////////////////////
 //                 ########  #######    #########  #########                //
@@ -54,21 +39,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{DummyStateChecker, StateChecker};
-    use crate::runtime_connectors::MockRuntimeStateGetter;
-
-    use ankaios_api::test_utils::{fixtures, generate_test_workload_named};
+    use super::DummyStateChecker;
+    use crate::runtime_connectors::StateChecker;
 
     // [utest->swdd~agent-skips-unknown-runtime~2]
     #[tokio::test]
     async fn utest_dummy_state_checker() {
-        let workload = generate_test_workload_named();
-        let workload_id = fixtures::WORKLOAD_IDS[0].to_string();
-        let (state_sender, _) = tokio::sync::mpsc::channel(10);
-        let state_getter = MockRuntimeStateGetter::default();
-
-        let checker =
-            DummyStateChecker::start_checker(&workload, workload_id, state_sender, state_getter);
+        let checker: Box<dyn StateChecker + Send + Sync> = Box::new(DummyStateChecker::new());
 
         checker.stop_checker().await;
     }

--- a/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
+++ b/agent/src/runtime_connectors/log_fetching/generic_log_fetcher.rs
@@ -182,8 +182,8 @@ pub mod test {
     use crate::runtime_connectors::{
         generic_log_fetcher::{GenericLogFetcher, GenericSingleLogFetcher},
         log_fetcher::{LogFetcher, StreamTrait},
-        podman::{PodmanWorkloadId, podman_log_fetcher::PodmanLogFetcher},
-        runtime_connector::LogRequestOptions,
+        podman::podman_log_fetcher::PodmanLogFetcher,
+        runtime_connector::{LogRequestOptions, RuntimeWorkloadId},
     };
 
     use std::{
@@ -463,11 +463,8 @@ pub mod test {
         stdout: Option<Box<dyn StreamTrait>>,
         stderr: Option<Box<dyn StreamTrait>>,
     ) -> GenericLogFetcher<PodmanLogFetcher> {
-        let workload_id = PodmanWorkloadId {
-            id: "test".to_string(),
-        };
         let mut podman_log_fetcher = PodmanLogFetcher::new(
-            &workload_id,
+            &RuntimeWorkloadId::from("test"),
             &LogRequestOptions {
                 follow: true,
                 since: Some("test_since".to_string()),

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -22,8 +22,7 @@ pub(crate) mod podman_kube;
 
 pub(crate) mod containerd;
 
-pub(crate) mod dummy_state_checker;
-pub(crate) mod unsupported_runtime;
+pub(crate) mod unsupported;
 
 mod runtime_connector;
 pub use runtime_connector::{

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -42,7 +42,7 @@ pub use runtime_facade::{GenericRuntimeFacade, RuntimeFacade};
 pub use runtime_facade::MockRuntimeFacade;
 
 mod state_checker;
-pub use state_checker::{RuntimeStateGetter, StateChecker};
+pub use state_checker::{RuntimeStateGetter, StateChecker, StateCheckerHandle};
 
 #[cfg(test)]
 pub use state_checker::MockRuntimeStateGetter;

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod unsupported_runtime;
 mod runtime_connector;
 pub use runtime_connector::{
     LogRequestOptions, OwnableRuntime, ReusableWorkloadState, RuntimeConnector, RuntimeError,
+    RuntimeWorkloadId,
 };
 
 #[cfg(test)]

--- a/agent/src/runtime_connectors/podman/mod.rs
+++ b/agent/src/runtime_connectors/podman/mod.rs
@@ -15,4 +15,4 @@
 pub(crate) mod podman_log_fetcher;
 mod podman_runtime;
 mod podman_runtime_config;
-pub use podman_runtime::{PODMAN_RUNTIME_NAME as NAME, PodmanRuntime, PodmanWorkloadId};
+pub use podman_runtime::{PODMAN_RUNTIME_NAME as NAME, PodmanRuntime};

--- a/agent/src/runtime_connectors/podman/podman_log_fetcher.rs
+++ b/agent/src/runtime_connectors/podman/podman_log_fetcher.rs
@@ -13,8 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::log_fetcher::{GetOutputStreams, StreamTrait};
-use super::PodmanWorkloadId;
-use crate::runtime_connectors::runtime_connector::LogRequestOptions;
+use crate::runtime_connectors::runtime_connector::{LogRequestOptions, RuntimeWorkloadId};
 
 use std::process::Stdio;
 #[cfg(test)]
@@ -34,7 +33,7 @@ pub struct PodmanLogFetcher {
 }
 
 impl PodmanLogFetcher {
-    pub fn new(workload_id: &PodmanWorkloadId, options: &LogRequestOptions) -> Self {
+    pub fn new(workload_id: &RuntimeWorkloadId, options: &LogRequestOptions) -> Self {
         let mut args = Vec::with_capacity(9);
         args.push("logs");
         if options.follow {
@@ -54,7 +53,7 @@ impl PodmanLogFetcher {
             args.push("--tail");
             args.push(_tail.as_str());
         }
-        args.push(&workload_id.id);
+        args.push(workload_id.as_ref());
         let cmd = Command::new("podman")
             .args(args)
             .stdout(Stdio::piped())
@@ -137,7 +136,7 @@ impl GetOutputStreams for PodmanLogFetcher {
 mod tests {
     use super::PodmanLogFetcher;
     use crate::runtime_connectors::{
-        LogRequestOptions, log_fetcher::GetOutputStreams, podman::PodmanWorkloadId,
+        LogRequestOptions, RuntimeWorkloadId, log_fetcher::GetOutputStreams,
     };
     use ankaios_api::test_utils::fixtures;
 
@@ -219,9 +218,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = true;
         let mut log_fetcher = PodmanLogFetcher::new(
-            &PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            },
+            &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]),
             &LogRequestOptions {
                 follow: false,
                 tail: None,
@@ -251,9 +248,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = true;
         let mut log_fetcher = PodmanLogFetcher::new(
-            &PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            },
+            &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]),
             &LogRequestOptions {
                 follow: true,
                 tail: Some(10),
@@ -282,9 +277,7 @@ mod tests {
         let _guard = TEST_LOCK.lock().unwrap();
         *CAN_SPAWN.lock().unwrap() = false;
         let log_fetcher = PodmanLogFetcher::new(
-            &PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            },
+            &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]),
             &LogRequestOptions {
                 follow: false,
                 tail: None,
@@ -304,9 +297,7 @@ mod tests {
 
         *CAN_KILL.lock().unwrap() = true;
         let log_fetcher = PodmanLogFetcher::new(
-            &PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            },
+            &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]),
             &LogRequestOptions {
                 follow: true,
                 tail: None,
@@ -327,9 +318,7 @@ mod tests {
         *CAN_SPAWN.lock().unwrap() = true;
         *CAN_KILL.lock().unwrap() = false;
         let log_fetcher = PodmanLogFetcher::new(
-            &PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            },
+            &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]),
             &LogRequestOptions {
                 follow: true,
                 tail: None,

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -430,10 +430,7 @@ mod tests {
         let (workload_id, _checker) = res.unwrap();
 
         // [utest->swdd~podman-create-workload-returns-workload-id~1]
-        assert_eq!(
-            workload_id.to_string(),
-            fixtures::WORKLOAD_IDS[0].to_string()
-        );
+        assert_eq!(workload_id.as_ref(), fixtures::WORKLOAD_IDS[0]);
     }
 
     // [utest->swdd~podman-create-workload-starts-existing-workload~1]
@@ -457,9 +454,7 @@ mod tests {
         let res = podman_runtime
             .create_workload(
                 workload,
-                Some(RuntimeWorkloadId::from(
-                    fixtures::WORKLOAD_IDS[0].to_string(),
-                )),
+                Some(RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0])),
                 Some(PathBuf::from(fixtures::RUN_FOLDER)),
                 state_change_tx,
                 Default::default(),
@@ -530,9 +525,7 @@ mod tests {
 
         let state_getter = PodmanStateGetter {};
         let execution_state = state_getter
-            .get_state(&RuntimeWorkloadId::from(
-                fixtures::WORKLOAD_IDS[0].to_string(),
-            ))
+            .get_state(&RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]))
             .await;
 
         assert_eq!(execution_state, ExecutionStateSpec::running());
@@ -644,12 +637,7 @@ mod tests {
         let podman_runtime = PodmanRuntime {};
         let res = podman_runtime.get_workload_id(&workload_name).await;
 
-        assert_eq!(
-            res,
-            Ok(RuntimeWorkloadId::from(
-                fixtures::WORKLOAD_IDS[0].to_string()
-            ))
-        )
+        assert_eq!(res, Ok(RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0])))
     }
 
     #[tokio::test]
@@ -701,7 +689,7 @@ mod tests {
             .expect()
             .return_const(Ok(Some(ExecutionStateSpec::running())));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
         let checker = PodmanStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::running());
@@ -729,7 +717,7 @@ mod tests {
         let context = PodmanCli::list_states_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
         let checker = PodmanStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(
@@ -746,7 +734,7 @@ mod tests {
         let context = PodmanCli::remove_workloads_by_id_context();
         context.expect().return_const(Ok(()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
 
         let podman_runtime = PodmanRuntime {};
         let res = podman_runtime.delete_workload(&workload_id).await;
@@ -760,7 +748,7 @@ mod tests {
         let context = PodmanCli::remove_workloads_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0]);
 
         let podman_runtime = PodmanRuntime {};
         let res = podman_runtime.delete_workload(&workload_id).await;

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -19,8 +19,8 @@ use crate::runtime_connectors::podman_cli::PodmanCli;
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
-        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter, StateChecker,
-        generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
+        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
+        StateCheckerHandle, generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
         podman_cli::PodmanStartConfig, runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
@@ -125,7 +125,7 @@ impl PodmanRuntime {
 
 #[async_trait]
 // [impl->swdd~podman-implements-runtime-connector~1]
-impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRuntime {
+impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
     // [impl->swdd~podman-name-returns-podman~1]
     fn name(&self) -> String {
         PODMAN_RUNTIME_NAME.to_string()
@@ -159,7 +159,7 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(PodmanWorkloadId, GenericPollingStateChecker), RuntimeError> {
+    ) -> Result<(PodmanWorkloadId, StateCheckerHandle), RuntimeError> {
         let workload_cfg = PodmanRuntimeConfig::try_from(&workload_named.workload)
             .map_err(RuntimeError::Unsupported)?;
 
@@ -247,7 +247,7 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
         workload_id: &PodmanWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
-    ) -> Result<GenericPollingStateChecker, RuntimeError> {
+    ) -> Result<StateCheckerHandle, RuntimeError> {
         // [impl->swdd~podman-state-getter-reset-cache~1]
         PodmanCli::reset_ps_cache().await;
 
@@ -262,7 +262,7 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
             update_state_tx,
             PodmanStateGetter {},
         );
-        Ok(checker)
+        Ok(Box::new(checker))
     }
 
     fn get_log_fetcher(

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -46,7 +46,7 @@ pub struct PodmanStateGetter {}
 
 #[async_trait]
 // [impl->swdd~podman-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<RuntimeWorkloadId> for PodmanStateGetter {
+impl RuntimeStateGetter for PodmanStateGetter {
     async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
         log::trace!("Getting the state for the workload '{}'", workload_id);
 

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -20,8 +20,9 @@ use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
         ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
-        StateCheckerHandle, generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
-        podman_cli::PodmanStartConfig, runtime_connector::LogRequestOptions,
+        RuntimeWorkloadId, StateCheckerHandle, generic_log_fetcher::GenericLogFetcher,
+        log_fetcher::LogFetcher, podman_cli::PodmanStartConfig,
+        runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
 };
@@ -33,7 +34,7 @@ use common::std_extensions::UnreachableOption;
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall_double::double;
-use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf};
 
 pub const PODMAN_RUNTIME_NAME: &str = "podman";
 
@@ -43,34 +44,16 @@ pub struct PodmanRuntime {}
 #[derive(Debug, Clone)]
 pub struct PodmanStateGetter {}
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct PodmanWorkloadId {
-    pub id: String,
-}
-
-impl Display for PodmanWorkloadId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.id.to_owned())
-    }
-}
-
-impl FromStr for PodmanWorkloadId {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(PodmanWorkloadId { id: s.to_string() })
-    }
-}
-
 #[async_trait]
 // [impl->swdd~podman-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<PodmanWorkloadId> for PodmanStateGetter {
-    async fn get_state(&self, workload_id: &PodmanWorkloadId) -> ExecutionStateSpec {
-        log::trace!("Getting the state for the workload '{}'", workload_id.id);
+impl RuntimeStateGetter<RuntimeWorkloadId> for PodmanStateGetter {
+    async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
+        log::trace!("Getting the state for the workload '{}'", workload_id);
 
         // [impl->swdd~podman-state-getter-returns-unknown-state~1]
         // [impl->swdd~podman-state-getter-uses-podmancli~1]
         // [impl->swdd~podman-state-getter-returns-lost-state~1]
-        let exec_state = match PodmanCli::list_states_by_id(workload_id.id.as_str()).await {
+        let exec_state = match PodmanCli::list_states_by_id(workload_id.as_ref()).await {
             Ok(state) => {
                 if let Some(state) = state {
                     state
@@ -81,7 +64,7 @@ impl RuntimeStateGetter<PodmanWorkloadId> for PodmanStateGetter {
             Err(err) => {
                 log::warn!(
                     "Could not get state of workload '{}': '{}'. Returning unknown.",
-                    workload_id.id,
+                    workload_id,
                     err
                 );
                 ExecutionStateSpec::unknown("Error getting state from Podman.")
@@ -91,7 +74,7 @@ impl RuntimeStateGetter<PodmanWorkloadId> for PodmanStateGetter {
         log::trace!(
             "Returning the state '{}' for the workload '{}'",
             exec_state,
-            workload_id.id
+            workload_id
         );
         exec_state
     }
@@ -104,8 +87,8 @@ impl PodmanRuntime {
     ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
         let mut workload_states = Vec::<ReusableWorkloadState>::default();
         for instance_name in workload_instance_names {
-            let workload_id = &self.get_workload_id(instance_name).await?.id;
-            match PodmanCli::list_states_by_id(workload_id).await {
+            let workload_id = self.get_workload_id(instance_name).await?;
+            match PodmanCli::list_states_by_id(workload_id.as_ref()).await {
                 Ok(Some(execution_state)) => workload_states.push(ReusableWorkloadState::new(
                     instance_name.clone(),
                     execution_state,
@@ -125,7 +108,7 @@ impl PodmanRuntime {
 
 #[async_trait]
 // [impl->swdd~podman-implements-runtime-connector~1]
-impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
+impl RuntimeConnector for PodmanRuntime {
     // [impl->swdd~podman-name-returns-podman~1]
     fn name(&self) -> String {
         PODMAN_RUNTIME_NAME.to_string()
@@ -155,11 +138,11 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
     async fn create_workload(
         &self,
         workload_named: WorkloadNamed,
-        reusable_workload_id: Option<PodmanWorkloadId>,
+        reusable_workload_id: Option<RuntimeWorkloadId>,
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(PodmanWorkloadId, StateCheckerHandle), RuntimeError> {
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
         let workload_cfg = PodmanRuntimeConfig::try_from(&workload_named.workload)
             .map_err(RuntimeError::Unsupported)?;
 
@@ -167,7 +150,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
             Some(workload_id) => {
                 let start_config = PodmanStartConfig {
                     general_options: workload_cfg.general_options,
-                    container_id: workload_id.id,
+                    container_id: workload_id.to_string(),
                 };
                 PodmanCli::podman_start(start_config, &workload_named.instance_name.to_string())
                     .await
@@ -192,7 +175,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
                     workload_id
                 );
 
-                let podman_workload_id = PodmanWorkloadId { id: workload_id };
+                let podman_workload_id = RuntimeWorkloadId::from(workload_id);
                 let state_checker = self
                     .start_checker(&podman_workload_id, workload_named, update_state_tx)
                     .await?;
@@ -221,7 +204,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
     async fn get_workload_id(
         &self,
         instance_name: &WorkloadInstanceNameSpec,
-    ) -> Result<PodmanWorkloadId, RuntimeError> {
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
         // [impl->swdd~podman-get-workload-id-uses-label~1]
         let res =
             PodmanCli::list_container_ids_by_label("name", instance_name.to_string().as_str())
@@ -232,7 +215,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
         if LENGTH_FOR_VALID_ID == res.len() {
             let id = res.first().unwrap_or_unreachable();
             log::debug!("Found an id for workload '{instance_name}': '{id}'");
-            Ok(PodmanWorkloadId { id: id.to_string() })
+            Ok(RuntimeWorkloadId::from(id.to_string()))
         } else {
             log::warn!("get_workload_id returned unexpected number of workloads {res:?}");
             Err(RuntimeError::List(
@@ -244,7 +227,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
     // [impl->swdd~podman-start-checker-starts-podman-state-checker~1]
     async fn start_checker(
         &self,
-        workload_id: &PodmanWorkloadId,
+        workload_id: &RuntimeWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
     ) -> Result<StateCheckerHandle, RuntimeError> {
@@ -254,7 +237,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
         log::debug!(
             "Starting the checker for the workload '{}' with internal id '{}'",
             workload_named.instance_name,
-            workload_id.id
+            workload_id
         );
         let checker = GenericPollingStateChecker::start_checker(
             &workload_named,
@@ -267,7 +250,7 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
 
     fn get_log_fetcher(
         &self,
-        workload_id: PodmanWorkloadId,
+        workload_id: RuntimeWorkloadId,
         options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
         let podman_log_fetcher =
@@ -277,9 +260,9 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
     }
 
     // [impl->swdd~podman-delete-workload-stops-and-removes-workload~1]
-    async fn delete_workload(&self, workload_id: &PodmanWorkloadId) -> Result<(), RuntimeError> {
-        log::debug!("Deleting workload with id '{}'", workload_id.id);
-        PodmanCli::remove_workloads_by_id(&workload_id.id)
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
+        log::debug!("Deleting workload with id '{}'", workload_id);
+        PodmanCli::remove_workloads_by_id(workload_id.as_ref())
             .await
             .map_err(|err| RuntimeError::Delete(err.to_string()))
     }
@@ -296,10 +279,10 @@ impl RuntimeConnector<PodmanWorkloadId> for PodmanRuntime {
 // [utest->swdd~agent-functions-required-by-runtime-connector~1]
 #[cfg(test)]
 mod tests {
-    use super::{
-        PODMAN_RUNTIME_NAME, PodmanCli, PodmanRuntime, PodmanStateGetter, PodmanWorkloadId,
+    use super::{PODMAN_RUNTIME_NAME, PodmanCli, PodmanRuntime, PodmanStateGetter};
+    use crate::runtime_connectors::{
+        RuntimeConnector, RuntimeError, RuntimeStateGetter, RuntimeWorkloadId,
     };
-    use crate::runtime_connectors::{RuntimeConnector, RuntimeError, RuntimeStateGetter};
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
 
     use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec, WorkloadNamed};
@@ -308,7 +291,6 @@ mod tests {
 
     use mockall::Sequence;
     use std::path::PathBuf;
-    use std::str::FromStr;
 
     fn generate_test_podman_workload() -> WorkloadNamed {
         generate_test_workload_named_with_params(
@@ -448,7 +430,10 @@ mod tests {
         let (workload_id, _checker) = res.unwrap();
 
         // [utest->swdd~podman-create-workload-returns-workload-id~1]
-        assert_eq!(workload_id.id, fixtures::WORKLOAD_IDS[0].to_string());
+        assert_eq!(
+            workload_id.to_string(),
+            fixtures::WORKLOAD_IDS[0].to_string()
+        );
     }
 
     // [utest->swdd~podman-create-workload-starts-existing-workload~1]
@@ -472,7 +457,9 @@ mod tests {
         let res = podman_runtime
             .create_workload(
                 workload,
-                Some(PodmanWorkloadId::from_str(fixtures::WORKLOAD_IDS[0]).unwrap()),
+                Some(RuntimeWorkloadId::from(
+                    fixtures::WORKLOAD_IDS[0].to_string(),
+                )),
                 Some(PathBuf::from(fixtures::RUN_FOLDER)),
                 state_change_tx,
                 Default::default(),
@@ -482,7 +469,7 @@ mod tests {
         let (workload_id, _checker) = res.unwrap();
 
         // [utest->swdd~podman-create-workload-returns-workload-id~1]
-        assert_eq!(workload_id.id, fixtures::WORKLOAD_IDS[0]);
+        assert_eq!(workload_id.to_string(), fixtures::WORKLOAD_IDS[0]);
     }
 
     // [utest->swdd~podman-state-getter-reset-cache~1]
@@ -543,9 +530,9 @@ mod tests {
 
         let state_getter = PodmanStateGetter {};
         let execution_state = state_getter
-            .get_state(&PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into(),
-            })
+            .get_state(&RuntimeWorkloadId::from(
+                fixtures::WORKLOAD_IDS[0].to_string(),
+            ))
             .await;
 
         assert_eq!(execution_state, ExecutionStateSpec::running());
@@ -659,9 +646,9 @@ mod tests {
 
         assert_eq!(
             res,
-            Ok(PodmanWorkloadId {
-                id: fixtures::WORKLOAD_IDS[0].into()
-            })
+            Ok(RuntimeWorkloadId::from(
+                fixtures::WORKLOAD_IDS[0].to_string()
+            ))
         )
     }
 
@@ -714,9 +701,7 @@ mod tests {
             .expect()
             .return_const(Ok(Some(ExecutionStateSpec::running())));
 
-        let workload_id = PodmanWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
         let checker = PodmanStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::running());
@@ -730,9 +715,7 @@ mod tests {
         let context = PodmanCli::list_states_by_id_context();
         context.expect().return_const(Ok(None));
 
-        let workload_id = PodmanWorkloadId {
-            id: "test_id".into(),
-        };
+        let workload_id = RuntimeWorkloadId::from("test_id");
         let checker = PodmanStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(res, ExecutionStateSpec::lost())
@@ -746,9 +729,7 @@ mod tests {
         let context = PodmanCli::list_states_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = PodmanWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
         let checker = PodmanStateGetter {};
         let res = checker.get_state(&workload_id).await;
         assert_eq!(
@@ -765,9 +746,7 @@ mod tests {
         let context = PodmanCli::remove_workloads_by_id_context();
         context.expect().return_const(Ok(()));
 
-        let workload_id = PodmanWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
 
         let podman_runtime = PodmanRuntime {};
         let res = podman_runtime.delete_workload(&workload_id).await;
@@ -781,9 +760,7 @@ mod tests {
         let context = PodmanCli::remove_workloads_by_id_context();
         context.expect().return_const(Err("simulated error".into()));
 
-        let workload_id = PodmanWorkloadId {
-            id: fixtures::WORKLOAD_IDS[0].into(),
-        };
+        let workload_id = RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_string());
 
         let podman_runtime = PodmanRuntime {};
         let res = podman_runtime.delete_workload(&workload_id).await;

--- a/agent/src/runtime_connectors/podman_kube/mod.rs
+++ b/agent/src/runtime_connectors/podman_kube/mod.rs
@@ -16,6 +16,4 @@ mod podman_kube_control_interface;
 pub mod podman_kube_log_fetcher;
 mod podman_kube_runtime;
 mod podman_kube_runtime_config;
-pub use podman_kube_runtime::{
-    PODMAN_KUBE_RUNTIME_NAME as NAME, PodmanKubeRuntime, PodmanKubeWorkloadId,
-};
+pub use podman_kube_runtime::{PODMAN_KUBE_RUNTIME_NAME as NAME, PodmanKubeRuntime};

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_log_fetcher.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_log_fetcher.rs
@@ -13,17 +13,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::super::log_fetcher::{GetOutputStreams, StreamTrait};
-use super::PodmanKubeWorkloadId;
-use crate::runtime_connectors::runtime_connector::LogRequestOptions;
 
 #[derive(Debug)]
-pub struct PodmanKubeLogFetcher {}
-
-impl PodmanKubeLogFetcher {
-    pub fn new(_workload_id: &PodmanKubeWorkloadId, _options: &LogRequestOptions) -> Self {
-        Self {}
-    }
-}
+pub struct PodmanKubeLogFetcher();
 
 impl GetOutputStreams for PodmanKubeLogFetcher {
     type OutputStream = Box<dyn StreamTrait>;

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -414,7 +414,7 @@ impl RuntimeConnector for PodmanKubeRuntime {
 
 #[async_trait]
 // [impl->swdd~podman-kube-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<RuntimeWorkloadId> for PodmanKubeRuntime {
+impl RuntimeStateGetter for PodmanKubeRuntime {
     async fn get_state(&self, id: &RuntimeWorkloadId) -> ExecutionStateSpec {
         let instance_name = match Self::instance_name_from_runtime_id(id) {
             Ok(instance_name) => instance_name,

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -40,8 +40,13 @@ pub const PODMAN_KUBE_RUNTIME_NAME: &str = "podman-kube";
 const CONFIG_VOLUME_SUFFIX: &str = ".config";
 const PODS_VOLUME_SUFFIX: &str = ".pods";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PodmanKubeRuntime {
+    workload_info_store: PodmanKubeWorkloadInfoStore,
+}
+
+#[derive(Debug, Clone, Default)]
+struct PodmanKubeWorkloadInfoStore {
     workload_info_cache: std::sync::Arc<Mutex<HashMap<String, PodmanKubeWorkloadId>>>,
 }
 
@@ -73,22 +78,16 @@ impl FromStr for PodmanKubeWorkloadId {
         Err("Not supported for PodmanKubeWorkloadId".to_string())
     }
 }
-impl Default for PodmanKubeRuntime {
-    fn default() -> Self {
-        Self {
-            workload_info_cache: std::sync::Arc::new(Mutex::new(HashMap::new())),
-        }
-    }
-}
 
-impl PodmanKubeRuntime {
-    fn instance_name_from_runtime_id(
-        runtime_id: &RuntimeWorkloadId,
-    ) -> Result<WorkloadInstanceNameSpec, RuntimeError> {
-        runtime_id
-            .to_string()
-            .try_into()
-            .map_err(|err| RuntimeError::List(format!("Invalid runtime workload id: {err}")))
+impl PodmanKubeWorkloadInfoStore {
+    async fn get_workload_info(
+        &self,
+        instance_name: &WorkloadInstanceNameSpec,
+    ) -> Result<PodmanKubeWorkloadId, RuntimeError> {
+        match self.get_cached_workload_info(instance_name) {
+            Some(cached_id) => Ok(cached_id),
+            None => self.load_workload_info(instance_name).await,
+        }
     }
 
     async fn load_workload_info(
@@ -128,7 +127,7 @@ impl PodmanKubeRuntime {
             manifest: runtime_config.manifest,
             down_options: runtime_config.down_options,
         };
-        // Cache the workload info by instance name
+
         self.workload_info_cache
             .lock()
             .unwrap()
@@ -147,13 +146,24 @@ impl PodmanKubeRuntime {
             .cloned()
     }
 
-    fn remove_cached_workload_info(&self, instance_name: &WorkloadInstanceNameSpec) {
+    fn delete_workload_info(&self, instance_name: &WorkloadInstanceNameSpec) {
         self.workload_info_cache
             .lock()
             .unwrap()
             .remove(&instance_name.to_string());
     }
+}
 
+fn instance_name_from_runtime_id(
+    runtime_id: &RuntimeWorkloadId,
+) -> Result<WorkloadInstanceNameSpec, RuntimeError> {
+    runtime_id
+        .to_string()
+        .try_into()
+        .map_err(|err| RuntimeError::List(format!("Invalid runtime workload id: {err}")))
+}
+
+impl PodmanKubeRuntime {
     async fn sample_workload_states(
         &self,
         workload_instance_names: &Vec<WorkloadInstanceNameSpec>,
@@ -334,7 +344,9 @@ impl RuntimeConnector for PodmanKubeRuntime {
         &self,
         instance_name: &WorkloadInstanceNameSpec,
     ) -> Result<RuntimeWorkloadId, RuntimeError> {
-        self.load_workload_info(instance_name).await?;
+        self.workload_info_store
+            .get_workload_info(instance_name)
+            .await?;
         Ok(RuntimeWorkloadId::from(instance_name.to_string()))
     }
 
@@ -356,9 +368,7 @@ impl RuntimeConnector for PodmanKubeRuntime {
             &workload_named,
             workload_id,
             update_state_tx,
-            PodmanKubeRuntime {
-                workload_info_cache: self.workload_info_cache.clone(),
-            },
+            self.clone(),
         )))
     }
 
@@ -367,7 +377,7 @@ impl RuntimeConnector for PodmanKubeRuntime {
         workload_id: RuntimeWorkloadId,
         options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
-        let instance_name = Self::instance_name_from_runtime_id(&workload_id)
+        let instance_name = instance_name_from_runtime_id(&workload_id)
             .map_err(|err| RuntimeError::CollectLog(err.to_string()))?;
         let workload_info = PodmanKubeWorkloadId {
             name: instance_name,
@@ -382,10 +392,11 @@ impl RuntimeConnector for PodmanKubeRuntime {
     }
 
     async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
-        let instance_name = Self::instance_name_from_runtime_id(workload_id)
+        let instance_name = instance_name_from_runtime_id(workload_id)
             .map_err(|err| RuntimeError::Delete(err.to_string()))?;
         let workload_id = self
-            .load_workload_info(&instance_name)
+            .workload_info_store
+            .get_workload_info(&instance_name)
             .await
             .map_err(|err| RuntimeError::Delete(err.to_string()))?;
         log::debug!(
@@ -407,7 +418,8 @@ impl RuntimeConnector for PodmanKubeRuntime {
             .await
             .unwrap_or_else(|err| log::warn!("Could not remove configs volume: '{err}'"));
         // Remove the workload info from cache after successful deletion
-        self.remove_cached_workload_info(&instance_name);
+        self.workload_info_store
+            .delete_workload_info(&instance_name);
         Ok(())
     }
 }
@@ -416,7 +428,7 @@ impl RuntimeConnector for PodmanKubeRuntime {
 // [impl->swdd~podman-kube-implements-runtime-state-getter~1]
 impl RuntimeStateGetter for PodmanKubeRuntime {
     async fn get_state(&self, id: &RuntimeWorkloadId) -> ExecutionStateSpec {
-        let instance_name = match Self::instance_name_from_runtime_id(id) {
+        let instance_name = match instance_name_from_runtime_id(id) {
             Ok(instance_name) => instance_name,
             Err(err) => {
                 log::warn!("Could not parse runtime workload id '{id}': '{err}'");
@@ -424,18 +436,19 @@ impl RuntimeStateGetter for PodmanKubeRuntime {
             }
         };
 
-        let id = match self.get_cached_workload_info(&instance_name) {
-            Some(cached_id) => cached_id,
-            None => match self.load_workload_info(&instance_name).await {
-                Ok(id) => id,
-                Err(err) => {
-                    log::warn!(
-                        "Could not load workload metadata for '{}': {err}",
-                        instance_name
-                    );
-                    return ExecutionStateSpec::unknown("Could not load workload metadata");
-                }
-            },
+        let id = match self
+            .workload_info_store
+            .get_workload_info(&instance_name)
+            .await
+        {
+            Ok(id) => id,
+            Err(err) => {
+                log::warn!(
+                    "Could not load workload metadata for '{}': {err}",
+                    instance_name
+                );
+                return ExecutionStateSpec::unknown("Could not load workload metadata");
+            }
         };
 
         log::trace!("Getting the state for the workload '{}'", id.name);

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -20,9 +20,9 @@ use crate::runtime_connectors::podman_cli::PodmanCli;
 use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
-        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter, StateChecker,
-        generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher, podman_cli,
-        runtime_connector::LogRequestOptions,
+        ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
+        StateCheckerHandle, generic_log_fetcher::GenericLogFetcher,
+        log_fetcher::LogFetcher, podman_cli, runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
 };
@@ -94,7 +94,7 @@ impl PodmanKubeRuntime {
 
 #[async_trait]
 // [impl->swdd~podman-kube-implements-runtime-connector~1]
-impl RuntimeConnector<PodmanKubeWorkloadId, GenericPollingStateChecker> for PodmanKubeRuntime {
+impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
     // [impl->swdd~podman-kube-name-returns-podman-kube~1]
     fn name(&self) -> String {
         PODMAN_KUBE_RUNTIME_NAME.to_string()
@@ -143,7 +143,7 @@ impl RuntimeConnector<PodmanKubeWorkloadId, GenericPollingStateChecker> for Podm
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(PodmanKubeWorkloadId, GenericPollingStateChecker), RuntimeError> {
+    ) -> Result<(PodmanKubeWorkloadId, StateCheckerHandle), RuntimeError> {
         let instance_name = workload_named.instance_name.clone();
 
         // [impl->swdd~podman-kube-rejects-workload-files~1]
@@ -292,19 +292,19 @@ impl RuntimeConnector<PodmanKubeWorkloadId, GenericPollingStateChecker> for Podm
         workload_id: &PodmanKubeWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
-    ) -> Result<GenericPollingStateChecker, RuntimeError> {
+    ) -> Result<StateCheckerHandle, RuntimeError> {
         // [impl->swdd~podman-kube-state-getter-reset-cache~1]
         PodmanCli::reset_ps_cache().await;
         log::debug!(
             "Starting the checker for the workload '{}'.",
             workload_named.instance_name,
         );
-        Ok(GenericPollingStateChecker::start_checker(
+        Ok(Box::new(GenericPollingStateChecker::start_checker(
             &workload_named,
             workload_id.clone(),
             update_state_tx,
             PodmanKubeRuntime {},
-        ))
+        )))
     }
 
     fn get_log_fetcher(
@@ -914,10 +914,7 @@ spec:
         let result = runtime
             .create_workload(workload_named, None, None, sender, Default::default())
             .await;
-        assert!(
-            matches!(&result, Err(RuntimeError::Unsupported(_))),
-            "Expected 'RuntimeError::Unsupported', Got: {result:?}"
-        );
+        assert!(matches!(result, Err(RuntimeError::Unsupported(_))));
     }
 
     // [utest->swdd~podman-kube-state-getter-reset-cache~1]

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -317,13 +317,7 @@ impl RuntimeConnector for PodmanKubeRuntime {
             )
         });
 
-        let workload_id = PodmanKubeWorkloadId {
-            name: instance_name,
-            pods: Some(created_pods),
-            manifest: workload_config.manifest,
-            down_options: workload_config.down_options,
-        };
-        let runtime_workload_id = RuntimeWorkloadId::from(workload_id.name.to_string());
+        let runtime_workload_id = RuntimeWorkloadId::from(instance_name.to_string());
 
         log::debug!(
             "The workload '{}' has been created.",
@@ -374,19 +368,10 @@ impl RuntimeConnector for PodmanKubeRuntime {
 
     fn get_log_fetcher(
         &self,
-        workload_id: RuntimeWorkloadId,
-        options: &LogRequestOptions,
+        _workload_id: RuntimeWorkloadId,
+        _options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
-        let instance_name = instance_name_from_runtime_id(&workload_id)
-            .map_err(|err| RuntimeError::CollectLog(err.to_string()))?;
-        let workload_info = PodmanKubeWorkloadId {
-            name: instance_name,
-            pods: None,
-            manifest: String::new(),
-            down_options: Vec::new(),
-        };
-        let podman_kube_log_fetcher =
-            super::podman_kube_log_fetcher::PodmanKubeLogFetcher::new(&workload_info, options);
+        let podman_kube_log_fetcher = super::podman_kube_log_fetcher::PodmanKubeLogFetcher();
         let log_fetcher = GenericLogFetcher::new(podman_kube_log_fetcher);
         Ok(Box::new(log_fetcher))
     }

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -128,11 +128,15 @@ impl PodmanKubeWorkloadInfoStore {
             down_options: runtime_config.down_options,
         };
 
+        self.add(workload_id.clone());
+        Ok(workload_id)
+    }
+
+    fn add(&self, workload_id: PodmanKubeWorkloadId) {
         self.workload_info_cache
             .lock()
             .unwrap()
-            .insert(instance_name.to_string(), workload_id.clone());
-        Ok(workload_id)
+            .insert(workload_id.name.to_string(), workload_id);
     }
 
     fn get_cached_workload_info(
@@ -296,6 +300,13 @@ impl RuntimeConnector for PodmanKubeRuntime {
         )
         .await
         .map_err(RuntimeError::Create)?;
+
+        self.workload_info_store.add(PodmanKubeWorkloadId {
+            name: instance_name.clone(),
+            pods: Some(created_pods.clone()),
+            manifest: workload_config.manifest.clone(),
+            down_options: workload_config.down_options.clone(),
+        });
 
         // [impl->swdd~podman-kube-create-workload-creates-pods-volume~1]
         // [impl->swdd~podman-kube-create-continues-if-cannot-create-volume~1]
@@ -1027,14 +1038,6 @@ spec:
                 SAMPLE_PODS_AS_JSON.as_str(),
             )
             .returns(Err(SAMPLE_ERROR.into()));
-
-        // Setup mock expectations for load_workload_info called by get_state
-        mock_context
-            .read_data(WORKLOAD_INSTANCE_NAME.as_config_volume())
-            .returns(Ok(SAMPLE_RUNTIME_CONFIG.into()));
-        mock_context
-            .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
-            .returns(Ok(SAMPLE_PODS_AS_JSON.clone()));
 
         let mut seq = Sequence::new();
 

--- a/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
+++ b/agent/src/runtime_connectors/podman_kube/podman_kube_runtime.rs
@@ -21,7 +21,7 @@ use crate::{
     generic_polling_state_checker::GenericPollingStateChecker,
     runtime_connectors::{
         ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeStateGetter,
-        StateCheckerHandle, generic_log_fetcher::GenericLogFetcher,
+        RuntimeWorkloadId, StateCheckerHandle, generic_log_fetcher::GenericLogFetcher,
         log_fetcher::LogFetcher, podman_cli, runtime_connector::LogRequestOptions,
     },
     workload_state::WorkloadStateSender,
@@ -34,14 +34,16 @@ use async_trait::async_trait;
 use futures_util::TryFutureExt;
 #[cfg(test)]
 use mockall_double::double;
-use std::{cmp::min, collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
+use std::{cmp::min, collections::HashMap, fmt::Display, path::PathBuf, str::FromStr, sync::Mutex};
 
 pub const PODMAN_KUBE_RUNTIME_NAME: &str = "podman-kube";
 const CONFIG_VOLUME_SUFFIX: &str = ".config";
 const PODS_VOLUME_SUFFIX: &str = ".pods";
 
 #[derive(Debug, Clone)]
-pub struct PodmanKubeRuntime {}
+pub struct PodmanKubeRuntime {
+    workload_info_cache: std::sync::Arc<Mutex<HashMap<String, PodmanKubeWorkloadId>>>,
+}
 
 // [impl->swdd~podman-kube-workload-id]
 #[derive(Clone, Debug)]
@@ -71,16 +73,95 @@ impl FromStr for PodmanKubeWorkloadId {
         Err("Not supported for PodmanKubeWorkloadId".to_string())
     }
 }
+impl Default for PodmanKubeRuntime {
+    fn default() -> Self {
+        Self {
+            workload_info_cache: std::sync::Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
 impl PodmanKubeRuntime {
+    fn instance_name_from_runtime_id(
+        runtime_id: &RuntimeWorkloadId,
+    ) -> Result<WorkloadInstanceNameSpec, RuntimeError> {
+        runtime_id
+            .to_string()
+            .try_into()
+            .map_err(|err| RuntimeError::List(format!("Invalid runtime workload id: {err}")))
+    }
+
+    async fn load_workload_info(
+        &self,
+        instance_name: &WorkloadInstanceNameSpec,
+    ) -> Result<PodmanKubeWorkloadId, RuntimeError> {
+        let runtime_config =
+            PodmanCli::read_data_from_volume(&(instance_name.to_string() + CONFIG_VOLUME_SUFFIX))
+                .await
+                .map_err(|err| format!("Could not read config from volume: {err:?}"))
+                .and_then(|json| {
+                    serde_yaml::from_str::<PodmanKubeRuntimeConfig>(&json)
+                        .map_err(|err| format!("Could not parse config read from volume: {err:?}"))
+                })
+                .map_err(RuntimeError::Create)?;
+        let pods =
+            PodmanCli::read_data_from_volume(&(instance_name.to_string() + PODS_VOLUME_SUFFIX))
+                .await
+                .map_err(|err| format!("Could not read pods from volume: {err:?}"))
+                .and_then(|json| {
+                    serde_json::from_str(&json).map_err(|err| {
+                        format!("Could not parse pod list read from volume: {err:?}")
+                    })
+                });
+
+        let pods = match pods {
+            Ok(pods) => Some(pods),
+            Err(err) => {
+                log::warn!("{err}");
+                None
+            }
+        };
+
+        let workload_id = PodmanKubeWorkloadId {
+            name: instance_name.clone(),
+            pods,
+            manifest: runtime_config.manifest,
+            down_options: runtime_config.down_options,
+        };
+        // Cache the workload info by instance name
+        self.workload_info_cache
+            .lock()
+            .unwrap()
+            .insert(instance_name.to_string(), workload_id.clone());
+        Ok(workload_id)
+    }
+
+    fn get_cached_workload_info(
+        &self,
+        instance_name: &WorkloadInstanceNameSpec,
+    ) -> Option<PodmanKubeWorkloadId> {
+        self.workload_info_cache
+            .lock()
+            .unwrap()
+            .get(&instance_name.to_string())
+            .cloned()
+    }
+
+    fn remove_cached_workload_info(&self, instance_name: &WorkloadInstanceNameSpec) {
+        self.workload_info_cache
+            .lock()
+            .unwrap()
+            .remove(&instance_name.to_string());
+    }
+
     async fn sample_workload_states(
         &self,
         workload_instance_names: &Vec<WorkloadInstanceNameSpec>,
     ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
         let mut workload_states = Vec::<ReusableWorkloadState>::default();
         for instance_name in workload_instance_names {
-            let execution_state = self
-                .get_state(&self.get_workload_id(instance_name).await?)
-                .await;
+            let runtime_workload_id = self.get_workload_id(instance_name).await?;
+            let execution_state = self.get_state(&runtime_workload_id).await;
             workload_states.push(ReusableWorkloadState::new(
                 instance_name.clone(),
                 execution_state,
@@ -94,7 +175,7 @@ impl PodmanKubeRuntime {
 
 #[async_trait]
 // [impl->swdd~podman-kube-implements-runtime-connector~1]
-impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
+impl RuntimeConnector for PodmanKubeRuntime {
     // [impl->swdd~podman-kube-name-returns-podman-kube~1]
     fn name(&self) -> String {
         PODMAN_KUBE_RUNTIME_NAME.to_string()
@@ -139,11 +220,11 @@ impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
     async fn create_workload(
         &self,
         workload_named: WorkloadNamed,
-        _reusable_workload_id: Option<PodmanKubeWorkloadId>,
+        _reusable_workload_id: Option<RuntimeWorkloadId>,
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(PodmanKubeWorkloadId, StateCheckerHandle), RuntimeError> {
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
         let instance_name = workload_named.instance_name.clone();
 
         // [impl->swdd~podman-kube-rejects-workload-files~1]
@@ -232,6 +313,7 @@ impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
             manifest: workload_config.manifest,
             down_options: workload_config.down_options,
         };
+        let runtime_workload_id = RuntimeWorkloadId::from(workload_id.name.to_string());
 
         log::debug!(
             "The workload '{}' has been created.",
@@ -240,56 +322,25 @@ impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
 
         // [impl->swdd~podman-kube-create-starts-podman-kube-state-getter~1]
         let state_checker = self
-            .start_checker(&workload_id, workload_named, update_state_tx)
+            .start_checker(&runtime_workload_id, workload_named, update_state_tx)
             .await?;
 
         // [impl->swdd~podman-kube-create-workload-returns-workload-id~1]
-        Ok((workload_id, state_checker))
+        Ok((runtime_workload_id, state_checker))
     }
 
     // [impl->swdd~podman-kube-get-workload-id-uses-volumes~1]
     async fn get_workload_id(
         &self,
         instance_name: &WorkloadInstanceNameSpec,
-    ) -> Result<PodmanKubeWorkloadId, RuntimeError> {
-        let runtime_config =
-            PodmanCli::read_data_from_volume(&(instance_name.to_string() + CONFIG_VOLUME_SUFFIX))
-                .await
-                .map_err(|err| format!("Could not read config from volume: {err:?}"))
-                .and_then(|json| {
-                    serde_yaml::from_str::<PodmanKubeRuntimeConfig>(&json)
-                        .map_err(|err| format!("Could not parse config read from volume: {err:?}"))
-                })
-                .map_err(RuntimeError::Create)?;
-        let pods =
-            PodmanCli::read_data_from_volume(&(instance_name.to_string() + PODS_VOLUME_SUFFIX))
-                .await
-                .map_err(|err| format!("Could not read pods from volume: {err:?}"))
-                .and_then(|json| {
-                    serde_json::from_str(&json).map_err(|err| {
-                        format!("Could not parse pod list read from volume: {err:?}")
-                    })
-                });
-
-        let pods = match pods {
-            Ok(pods) => Some(pods),
-            Err(err) => {
-                log::warn!("{err}");
-                None
-            }
-        };
-
-        Ok(PodmanKubeWorkloadId {
-            name: instance_name.clone(),
-            pods,
-            manifest: runtime_config.manifest,
-            down_options: runtime_config.down_options,
-        })
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
+        self.load_workload_info(instance_name).await?;
+        Ok(RuntimeWorkloadId::from(instance_name.to_string()))
     }
 
     async fn start_checker(
         &self,
-        workload_id: &PodmanKubeWorkloadId,
+        workload_id: &RuntimeWorkloadId,
         workload_named: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
     ) -> Result<StateCheckerHandle, RuntimeError> {
@@ -299,29 +350,44 @@ impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
             "Starting the checker for the workload '{}'.",
             workload_named.instance_name,
         );
+        let workload_id = workload_id.clone();
+
         Ok(Box::new(GenericPollingStateChecker::start_checker(
             &workload_named,
-            workload_id.clone(),
+            workload_id,
             update_state_tx,
-            PodmanKubeRuntime {},
+            PodmanKubeRuntime {
+                workload_info_cache: self.workload_info_cache.clone(),
+            },
         )))
     }
 
     fn get_log_fetcher(
         &self,
-        workload_id: PodmanKubeWorkloadId,
+        workload_id: RuntimeWorkloadId,
         options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
+        let instance_name = Self::instance_name_from_runtime_id(&workload_id)
+            .map_err(|err| RuntimeError::CollectLog(err.to_string()))?;
+        let workload_info = PodmanKubeWorkloadId {
+            name: instance_name,
+            pods: None,
+            manifest: String::new(),
+            down_options: Vec::new(),
+        };
         let podman_kube_log_fetcher =
-            super::podman_kube_log_fetcher::PodmanKubeLogFetcher::new(&workload_id, options);
+            super::podman_kube_log_fetcher::PodmanKubeLogFetcher::new(&workload_info, options);
         let log_fetcher = GenericLogFetcher::new(podman_kube_log_fetcher);
         Ok(Box::new(log_fetcher))
     }
 
-    async fn delete_workload(
-        &self,
-        workload_id: &PodmanKubeWorkloadId,
-    ) -> Result<(), RuntimeError> {
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
+        let instance_name = Self::instance_name_from_runtime_id(workload_id)
+            .map_err(|err| RuntimeError::Delete(err.to_string()))?;
+        let workload_id = self
+            .load_workload_info(&instance_name)
+            .await
+            .map_err(|err| RuntimeError::Delete(err.to_string()))?;
         log::debug!(
             "Deleting workload with workload execution instance name '{}'",
             workload_id.name
@@ -340,14 +406,38 @@ impl RuntimeConnector<PodmanKubeWorkloadId> for PodmanKubeRuntime {
         PodmanCli::remove_volume(&(workload_id.name.to_string() + CONFIG_VOLUME_SUFFIX))
             .await
             .unwrap_or_else(|err| log::warn!("Could not remove configs volume: '{err}'"));
+        // Remove the workload info from cache after successful deletion
+        self.remove_cached_workload_info(&instance_name);
         Ok(())
     }
 }
 
 #[async_trait]
 // [impl->swdd~podman-kube-implements-runtime-state-getter~1]
-impl RuntimeStateGetter<PodmanKubeWorkloadId> for PodmanKubeRuntime {
-    async fn get_state(&self, id: &PodmanKubeWorkloadId) -> ExecutionStateSpec {
+impl RuntimeStateGetter<RuntimeWorkloadId> for PodmanKubeRuntime {
+    async fn get_state(&self, id: &RuntimeWorkloadId) -> ExecutionStateSpec {
+        let instance_name = match Self::instance_name_from_runtime_id(id) {
+            Ok(instance_name) => instance_name,
+            Err(err) => {
+                log::warn!("Could not parse runtime workload id '{id}': '{err}'");
+                return ExecutionStateSpec::unknown("Invalid runtime workload id");
+            }
+        };
+
+        let id = match self.get_cached_workload_info(&instance_name) {
+            Some(cached_id) => cached_id,
+            None => match self.load_workload_info(&instance_name).await {
+                Ok(id) => id,
+                Err(err) => {
+                    log::warn!(
+                        "Could not load workload metadata for '{}': {err}",
+                        instance_name
+                    );
+                    return ExecutionStateSpec::unknown("Could not load workload metadata");
+                }
+            },
+        };
+
         log::trace!("Getting the state for the workload '{}'", id.name);
         if let Some(pods) = &id.pods {
             // [impl->swdd~podman-kube-state-getter-uses-container-states~1]
@@ -443,7 +533,9 @@ mod tests {
     };
     use crate::runtime_connectors::RuntimeStateGetter;
     use crate::runtime_connectors::podman_cli::__mock_MockPodmanCli as podman_cli_mock;
-    use crate::runtime_connectors::{RuntimeConnector, RuntimeError, podman_cli::ContainerState};
+    use crate::runtime_connectors::{
+        RuntimeConnector, RuntimeError, RuntimeWorkloadId, podman_cli::ContainerState,
+    };
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
 
     use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec, WorkloadNamed};
@@ -492,12 +584,14 @@ mod tests {
             manifest: SAMPLE_KUBE_CONFIG.into(),
             down_options: SAMPLE_DOWN_OPTIONS.clone(),
         };
+        pub static ref RUNTIME_WORKLOAD_ID: RuntimeWorkloadId =
+            RuntimeWorkloadId::from(WORKLOAD_INSTANCE_NAME.to_string());
     }
 
     // [utest->swdd~podman-kube-name-returns-podman-kube~1]
     #[test]
     fn utest_name_podman_kube() {
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         assert_eq!(runtime.name(), "podman-kube");
     }
 
@@ -535,7 +629,7 @@ mod tests {
             .expect()
             .return_const(Ok(workload.runtime_config));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let workloads = runtime
             .get_reusable_workloads(&fixtures::AGENT_NAMES[0].into())
@@ -567,7 +661,7 @@ mod tests {
         let mock_context = MockContext::new().await;
         mock_context.list_agent_config_volumes_returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let workloads = runtime
             .get_reusable_workloads(&fixtures::AGENT_NAMES[0].into())
@@ -608,7 +702,7 @@ mod tests {
             .expect()
             .return_const(Ok(vec![ContainerState::Unknown]));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let workloads = runtime
             .get_reusable_workloads(&fixtures::AGENT_NAMES[0].into())
@@ -651,7 +745,7 @@ mod tests {
             .expect()
             .return_const(Ok(vec![ContainerState::Unknown]));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let workloads = runtime
             .get_reusable_workloads(&fixtures::AGENT_NAMES[0].into())
@@ -693,7 +787,7 @@ mod tests {
 
         mock_context.reset_ps_cache.expect().return_const(());
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let mut workload_named = generate_test_podman_kube_workload();
         workload_named.workload.files = Default::default();
@@ -705,10 +799,7 @@ mod tests {
             .await;
         // [utest->swdd~podman-kube-create-workload-returns-workload-id~1]
         assert!(matches!(workload, Ok((workload_id, _)) if
-                workload_id.name == *WORKLOAD_INSTANCE_NAME &&
-                workload_id.manifest == SAMPLE_KUBE_CONFIG &&
-                workload_id.pods == Some(SAMPLE_POD_LIST.clone()) &&
-                workload_id.down_options == *SAMPLE_DOWN_OPTIONS));
+            workload_id.to_string() == WORKLOAD_INSTANCE_NAME.to_string()));
     }
 
     // [utest->swdd~podman-kube-mounts-control-interface~2]
@@ -788,7 +879,8 @@ spec:
 
         mock_context.reset_ps_cache.expect().return_const(());
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
+        let expected_instance_name = workload_named.instance_name.clone();
         let (sender, _) = tokio::sync::mpsc::channel(1);
 
         let result = runtime
@@ -803,7 +895,7 @@ spec:
 
         assert!(matches!(
             &result,
-            Ok((workload_id, _)) if workload_id.manifest.contains("control-interface-volume")
+            Ok((workload_id, _)) if workload_id.to_string() == expected_instance_name.to_string()
         ));
     }
 
@@ -836,7 +928,7 @@ spec:
 
         mock_context.reset_ps_cache.expect().return_const(());
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let mut workload_named = generate_test_podman_kube_workload();
         workload_named.workload.files = Default::default();
@@ -847,10 +939,7 @@ spec:
             .create_workload(workload_named, None, None, sender, Default::default())
             .await;
         assert!(matches!(workload, Ok((workload_id, _)) if
-                workload_id.name == *WORKLOAD_INSTANCE_NAME &&
-                workload_id.manifest == SAMPLE_KUBE_CONFIG &&
-                workload_id.pods == Some(SAMPLE_POD_LIST.clone()) &&
-                workload_id.down_options == *SAMPLE_DOWN_OPTIONS));
+            workload_id.to_string() == WORKLOAD_INSTANCE_NAME.to_string()));
     }
 
     // [utest->swdd~podman-kube-create-continues-if-cannot-create-volume~1]
@@ -882,7 +971,7 @@ spec:
 
         mock_context.reset_ps_cache.expect().return_const(());
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let mut workload_named = generate_test_podman_kube_workload();
         workload_named.workload.files = Default::default();
@@ -893,16 +982,13 @@ spec:
             .create_workload(workload_named, None, None, sender, Default::default())
             .await;
         assert!(matches!(workload, Ok((workload_id, _)) if
-                workload_id.name == *WORKLOAD_INSTANCE_NAME &&
-                workload_id.manifest == SAMPLE_KUBE_CONFIG &&
-                workload_id.pods == Some(SAMPLE_POD_LIST.clone()) &&
-                workload_id.down_options == *SAMPLE_DOWN_OPTIONS));
+            workload_id.to_string() == WORKLOAD_INSTANCE_NAME.to_string()));
     }
 
     // [utest->swdd~podman-kube-rejects-workload-files~1]
     #[tokio::test]
     async fn utest_create_workload_unsupported_workload_files_error() {
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let workload_named = generate_test_workload_named_with_params(
             fixtures::WORKLOAD_NAMES[0],
@@ -944,6 +1030,14 @@ spec:
             )
             .returns(Err(SAMPLE_ERROR.into()));
 
+        // Setup mock expectations for load_workload_info called by get_state
+        mock_context
+            .read_data(WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .returns(Ok(SAMPLE_RUNTIME_CONFIG.into()));
+        mock_context
+            .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .returns(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         let mut seq = Sequence::new();
 
         mock_context
@@ -960,7 +1054,7 @@ spec:
             .return_const(Ok(vec![ContainerState::Running]))
             .in_sequence(&mut seq);
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let mut workload_named = generate_test_podman_kube_workload();
         workload_named.workload.files = Default::default();
@@ -994,7 +1088,7 @@ spec:
             )
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
 
         let mut workload_named = generate_test_podman_kube_workload();
         workload_named.workload.files = Default::default();
@@ -1020,14 +1114,11 @@ spec:
             .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
             .returns(Ok(SAMPLE_PODS_AS_JSON.to_string()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         let workload = runtime.get_workload_id(&WORKLOAD_INSTANCE_NAME).await;
 
         assert!(matches!(workload, Ok(workload) if
-            workload.name == *WORKLOAD_INSTANCE_NAME &&
-            workload.pods == Some(SAMPLE_POD_LIST.clone()) &&
-            workload.manifest == SAMPLE_KUBE_CONFIG &&
-            workload.down_options == *SAMPLE_DOWN_OPTIONS
+            workload.to_string() == WORKLOAD_INSTANCE_NAME.to_string()
         ));
     }
 
@@ -1042,14 +1133,11 @@ spec:
             .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         let workload = runtime.get_workload_id(&WORKLOAD_INSTANCE_NAME).await;
 
         assert!(matches!(workload, Ok(workload) if
-            workload.name == *WORKLOAD_INSTANCE_NAME &&
-            workload.pods.is_none() &&
-            workload.manifest == SAMPLE_KUBE_CONFIG &&
-            workload.down_options == *SAMPLE_DOWN_OPTIONS
+            workload.to_string() == WORKLOAD_INSTANCE_NAME.to_string()
         ));
     }
 
@@ -1064,14 +1152,11 @@ spec:
             .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
             .returns(Ok(r#"{"#.into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         let workload = runtime.get_workload_id(&WORKLOAD_INSTANCE_NAME).await;
 
         assert!(matches!(workload, Ok(workload) if
-            workload.name == *WORKLOAD_INSTANCE_NAME &&
-            workload.pods.is_none() &&
-            workload.manifest == SAMPLE_KUBE_CONFIG &&
-            workload.down_options == *SAMPLE_DOWN_OPTIONS
+            workload.to_string() == WORKLOAD_INSTANCE_NAME.to_string()
         ));
     }
 
@@ -1083,7 +1168,7 @@ spec:
             .read_data(WORKLOAD_INSTANCE_NAME.as_config_volume())
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         let workload = runtime.get_workload_id(&WORKLOAD_INSTANCE_NAME).await;
 
         assert!(matches!(workload, Err(..)));
@@ -1097,7 +1182,7 @@ spec:
             .read_data(WORKLOAD_INSTANCE_NAME.as_config_volume())
             .returns(Ok("{".into()));
 
-        let runtime = PodmanKubeRuntime {};
+        let runtime = PodmanKubeRuntime::default();
         let workload = runtime.get_workload_id(&WORKLOAD_INSTANCE_NAME).await;
 
         assert!(matches!(workload, Err(..)));
@@ -1106,6 +1191,18 @@ spec:
     #[tokio::test]
     async fn utest_delete_workload_success() {
         let mock_context = MockContext::new().await;
+
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
 
         // [utest->swdd~podman-kube-delete-workload-downs-manifest-file~1]
         mock_context
@@ -1120,8 +1217,8 @@ spec:
             .remove_volume(WORKLOAD_INSTANCE_NAME.as_pods_volume())
             .returns(Ok(()));
 
-        let runtime = PodmanKubeRuntime {};
-        let workload = runtime.delete_workload(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let workload = runtime.delete_workload(&RUNTIME_WORKLOAD_ID).await;
 
         assert!(matches!(workload, Ok(())));
     }
@@ -1129,6 +1226,18 @@ spec:
     #[tokio::test]
     async fn utest_delete_workload_handles_remove_volume_fails() {
         let mock_context = MockContext::new().await;
+
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
 
         mock_context
             .down_kube(&*SAMPLE_DOWN_OPTIONS, SAMPLE_KUBE_CONFIG)
@@ -1140,8 +1249,8 @@ spec:
             .remove_volume(WORKLOAD_INSTANCE_NAME.as_pods_volume())
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
-        let workload = runtime.delete_workload(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let workload = runtime.delete_workload(&RUNTIME_WORKLOAD_ID).await;
 
         assert!(matches!(workload, Ok(())));
     }
@@ -1150,12 +1259,24 @@ spec:
     async fn utest_delete_workload_fails() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         mock_context
             .down_kube(&*SAMPLE_DOWN_OPTIONS, SAMPLE_KUBE_CONFIG)
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
-        let workload = runtime.delete_workload(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let workload = runtime.delete_workload(&RUNTIME_WORKLOAD_ID).await;
 
         assert!(matches!(workload, Err(..)));
     }
@@ -1165,6 +1286,18 @@ spec:
     #[tokio::test]
     async fn utest_get_state_failed() {
         let mock_context = MockContext::new().await;
+
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
 
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
@@ -1179,8 +1312,8 @@ spec:
                 ContainerState::Stopping,
             ]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(
             execution_state,
@@ -1194,6 +1327,18 @@ spec:
     async fn utest_get_state_starting() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
@@ -1206,8 +1351,8 @@ spec:
                 ContainerState::Stopping,
             ]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(
             execution_state,
@@ -1221,6 +1366,18 @@ spec:
     async fn utest_get_state_unknown() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
@@ -1231,8 +1388,8 @@ spec:
                 ContainerState::Unknown,
             ]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(
             execution_state,
@@ -1246,6 +1403,18 @@ spec:
     async fn utest_get_state_unknown_from_paused() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
@@ -1255,8 +1424,8 @@ spec:
                 ContainerState::Running,
             ]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(
             execution_state,
@@ -1270,13 +1439,25 @@ spec:
     async fn utest_get_state_running() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
             .returns(Ok(vec![ContainerState::Exited(0), ContainerState::Running]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(execution_state, ExecutionStateSpec::running());
     }
@@ -1287,13 +1468,25 @@ spec:
     async fn utest_get_state_succeeded() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
             .returns(Ok(vec![ContainerState::Exited(0)]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(execution_state, ExecutionStateSpec::succeeded());
     }
@@ -1304,13 +1497,25 @@ spec:
     async fn utest_get_state_removed() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         // [utest->swdd~podman-kube-state-getter-uses-container-states~1]
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
             .returns(Ok(vec![]));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(execution_state, ExecutionStateSpec::lost())
     }
@@ -1319,12 +1524,24 @@ spec:
     async fn utest_get_state_unknown_as_command_fails() {
         let mock_context = MockContext::new().await;
 
+        // Setup mock expectations for load_workload_info
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .return_const(Ok(SAMPLE_RUNTIME_CONFIG.to_string()));
+        mock_context
+            .read_data
+            .expect()
+            .withf(|volume_name| volume_name == WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .return_const(Ok(SAMPLE_PODS_AS_JSON.clone()));
+
         mock_context
             .list_states_from_pods(&*SAMPLE_POD_LIST)
             .returns(Err(SAMPLE_ERROR.into()));
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&WORKLOAD_ID).await;
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(
             execution_state,
@@ -1334,13 +1551,17 @@ spec:
 
     #[tokio::test]
     async fn utest_get_state_unknown_as_pods_unknown() {
-        let workload_id = PodmanKubeWorkloadId {
-            pods: None,
-            ..WORKLOAD_ID.clone()
-        };
+        let mock_context = MockContext::new().await;
 
-        let runtime = PodmanKubeRuntime {};
-        let execution_state = runtime.get_state(&workload_id).await;
+        mock_context
+            .read_data(WORKLOAD_INSTANCE_NAME.as_config_volume())
+            .returns(Ok(SAMPLE_RUNTIME_CONFIG.into()));
+        mock_context
+            .read_data(WORKLOAD_INSTANCE_NAME.as_pods_volume())
+            .returns(Err(SAMPLE_ERROR.into()));
+
+        let runtime = PodmanKubeRuntime::default();
+        let execution_state = runtime.get_state(&RUNTIME_WORKLOAD_ID).await;
 
         assert_eq!(execution_state, ExecutionStateSpec::succeeded());
     }

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -58,9 +58,9 @@ impl AsRef<str> for RuntimeWorkloadId {
     }
 }
 
-impl Into<String> for RuntimeWorkloadId {
-    fn into(self) -> String {
-        self.0
+impl From<RuntimeWorkloadId> for String {
+    fn from(value: RuntimeWorkloadId) -> String {
+        value.0
     }
 }
 

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -259,9 +259,12 @@ pub mod test {
             Option<String>,
             Option<PathBuf>,
             HashMap<PathBuf, PathBuf>,
-            Result<(String, StateCheckerHandle), RuntimeError>,
+            Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError>,
         ),
-        GetWorkloadId(WorkloadInstanceNameSpec, Result<String, RuntimeError>),
+        GetWorkloadId(
+            WorkloadInstanceNameSpec,
+            Result<RuntimeWorkloadId, RuntimeError>,
+        ),
         StartChecker(
             String,
             WorkloadNamed,
@@ -429,9 +432,7 @@ pub mod test {
                     && host_workload_file_path_mappings
                         == expected_host_workload_file_path_mappings =>
                 {
-                    return result.map(|(workload_id, checker)| {
-                        (RuntimeWorkloadId::from(workload_id), checker)
-                    });
+                    return result;
                 }
                 expected_call => {
                     self.unexpected_call();
@@ -450,7 +451,7 @@ pub mod test {
                 RuntimeCall::GetWorkloadId(expected_instance_name, result)
                     if expected_instance_name == *instance_name =>
                 {
-                    return result.map(RuntimeWorkloadId::from);
+                    return result;
                 }
                 expected_call => {
                     self.unexpected_call();

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -13,10 +13,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::log_fetcher::LogFetcher;
-use crate::{runtime_connectors::StateChecker, workload_state::WorkloadStateSender};
+use crate::{runtime_connectors::StateCheckerHandle, workload_state::WorkloadStateSender};
 
 use ankaios_api::ank_base::{
-    ExecutionStateSpec, LogsRequest, WorkloadInstanceNameSpec, WorkloadNamed, WorkloadStateSpec
+    ExecutionStateSpec, LogsRequest, WorkloadInstanceNameSpec, WorkloadNamed, WorkloadStateSpec,
 };
 use common::objects::AgentName;
 
@@ -99,9 +99,8 @@ impl ReusableWorkloadState {
 
 // [impl->swdd~agent-functions-required-by-runtime-connector~1]
 #[async_trait]
-pub trait RuntimeConnector<WorkloadId, StChecker>: Sync + Send
+pub trait RuntimeConnector<WorkloadId>: Sync + Send
 where
-    StChecker: StateChecker<WorkloadId> + Send + Sync,
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
 {
     fn name(&self) -> String;
@@ -118,7 +117,7 @@ where
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(WorkloadId, StChecker), RuntimeError>;
+    ) -> Result<(WorkloadId, StateCheckerHandle), RuntimeError>;
 
     async fn get_workload_id(
         &self,
@@ -130,7 +129,7 @@ where
         workload_id: &WorkloadId,
         runtime_workload_config: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
-    ) -> Result<StChecker, RuntimeError>;
+    ) -> Result<StateCheckerHandle, RuntimeError>;
 
     fn get_log_fetcher(
         &self,
@@ -141,21 +140,19 @@ where
     async fn delete_workload(&self, workload_id: &WorkloadId) -> Result<(), RuntimeError>;
 }
 
-pub trait OwnableRuntime<WorkloadId, StChecker>: RuntimeConnector<WorkloadId, StChecker>
+pub trait OwnableRuntime<WorkloadId>: RuntimeConnector<WorkloadId>
 where
-    StChecker: StateChecker<WorkloadId> + Send + Sync,
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
 {
-    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId, StChecker>>;
+    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId>>;
 }
 
-impl<R, WorkloadId, StChecker> OwnableRuntime<WorkloadId, StChecker> for R
+impl<R, WorkloadId> OwnableRuntime<WorkloadId> for R
 where
-    R: RuntimeConnector<WorkloadId, StChecker> + Clone + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync,
+    R: RuntimeConnector<WorkloadId> + Clone + 'static,
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
 {
-    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId, StChecker>> {
+    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId>> {
         Box::new(self.clone())
     }
 }
@@ -173,12 +170,12 @@ pub mod test {
     use super::{LogRequestOptions, RuntimeConnector, RuntimeError};
     use crate::{
         runtime_connectors::{
-            ReusableWorkloadState, RuntimeStateGetter, StateChecker, log_fetcher::LogFetcher,
+            ReusableWorkloadState, StateChecker, StateCheckerHandle, log_fetcher::LogFetcher,
         },
         workload_state::WorkloadStateSender,
     };
 
-    use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec, WorkloadNamed};
+    use ankaios_api::ank_base::{WorkloadInstanceNameSpec, WorkloadNamed};
     use common::objects::AgentName;
 
     use async_trait::async_trait;
@@ -187,13 +184,6 @@ pub mod test {
         path::PathBuf,
         sync::{Arc, Mutex},
     };
-
-    #[async_trait]
-    impl RuntimeStateGetter<String> for StubStateChecker {
-        async fn get_state(&self, _workload_id: &String) -> ExecutionStateSpec {
-            ExecutionStateSpec::running()
-        }
-    }
 
     #[derive(Debug)]
     pub struct StubStateChecker {
@@ -213,18 +203,8 @@ pub mod test {
     }
 
     #[async_trait]
-    impl StateChecker<String> for StubStateChecker {
-        fn start_checker(
-            _workload: &WorkloadNamed,
-            _workload_id: String,
-            _manager_interface: WorkloadStateSender,
-            _state_getter: impl RuntimeStateGetter<String>,
-        ) -> Self {
-            log::info!("Starting the checker ;)");
-            StubStateChecker::new()
-        }
-
-        async fn stop_checker(mut self) {
+    impl StateChecker for StubStateChecker {
+        async fn stop_checker(mut self: Box<Self>) {
             log::info!("Stopping the checker ;)");
             self.panic_if_not_stopped = false;
         }
@@ -238,7 +218,6 @@ pub mod test {
         }
     }
 
-    #[derive(Debug)]
     pub enum RuntimeCall {
         GetReusableWorkloads(AgentName, Result<Vec<ReusableWorkloadState>, RuntimeError>),
         CreateWorkload(
@@ -246,20 +225,35 @@ pub mod test {
             Option<String>,
             Option<PathBuf>,
             HashMap<PathBuf, PathBuf>,
-            Result<(String, StubStateChecker), RuntimeError>,
+            Result<(String, StateCheckerHandle), RuntimeError>,
         ),
         GetWorkloadId(WorkloadInstanceNameSpec, Result<String, RuntimeError>),
         StartChecker(
             String,
             WorkloadNamed,
             WorkloadStateSender,
-            Result<StubStateChecker, RuntimeError>,
+            Result<StateCheckerHandle, RuntimeError>,
         ),
         DeleteWorkload(String, Result<(), RuntimeError>),
         StartLogFetcher(
             LogRequestOptions,
             Result<Box<dyn LogFetcher + Send>, RuntimeError>,
         ),
+    }
+
+    impl std::fmt::Debug for RuntimeCall {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let variant_name = match self {
+                RuntimeCall::GetReusableWorkloads(_, _) => "GetReusableWorkloads",
+                RuntimeCall::CreateWorkload(_, _, _, _, _) => "CreateWorkload",
+                RuntimeCall::GetWorkloadId(_, _) => "GetWorkloadId",
+                RuntimeCall::StartChecker(_, _, _, _) => "StartChecker",
+                RuntimeCall::DeleteWorkload(_, _) => "DeleteWorkload",
+                RuntimeCall::StartLogFetcher(_, _) => "StartLogFetcher",
+            };
+
+            write!(f, "{variant_name}")
+        }
     }
 
     #[derive(Debug)]
@@ -355,7 +349,7 @@ pub mod test {
     pub type MockRuntimeConnector = MockBase<RuntimeCall>;
 
     #[async_trait]
-    impl RuntimeConnector<String, StubStateChecker> for MockBase<RuntimeCall> {
+    impl RuntimeConnector<String> for MockBase<RuntimeCall> {
         fn name(&self) -> String {
             "mock-runtime".to_string()
         }
@@ -386,7 +380,7 @@ pub mod test {
             control_interface_path: Option<PathBuf>,
             _update_state_tx: WorkloadStateSender,
             host_workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-        ) -> Result<(String, StubStateChecker), RuntimeError> {
+        ) -> Result<(String, StateCheckerHandle), RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::CreateWorkload(
                     expected_runtime_workload_config,
@@ -435,7 +429,7 @@ pub mod test {
             workload_id: &String,
             runtime_workload_config: WorkloadNamed,
             update_state_tx: WorkloadStateSender,
-        ) -> Result<StubStateChecker, RuntimeError> {
+        ) -> Result<StateCheckerHandle, RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::StartChecker(
                     expected_workload_id,

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -23,6 +23,41 @@ use common::objects::AgentName;
 use async_trait::async_trait;
 use std::{collections::HashMap, fmt::Display, path::PathBuf, str::FromStr};
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RuntimeWorkloadId(String);
+
+impl Display for RuntimeWorkloadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<String> for RuntimeWorkloadId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for RuntimeWorkloadId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl FromStr for RuntimeWorkloadId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_string()))
+    }
+}
+
+impl AsRef<str> for RuntimeWorkloadId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuntimeError {
     Create(String),
@@ -99,10 +134,7 @@ impl ReusableWorkloadState {
 
 // [impl->swdd~agent-functions-required-by-runtime-connector~1]
 #[async_trait]
-pub trait RuntimeConnector<WorkloadId>: Sync + Send
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
+pub trait RuntimeConnector: Sync + Send {
     fn name(&self) -> String;
 
     async fn get_reusable_workloads(
@@ -113,46 +145,42 @@ where
     async fn create_workload(
         &self,
         runtime_workload_config: WorkloadNamed,
-        reusable_workload_id: Option<WorkloadId>,
+        reusable_workload_id: Option<RuntimeWorkloadId>,
         control_interface_path: Option<PathBuf>,
         update_state_tx: WorkloadStateSender,
         workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(WorkloadId, StateCheckerHandle), RuntimeError>;
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError>;
 
     async fn get_workload_id(
         &self,
         instance_name: &WorkloadInstanceNameSpec,
-    ) -> Result<WorkloadId, RuntimeError>;
+    ) -> Result<RuntimeWorkloadId, RuntimeError>;
 
     async fn start_checker(
         &self,
-        workload_id: &WorkloadId,
+        workload_id: &RuntimeWorkloadId,
         runtime_workload_config: WorkloadNamed,
         update_state_tx: WorkloadStateSender,
     ) -> Result<StateCheckerHandle, RuntimeError>;
 
     fn get_log_fetcher(
         &self,
-        workload_id: WorkloadId,
+        workload_id: RuntimeWorkloadId,
         options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError>;
 
-    async fn delete_workload(&self, workload_id: &WorkloadId) -> Result<(), RuntimeError>;
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError>;
 }
 
-pub trait OwnableRuntime<WorkloadId>: RuntimeConnector<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId>>;
+pub trait OwnableRuntime: RuntimeConnector {
+    fn to_owned(&self) -> Box<dyn RuntimeConnector>;
 }
 
-impl<R, WorkloadId> OwnableRuntime<WorkloadId> for R
+impl<R> OwnableRuntime for R
 where
-    R: RuntimeConnector<WorkloadId> + Clone + 'static,
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
+    R: RuntimeConnector + Clone + 'static,
 {
-    fn to_owned(&self) -> Box<dyn RuntimeConnector<WorkloadId>> {
+    fn to_owned(&self) -> Box<dyn RuntimeConnector> {
         Box::new(self.clone())
     }
 }
@@ -167,7 +195,7 @@ where
 
 #[cfg(test)]
 pub mod test {
-    use super::{LogRequestOptions, RuntimeConnector, RuntimeError};
+    use super::{LogRequestOptions, RuntimeConnector, RuntimeError, RuntimeWorkloadId};
     use crate::{
         runtime_connectors::{
             ReusableWorkloadState, StateChecker, StateCheckerHandle, log_fetcher::LogFetcher,
@@ -349,7 +377,7 @@ pub mod test {
     pub type MockRuntimeConnector = MockBase<RuntimeCall>;
 
     #[async_trait]
-    impl RuntimeConnector<String> for MockBase<RuntimeCall> {
+    impl RuntimeConnector for MockBase<RuntimeCall> {
         fn name(&self) -> String {
             "mock-runtime".to_string()
         }
@@ -376,11 +404,11 @@ pub mod test {
         async fn create_workload(
             &self,
             runtime_workload_config: WorkloadNamed,
-            reusable_workload_id: Option<String>,
+            reusable_workload_id: Option<RuntimeWorkloadId>,
             control_interface_path: Option<PathBuf>,
             _update_state_tx: WorkloadStateSender,
             host_workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
-        ) -> Result<(String, StateCheckerHandle), RuntimeError> {
+        ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::CreateWorkload(
                     expected_runtime_workload_config,
@@ -389,12 +417,15 @@ pub mod test {
                     expected_host_workload_file_path_mappings,
                     result,
                 ) if expected_runtime_workload_config == runtime_workload_config
-                    && expected_reusable_workload_id == reusable_workload_id
+                    && expected_reusable_workload_id
+                        == reusable_workload_id.as_ref().map(ToString::to_string)
                     && expected_control_interface_path == control_interface_path
                     && host_workload_file_path_mappings
                         == expected_host_workload_file_path_mappings =>
                 {
-                    return result;
+                    return result.map(|(workload_id, checker)| {
+                        (RuntimeWorkloadId::from(workload_id), checker)
+                    });
                 }
                 expected_call => {
                     self.unexpected_call();
@@ -408,12 +439,12 @@ pub mod test {
         async fn get_workload_id(
             &self,
             instance_name: &WorkloadInstanceNameSpec,
-        ) -> Result<String, RuntimeError> {
+        ) -> Result<RuntimeWorkloadId, RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::GetWorkloadId(expected_instance_name, result)
                     if expected_instance_name == *instance_name =>
                 {
-                    return result;
+                    return result.map(RuntimeWorkloadId::from);
                 }
                 expected_call => {
                     self.unexpected_call();
@@ -426,7 +457,7 @@ pub mod test {
 
         async fn start_checker(
             &self,
-            workload_id: &String,
+            workload_id: &RuntimeWorkloadId,
             runtime_workload_config: WorkloadNamed,
             update_state_tx: WorkloadStateSender,
         ) -> Result<StateCheckerHandle, RuntimeError> {
@@ -436,7 +467,7 @@ pub mod test {
                     expected_runtime_workload_config,
                     expected_update_state_tx,
                     result,
-                ) if expected_workload_id == *workload_id
+                ) if expected_workload_id == workload_id.to_string()
                     && expected_runtime_workload_config == runtime_workload_config
                     && expected_update_state_tx.same_channel(&update_state_tx) =>
                 {
@@ -453,7 +484,7 @@ pub mod test {
 
         fn get_log_fetcher(
             &self,
-            workload_id: String,
+            workload_id: RuntimeWorkloadId,
             options: &LogRequestOptions,
         ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
             match self.get_expected_call() {
@@ -471,10 +502,13 @@ pub mod test {
             }
         }
 
-        async fn delete_workload(&self, workload_id: &String) -> Result<(), RuntimeError> {
+        async fn delete_workload(
+            &self,
+            workload_id: &RuntimeWorkloadId,
+        ) -> Result<(), RuntimeError> {
             match self.get_expected_call() {
                 RuntimeCall::DeleteWorkload(expected_workload_id, result)
-                    if expected_workload_id == *workload_id =>
+                    if expected_workload_id == workload_id.to_string() =>
                 {
                     return result;
                 }

--- a/agent/src/runtime_connectors/runtime_connector.rs
+++ b/agent/src/runtime_connectors/runtime_connector.rs
@@ -58,6 +58,12 @@ impl AsRef<str> for RuntimeWorkloadId {
     }
 }
 
+impl Into<String> for RuntimeWorkloadId {
+    fn into(self) -> String {
+        self.0
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum RuntimeError {
     Create(String),

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     io_utils::FileSystemError,
-    runtime_connectors::{OwnableRuntime, ReusableWorkloadState, RuntimeError},
+    runtime_connectors::{OwnableRuntime, ReusableWorkloadState, RuntimeError, RuntimeWorkloadId},
     workload::WorkloadCommandSender,
     workload::control_loop_state::ControlLoopState,
     workload_operation::ReusableWorkload,
@@ -26,7 +26,7 @@ use common::objects::AgentName;
 use common::std_extensions::IllegalStateResult;
 
 use async_trait::async_trait;
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
 
 #[cfg_attr(test, mockall_double::double)]
@@ -71,18 +71,13 @@ pub trait RuntimeFacade: Send + Sync + 'static {
     );
 }
 
-pub struct GenericRuntimeFacade<
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-> {
-    runtime: Box<dyn OwnableRuntime<WorkloadId>>,
+pub struct GenericRuntimeFacade {
+    runtime: Box<dyn OwnableRuntime>,
     run_folder: PathBuf,
 }
 
-impl<WorkloadId> GenericRuntimeFacade<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    pub fn new(runtime: Box<dyn OwnableRuntime<WorkloadId>>, run_folder: PathBuf) -> Self {
+impl GenericRuntimeFacade {
+    pub fn new(runtime: Box<dyn OwnableRuntime>, run_folder: PathBuf) -> Self {
         GenericRuntimeFacade {
             runtime,
             run_folder,
@@ -91,10 +86,7 @@ where
 }
 
 #[async_trait]
-impl<
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-> RuntimeFacade for GenericRuntimeFacade<WorkloadId>
-{
+impl RuntimeFacade for GenericRuntimeFacade {
     // [impl->swdd~agent-facade-forwards-list-reusable-workloads-call~1]
     async fn get_reusable_workloads(
         &self,
@@ -150,10 +142,7 @@ impl<
     }
 }
 
-impl<
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-> GenericRuntimeFacade<WorkloadId>
-{
+impl GenericRuntimeFacade {
     // [impl->swdd~agent-create-workload~2]
     fn create_workload_non_blocking(
         &self,
@@ -162,16 +151,7 @@ impl<
         update_state_tx: &WorkloadStateSender,
     ) -> (JoinHandle<()>, Workload) {
         let workload_named = reusable_workload.workload_named;
-        let workload_id = match reusable_workload.runtime_workload_id {
-            Some(id) => match WorkloadId::from_str(&id) {
-                Ok(id) => Some(id),
-                Err(_) => {
-                    log::warn!("Cannot decode workload id '{id}'");
-                    None
-                }
-            },
-            None => None,
-        };
+        let workload_id = reusable_workload.runtime_workload_id;
 
         let runtime = self.runtime.to_owned();
         let update_state_tx = update_state_tx.clone();
@@ -226,7 +206,7 @@ impl<
 
             let control_loop_state = ControlLoopState::builder()
                 .workload_named(workload_named)
-                .workload_id(workload_id)
+                .workload_id(workload_id.map(RuntimeWorkloadId::from))
                 .control_interface_path(control_interface_path)
                 .run_folder(run_folder)
                 .workload_state_sender(update_state_tx)
@@ -390,7 +370,7 @@ impl<
 #[cfg(test)]
 mockall::mock! {
     pub GenericRuntimeFacade {
-        pub fn new(runtime: Box<dyn OwnableRuntime<String>>,
+        pub fn new(runtime: Box<dyn OwnableRuntime>,
             run_folder: PathBuf) -> Self;
     }
 
@@ -471,9 +451,9 @@ mod tests {
             Ok(vec![workload_state]),
         )]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -547,9 +527,9 @@ mod tests {
         let mut runtime_mock = MockRuntimeConnector::new();
         runtime_mock.expect(vec![]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -558,7 +538,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String>| ());
+            .return_once(|_: ControlLoopState| ());
 
         let (task_handle, _workload) = test_runtime_facade.create_workload_non_blocking(
             reusable_workload.clone(),
@@ -617,7 +597,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String>| ());
+            .return_once(|_: ControlLoopState| ());
 
         let mock_workload = MockWorkload::default();
         let new_workload_context = MockWorkload::new_context();
@@ -628,9 +608,9 @@ mod tests {
 
         let runtime_mock = MockRuntimeConnector::new();
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -665,7 +645,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String>| ());
+            .return_once(|_: ControlLoopState| ());
 
         let mock_workload = MockWorkload::default();
         let new_workload_context = MockWorkload::new_context();
@@ -676,9 +656,9 @@ mod tests {
 
         let runtime_mock = MockRuntimeConnector::new();
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -711,9 +691,9 @@ mod tests {
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),
         ]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -762,9 +742,9 @@ mod tests {
             ),
         ]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -687,7 +687,10 @@ mod tests {
             .build();
 
         runtime_mock.expect(vec![
-            RuntimeCall::GetWorkloadId(workload_instance_name.clone(), Ok(fixtures::WORKLOAD_IDS[0].to_string())),
+            RuntimeCall::GetWorkloadId(
+                workload_instance_name.clone(),
+                Ok(fixtures::WORKLOAD_IDS[0].into()),
+            ),
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),
         ]);
 
@@ -733,7 +736,10 @@ mod tests {
             .build();
 
         runtime_mock.expect(vec![
-            RuntimeCall::GetWorkloadId(workload_instance_name.clone(), Ok(fixtures::WORKLOAD_IDS[0].to_string())),
+            RuntimeCall::GetWorkloadId(
+                workload_instance_name.clone(),
+                Ok(fixtures::WORKLOAD_IDS[0].into()),
+            ),
             RuntimeCall::DeleteWorkload(
                 fixtures::WORKLOAD_IDS[0].to_string(),
                 Err(crate::runtime_connectors::RuntimeError::Delete(

--- a/agent/src/runtime_connectors/runtime_facade.rs
+++ b/agent/src/runtime_connectors/runtime_facade.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     io_utils::FileSystemError,
-    runtime_connectors::{OwnableRuntime, ReusableWorkloadState, RuntimeError, StateChecker},
+    runtime_connectors::{OwnableRuntime, ReusableWorkloadState, RuntimeError},
     workload::WorkloadCommandSender,
     workload::control_loop_state::ControlLoopState,
     workload_operation::ReusableWorkload,
@@ -35,8 +35,6 @@ use crate::control_interface::ControlInterface;
 use crate::control_interface::control_interface_info::ControlInterfaceInfo;
 #[cfg_attr(test, mockall_double::double)]
 use crate::io_utils::filesystem_async;
-#[cfg(test)]
-use crate::runtime_connectors::dummy_state_checker::DummyStateChecker;
 #[cfg_attr(test, mockall_double::double)]
 use crate::workload::Workload;
 #[cfg_attr(test, mockall_double::double)]
@@ -75,21 +73,16 @@ pub trait RuntimeFacade: Send + Sync + 'static {
 
 pub struct GenericRuntimeFacade<
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync,
 > {
-    runtime: Box<dyn OwnableRuntime<WorkloadId, StChecker>>,
+    runtime: Box<dyn OwnableRuntime<WorkloadId>>,
     run_folder: PathBuf,
 }
 
-impl<WorkloadId, StChecker> GenericRuntimeFacade<WorkloadId, StChecker>
+impl<WorkloadId> GenericRuntimeFacade<WorkloadId>
 where
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
 {
-    pub fn new(
-        runtime: Box<dyn OwnableRuntime<WorkloadId, StChecker>>,
-        run_folder: PathBuf,
-    ) -> Self {
+    pub fn new(runtime: Box<dyn OwnableRuntime<WorkloadId>>, run_folder: PathBuf) -> Self {
         GenericRuntimeFacade {
             runtime,
             run_folder,
@@ -100,8 +93,7 @@ where
 #[async_trait]
 impl<
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
-> RuntimeFacade for GenericRuntimeFacade<WorkloadId, StChecker>
+> RuntimeFacade for GenericRuntimeFacade<WorkloadId>
 {
     // [impl->swdd~agent-facade-forwards-list-reusable-workloads-call~1]
     async fn get_reusable_workloads(
@@ -160,8 +152,7 @@ impl<
 
 impl<
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
-> GenericRuntimeFacade<WorkloadId, StChecker>
+> GenericRuntimeFacade<WorkloadId>
 {
     // [impl->swdd~agent-create-workload~2]
     fn create_workload_non_blocking(
@@ -399,7 +390,7 @@ impl<
 #[cfg(test)]
 mockall::mock! {
     pub GenericRuntimeFacade {
-        pub fn new(runtime: Box<dyn OwnableRuntime<String, DummyStateChecker<String>>>,
+        pub fn new(runtime: Box<dyn OwnableRuntime<String>>,
             run_folder: PathBuf) -> Self;
     }
 
@@ -450,7 +441,7 @@ mod tests {
         io_utils::mock_filesystem_async,
         runtime_connectors::{
             GenericRuntimeFacade, OwnableRuntime, ReusableWorkloadState, RuntimeFacade,
-            runtime_connector::test::{MockRuntimeConnector, RuntimeCall, StubStateChecker},
+            runtime_connector::test::{MockRuntimeConnector, RuntimeCall},
         },
         workload::{ControlLoopState, MockWorkload, MockWorkloadControlLoop},
         workload_operation::ReusableWorkload,
@@ -480,9 +471,9 @@ mod tests {
             Ok(vec![workload_state]),
         )]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -556,9 +547,9 @@ mod tests {
         let mut runtime_mock = MockRuntimeConnector::new();
         runtime_mock.expect(vec![]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -567,7 +558,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String, StubStateChecker>| ());
+            .return_once(|_: ControlLoopState<String>| ());
 
         let (task_handle, _workload) = test_runtime_facade.create_workload_non_blocking(
             reusable_workload.clone(),
@@ -626,7 +617,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String, StubStateChecker>| ());
+            .return_once(|_: ControlLoopState<String>| ());
 
         let mock_workload = MockWorkload::default();
         let new_workload_context = MockWorkload::new_context();
@@ -637,9 +628,9 @@ mod tests {
 
         let runtime_mock = MockRuntimeConnector::new();
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -674,7 +665,7 @@ mod tests {
         mock_control_loop
             .expect()
             .once()
-            .return_once(|_: ControlLoopState<String, StubStateChecker>| ());
+            .return_once(|_: ControlLoopState<String>| ());
 
         let mock_workload = MockWorkload::default();
         let new_workload_context = MockWorkload::new_context();
@@ -685,9 +676,9 @@ mod tests {
 
         let runtime_mock = MockRuntimeConnector::new();
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -720,9 +711,9 @@ mod tests {
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),
         ]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));
@@ -771,9 +762,9 @@ mod tests {
             ),
         ]);
 
-        let ownable_runtime_mock: Box<dyn OwnableRuntime<String, StubStateChecker>> =
+        let ownable_runtime_mock: Box<dyn OwnableRuntime<String>> =
             Box::new(runtime_mock.clone());
-        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String, StubStateChecker>::new(
+        let test_runtime_facade = Box::new(GenericRuntimeFacade::<String>::new(
             ownable_runtime_mock,
             fixtures::RUN_FOLDER.into(),
         ));

--- a/agent/src/runtime_connectors/state_checker.rs
+++ b/agent/src/runtime_connectors/state_checker.rs
@@ -19,17 +19,16 @@ use async_trait::async_trait;
 use mockall::automock;
 use std::str::FromStr;
 
+use crate::runtime_connectors::RuntimeWorkloadId;
+
 pub type StateCheckerHandle = Box<dyn StateChecker + Send + Sync>;
 
 // [impl->swdd~agent-general-runtime-state-getter-interface~1]
 #[async_trait]
 #[cfg_attr(test, automock)]
-pub trait RuntimeStateGetter<WorkloadId>: Send + Sync + 'static
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
+pub trait RuntimeStateGetter: Send + Sync + 'static {
     // [impl->swdd~allowed-workload-states~2]
-    async fn get_state(&self, workload_id: &WorkloadId) -> ExecutionStateSpec;
+    async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec;
 }
 
 // [impl->swdd~agent-general-state-checker-interface~1]

--- a/agent/src/runtime_connectors/state_checker.rs
+++ b/agent/src/runtime_connectors/state_checker.rs
@@ -12,13 +12,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::workload_state::WorkloadStateSender;
-use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadNamed};
+use ankaios_api::ank_base::ExecutionStateSpec;
 
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
 use std::str::FromStr;
+
+pub type StateCheckerHandle = Box<dyn StateChecker + Send + Sync>;
 
 // [impl->swdd~agent-general-runtime-state-getter-interface~1]
 #[async_trait]
@@ -33,15 +34,6 @@ where
 
 // [impl->swdd~agent-general-state-checker-interface~1]
 #[async_trait]
-pub trait StateChecker<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    fn start_checker(
-        workload_named: &WorkloadNamed,
-        workload_id: WorkloadId,
-        manager_interface: WorkloadStateSender,
-        state_getter: impl RuntimeStateGetter<WorkloadId>,
-    ) -> Self;
-    async fn stop_checker(self);
+pub trait StateChecker: Send + Sync {
+    async fn stop_checker(self: Box<Self>);
 }

--- a/agent/src/runtime_connectors/state_checker.rs
+++ b/agent/src/runtime_connectors/state_checker.rs
@@ -17,7 +17,6 @@ use ankaios_api::ank_base::ExecutionStateSpec;
 use async_trait::async_trait;
 #[cfg(test)]
 use mockall::automock;
-use std::str::FromStr;
 
 use crate::runtime_connectors::RuntimeWorkloadId;
 

--- a/agent/src/runtime_connectors/unsupported/dummy_state_checker.rs
+++ b/agent/src/runtime_connectors/unsupported/dummy_state_checker.rs
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use super::StateChecker;
+use crate::runtime_connectors::StateChecker;
 use async_trait::async_trait;
 
 // [impl->swdd~agent-skips-unknown-runtime~2]

--- a/agent/src/runtime_connectors/unsupported/mod.rs
+++ b/agent/src/runtime_connectors/unsupported/mod.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+mod dummy_state_checker;
+pub(crate) mod unsupported_runtime;

--- a/agent/src/runtime_connectors/unsupported/unsupported_runtime.rs
+++ b/agent/src/runtime_connectors/unsupported/unsupported_runtime.rs
@@ -12,9 +12,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeWorkloadId, StateCheckerHandle,
-    dummy_state_checker::DummyStateChecker,
+use super::dummy_state_checker::DummyStateChecker;
+use crate::runtime_connectors::{
+    LogRequestOptions, ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeWorkloadId,
+    StateCheckerHandle, log_fetcher::LogFetcher,
 };
 use crate::workload_state::WorkloadStateSender;
 use ankaios_api::ank_base::{WorkloadInstanceNameSpec, WorkloadNamed};
@@ -80,8 +81,8 @@ impl RuntimeConnector for UnsupportedRuntime {
     fn get_log_fetcher(
         &self,
         _workload_id: RuntimeWorkloadId,
-        _options: &super::LogRequestOptions,
-    ) -> Result<Box<dyn super::log_fetcher::LogFetcher + Send>, RuntimeError> {
+        _options: &LogRequestOptions,
+    ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
         Err(RuntimeError::Unsupported(
             "Cannot collect logs for workload with unsupported runtime".into(),
         ))

--- a/agent/src/runtime_connectors/unsupported_runtime.rs
+++ b/agent/src/runtime_connectors/unsupported_runtime.rs
@@ -13,7 +13,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    ReusableWorkloadState, RuntimeConnector, RuntimeError, dummy_state_checker::DummyStateChecker,
+    ReusableWorkloadState, RuntimeConnector, RuntimeError, StateCheckerHandle,
+    dummy_state_checker::DummyStateChecker,
 };
 use crate::workload_state::WorkloadStateSender;
 use ankaios_api::ank_base::{WorkloadInstanceNameSpec, WorkloadNamed};
@@ -28,7 +29,7 @@ pub struct UnsupportedRuntime(pub String);
 
 // [impl->swdd~agent-skips-unknown-runtime~2]
 #[async_trait]
-impl RuntimeConnector<String, DummyStateChecker<String>> for UnsupportedRuntime {
+impl RuntimeConnector<String> for UnsupportedRuntime {
     fn name(&self) -> String {
         self.0.clone()
     }
@@ -47,7 +48,7 @@ impl RuntimeConnector<String, DummyStateChecker<String>> for UnsupportedRuntime 
         _control_interface_path: Option<PathBuf>,
         _update_state_tx: WorkloadStateSender,
         _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(String, DummyStateChecker<String>), RuntimeError> {
+    ) -> Result<(String, StateCheckerHandle), RuntimeError> {
         if runtime_workload_config.workload.runtime == self.0 {
             Err(RuntimeError::Unsupported("Unsupported Runtime".into()))
         } else {
@@ -72,8 +73,8 @@ impl RuntimeConnector<String, DummyStateChecker<String>> for UnsupportedRuntime 
         _workload_id: &String,
         _runtime_workload_config: WorkloadNamed,
         _update_state_tx: WorkloadStateSender,
-    ) -> Result<DummyStateChecker<String>, RuntimeError> {
-        Ok(DummyStateChecker::new())
+    ) -> Result<StateCheckerHandle, RuntimeError> {
+        Ok(Box::new(DummyStateChecker::new()))
     }
 
     fn get_log_fetcher(

--- a/agent/src/runtime_connectors/unsupported_runtime.rs
+++ b/agent/src/runtime_connectors/unsupported_runtime.rs
@@ -13,7 +13,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    ReusableWorkloadState, RuntimeConnector, RuntimeError, StateCheckerHandle,
+    ReusableWorkloadState, RuntimeConnector, RuntimeError, RuntimeWorkloadId, StateCheckerHandle,
     dummy_state_checker::DummyStateChecker,
 };
 use crate::workload_state::WorkloadStateSender;
@@ -29,7 +29,7 @@ pub struct UnsupportedRuntime(pub String);
 
 // [impl->swdd~agent-skips-unknown-runtime~2]
 #[async_trait]
-impl RuntimeConnector<String> for UnsupportedRuntime {
+impl RuntimeConnector for UnsupportedRuntime {
     fn name(&self) -> String {
         self.0.clone()
     }
@@ -44,11 +44,11 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
     async fn create_workload(
         &self,
         runtime_workload_config: WorkloadNamed,
-        _reusable_workload_id: Option<String>,
+        _reusable_workload_id: Option<RuntimeWorkloadId>,
         _control_interface_path: Option<PathBuf>,
         _update_state_tx: WorkloadStateSender,
         _workload_file_path_mapping: HashMap<PathBuf, PathBuf>,
-    ) -> Result<(String, StateCheckerHandle), RuntimeError> {
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
         if runtime_workload_config.workload.runtime == self.0 {
             Err(RuntimeError::Unsupported("Unsupported Runtime".into()))
         } else {
@@ -62,7 +62,7 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
     async fn get_workload_id(
         &self,
         _instance_name: &WorkloadInstanceNameSpec,
-    ) -> Result<String, RuntimeError> {
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
         Err(RuntimeError::List(
             "Cannot get information about workload with unsupported runtime".into(),
         ))
@@ -70,7 +70,7 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
 
     async fn start_checker(
         &self,
-        _workload_id: &String,
+        _workload_id: &RuntimeWorkloadId,
         _runtime_workload_config: WorkloadNamed,
         _update_state_tx: WorkloadStateSender,
     ) -> Result<StateCheckerHandle, RuntimeError> {
@@ -79,7 +79,7 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
 
     fn get_log_fetcher(
         &self,
-        _workload_id: String,
+        _workload_id: RuntimeWorkloadId,
         _options: &super::LogRequestOptions,
     ) -> Result<Box<dyn super::log_fetcher::LogFetcher + Send>, RuntimeError> {
         Err(RuntimeError::Unsupported(
@@ -87,7 +87,7 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
         ))
     }
 
-    async fn delete_workload(&self, _workload_id: &String) -> Result<(), RuntimeError> {
+    async fn delete_workload(&self, _workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
         Ok(())
     }
 }
@@ -103,10 +103,10 @@ impl RuntimeConnector<String> for UnsupportedRuntime {
 #[cfg(test)]
 mod tests {
     use super::{RuntimeError, UnsupportedRuntime, WorkloadInstanceNameSpec};
-    use crate::runtime_connectors::{LogRequestOptions, RuntimeConnector};
+    use crate::runtime_connectors::{LogRequestOptions, RuntimeConnector, RuntimeWorkloadId};
 
     use ankaios_api::test_utils::{
-        generate_test_workload_named, generate_test_workload_named_with_params, fixtures,
+        fixtures, generate_test_workload_named, generate_test_workload_named_with_params,
     };
     use common::objects::AgentName;
 
@@ -203,7 +203,7 @@ mod tests {
 
         let result = unsupported_runtime
             .start_checker(
-                &fixtures::WORKLOAD_IDS[0].to_owned(),
+                &RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_owned()),
                 workload,
                 mpsc::channel(1).0,
             )
@@ -223,8 +223,10 @@ mod tests {
             tail: None,
         };
 
-        let result =
-            unsupported_runtime.get_log_fetcher(fixtures::WORKLOAD_IDS[0].to_owned(), &options);
+        let result = unsupported_runtime.get_log_fetcher(
+            RuntimeWorkloadId::from(fixtures::WORKLOAD_IDS[0].to_owned()),
+            &options,
+        );
 
         assert!(matches!(
             result,
@@ -238,7 +240,9 @@ mod tests {
         let unsupported_runtime = UnsupportedRuntime(TEST_RUNTIME_NAME.to_string());
 
         let result = unsupported_runtime
-            .delete_workload(&fixtures::WORKLOAD_IDS[0].to_owned())
+            .delete_workload(&RuntimeWorkloadId::from(
+                fixtures::WORKLOAD_IDS[0].to_owned(),
+            ))
             .await;
 
         assert!(result.is_ok());

--- a/agent/src/runtime_manager.rs
+++ b/agent/src/runtime_manager.rs
@@ -15,7 +15,8 @@
 use crate::{
     control_interface::ControlInterfacePath,
     runtime_connectors::{
-        LogRequestOptions, log_fetcher::LogFetcher, unsupported_runtime::UnsupportedRuntime,
+        LogRequestOptions, log_fetcher::LogFetcher,
+        unsupported::unsupported_runtime::UnsupportedRuntime,
     },
 };
 

--- a/agent/src/workload/control_loop_state.rs
+++ b/agent/src/workload/control_loop_state.rs
@@ -16,39 +16,32 @@
 use super::retry_manager::RetryManager;
 use crate::BUFFER_SIZE;
 use crate::control_interface::ControlInterfacePath;
-use crate::runtime_connectors::{RuntimeConnector, StateCheckerHandle};
+use crate::runtime_connectors::{RuntimeConnector, RuntimeWorkloadId, StateCheckerHandle};
 use crate::workload::workload_command_channel::{WorkloadCommandReceiver, WorkloadCommandSender};
 use crate::workload_state::{WorkloadStateReceiver, WorkloadStateSender};
 
 use ankaios_api::ank_base::{WorkloadInstanceNameSpec, WorkloadNamed, WorkloadStateSpec};
 
 use std::path::PathBuf;
-use std::str::FromStr;
 use tokio::sync::mpsc;
 
-pub struct ControlLoopState<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
+pub struct ControlLoopState {
     pub workload_named: WorkloadNamed,
     pub control_interface_path: Option<ControlInterfacePath>,
     pub run_folder: PathBuf,
-    pub workload_id: Option<WorkloadId>,
+    pub workload_id: Option<RuntimeWorkloadId>,
     pub state_checker: Option<StateCheckerHandle>,
     pub to_agent_workload_state_sender: WorkloadStateSender,
     pub state_checker_workload_state_sender: WorkloadStateSender,
     pub state_checker_workload_state_receiver: WorkloadStateReceiver,
-    pub runtime: Box<dyn RuntimeConnector<WorkloadId>>,
+    pub runtime: Box<dyn RuntimeConnector>,
     pub command_receiver: WorkloadCommandReceiver,
     pub retry_sender: WorkloadCommandSender,
     pub retry_manager: RetryManager,
 }
 
-impl<WorkloadId> ControlLoopState<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
-    pub fn builder() -> ControlLoopStateBuilder<WorkloadId> {
+impl ControlLoopState {
+    pub fn builder() -> ControlLoopStateBuilder {
         ControlLoopStateBuilder::new()
     }
 
@@ -57,24 +50,18 @@ where
     }
 }
 
-pub struct ControlLoopStateBuilder<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
+pub struct ControlLoopStateBuilder {
     workload_named: Option<WorkloadNamed>,
-    workload_id: Option<WorkloadId>,
+    workload_id: Option<RuntimeWorkloadId>,
     control_interface_path: Option<ControlInterfacePath>,
     run_folder: Option<PathBuf>,
     workload_state_sender: Option<WorkloadStateSender>,
-    runtime: Option<Box<dyn RuntimeConnector<WorkloadId>>>,
+    runtime: Option<Box<dyn RuntimeConnector>>,
     workload_command_receiver: Option<WorkloadCommandReceiver>,
     retry_sender: Option<WorkloadCommandSender>,
 }
 
-impl<WorkloadId> ControlLoopStateBuilder<WorkloadId>
-where
-    WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-{
+impl ControlLoopStateBuilder {
     pub fn new() -> Self {
         ControlLoopStateBuilder {
             workload_named: None,
@@ -93,7 +80,7 @@ where
         self
     }
 
-    pub fn workload_id(mut self, workload_id: Option<WorkloadId>) -> Self {
+    pub fn workload_id(mut self, workload_id: Option<RuntimeWorkloadId>) -> Self {
         self.workload_id = workload_id;
         self
     }
@@ -116,7 +103,7 @@ where
         self
     }
 
-    pub fn runtime(mut self, runtime: Box<dyn RuntimeConnector<WorkloadId>>) -> Self {
+    pub fn runtime(mut self, runtime: Box<dyn RuntimeConnector>) -> Self {
         self.runtime = Some(runtime);
         self
     }
@@ -131,7 +118,7 @@ where
         self
     }
 
-    pub fn build(self) -> Result<ControlLoopState<WorkloadId>, String> {
+    pub fn build(self) -> Result<ControlLoopState, String> {
         // new channel for receiving the workload states from the state checker
         let (state_checker_wl_state_sender, state_checker_wl_state_receiver) =
             mpsc::channel::<WorkloadStateSpec>(BUFFER_SIZE);
@@ -177,15 +164,14 @@ where
 mod tests {
     use super::ControlLoopState;
     use crate::{
-        control_interface::ControlInterfacePath,
-        runtime_connectors::test::MockRuntimeConnector,
+        control_interface::ControlInterfacePath, runtime_connectors::test::MockRuntimeConnector,
         workload::workload_command_channel::WorkloadCommandSender,
         workload_state::WorkloadStateSenderInterface,
     };
 
     use ankaios_api::ank_base::ExecutionStateSpec;
     use ankaios_api::test_utils::{
-        generate_test_workload_named, generate_test_workload_state_with_workload_named, fixtures,
+        fixtures, generate_test_workload_named, generate_test_workload_state_with_workload_named,
     };
 
     use tokio::{sync::mpsc, time};
@@ -275,7 +261,7 @@ mod tests {
 
     #[test]
     fn utest_control_loop_state_builder_build_failed() {
-        let control_loop_state = ControlLoopState::<String>::builder().build();
+        let control_loop_state = ControlLoopState::builder().build();
         assert!(control_loop_state.is_err());
     }
 

--- a/agent/src/workload/control_loop_state.rs
+++ b/agent/src/workload/control_loop_state.rs
@@ -16,7 +16,7 @@
 use super::retry_manager::RetryManager;
 use crate::BUFFER_SIZE;
 use crate::control_interface::ControlInterfacePath;
-use crate::runtime_connectors::{RuntimeConnector, StateChecker};
+use crate::runtime_connectors::{RuntimeConnector, StateCheckerHandle};
 use crate::workload::workload_command_channel::{WorkloadCommandReceiver, WorkloadCommandSender};
 use crate::workload_state::{WorkloadStateReceiver, WorkloadStateSender};
 
@@ -26,31 +26,29 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use tokio::sync::mpsc;
 
-pub struct ControlLoopState<WorkloadId, StChecker>
+pub struct ControlLoopState<WorkloadId>
 where
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
 {
     pub workload_named: WorkloadNamed,
     pub control_interface_path: Option<ControlInterfacePath>,
     pub run_folder: PathBuf,
     pub workload_id: Option<WorkloadId>,
-    pub state_checker: Option<StChecker>,
+    pub state_checker: Option<StateCheckerHandle>,
     pub to_agent_workload_state_sender: WorkloadStateSender,
     pub state_checker_workload_state_sender: WorkloadStateSender,
     pub state_checker_workload_state_receiver: WorkloadStateReceiver,
-    pub runtime: Box<dyn RuntimeConnector<WorkloadId, StChecker>>,
+    pub runtime: Box<dyn RuntimeConnector<WorkloadId>>,
     pub command_receiver: WorkloadCommandReceiver,
     pub retry_sender: WorkloadCommandSender,
     pub retry_manager: RetryManager,
 }
 
-impl<WorkloadId, StChecker> ControlLoopState<WorkloadId, StChecker>
+impl<WorkloadId> ControlLoopState<WorkloadId>
 where
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
 {
-    pub fn builder() -> ControlLoopStateBuilder<WorkloadId, StChecker> {
+    pub fn builder() -> ControlLoopStateBuilder<WorkloadId> {
         ControlLoopStateBuilder::new()
     }
 
@@ -59,25 +57,23 @@ where
     }
 }
 
-pub struct ControlLoopStateBuilder<WorkloadId, StChecker>
+pub struct ControlLoopStateBuilder<WorkloadId>
 where
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
 {
     workload_named: Option<WorkloadNamed>,
     workload_id: Option<WorkloadId>,
     control_interface_path: Option<ControlInterfacePath>,
     run_folder: Option<PathBuf>,
     workload_state_sender: Option<WorkloadStateSender>,
-    runtime: Option<Box<dyn RuntimeConnector<WorkloadId, StChecker>>>,
+    runtime: Option<Box<dyn RuntimeConnector<WorkloadId>>>,
     workload_command_receiver: Option<WorkloadCommandReceiver>,
     retry_sender: Option<WorkloadCommandSender>,
 }
 
-impl<WorkloadId, StChecker> ControlLoopStateBuilder<WorkloadId, StChecker>
+impl<WorkloadId> ControlLoopStateBuilder<WorkloadId>
 where
     WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
 {
     pub fn new() -> Self {
         ControlLoopStateBuilder {
@@ -120,7 +116,7 @@ where
         self
     }
 
-    pub fn runtime(mut self, runtime: Box<dyn RuntimeConnector<WorkloadId, StChecker>>) -> Self {
+    pub fn runtime(mut self, runtime: Box<dyn RuntimeConnector<WorkloadId>>) -> Self {
         self.runtime = Some(runtime);
         self
     }
@@ -135,7 +131,7 @@ where
         self
     }
 
-    pub fn build(self) -> Result<ControlLoopState<WorkloadId, StChecker>, String> {
+    pub fn build(self) -> Result<ControlLoopState<WorkloadId>, String> {
         // new channel for receiving the workload states from the state checker
         let (state_checker_wl_state_sender, state_checker_wl_state_receiver) =
             mpsc::channel::<WorkloadStateSpec>(BUFFER_SIZE);
@@ -182,7 +178,7 @@ mod tests {
     use super::ControlLoopState;
     use crate::{
         control_interface::ControlInterfacePath,
-        runtime_connectors::test::{MockRuntimeConnector, StubStateChecker},
+        runtime_connectors::test::MockRuntimeConnector,
         workload::workload_command_channel::WorkloadCommandSender,
         workload_state::WorkloadStateSenderInterface,
     };
@@ -279,7 +275,7 @@ mod tests {
 
     #[test]
     fn utest_control_loop_state_builder_build_failed() {
-        let control_loop_state = ControlLoopState::<String, StubStateChecker>::builder().build();
+        let control_loop_state = ControlLoopState::<String>::builder().build();
         assert!(control_loop_state.is_err());
     }
 

--- a/agent/src/workload/workload_control_loop.rs
+++ b/agent/src/workload/workload_control_loop.rs
@@ -786,7 +786,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -991,7 +991,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -1107,7 +1107,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -1424,7 +1424,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -1505,7 +1505,7 @@ mod tests {
         runtime_mock.expect(vec![
             RuntimeCall::GetWorkloadId(
                 workload.instance_name.clone(),
-                Ok(fixtures::WORKLOAD_IDS[0].to_string()),
+                Ok(fixtures::WORKLOAD_IDS[0].into()),
             ),
             RuntimeCall::StartChecker(
                 fixtures::WORKLOAD_IDS[0].to_string(),
@@ -1575,7 +1575,7 @@ mod tests {
         runtime_mock.expect(vec![
             RuntimeCall::GetWorkloadId(
                 workload.instance_name.clone(),
-                Ok(fixtures::WORKLOAD_IDS[0].to_string()),
+                Ok(fixtures::WORKLOAD_IDS[0].into()),
             ),
             RuntimeCall::StartChecker(
                 fixtures::WORKLOAD_IDS[0].to_string(),
@@ -1678,7 +1678,7 @@ mod tests {
         runtime_mock.expect(vec![
             RuntimeCall::GetWorkloadId(
                 workload.instance_name.clone(),
-                Ok(fixtures::WORKLOAD_IDS[0].to_string()),
+                Ok(fixtures::WORKLOAD_IDS[0].into()),
             ),
             RuntimeCall::StartChecker(
                 fixtures::WORKLOAD_IDS[0].to_string(),
@@ -1834,7 +1834,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[1].to_string(), // new workload id after restart
+                    fixtures::WORKLOAD_IDS[1].into(), // new workload id after restart
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -1941,7 +1941,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(new_mock_state_checker),
                 )),
             ),
@@ -2152,7 +2152,7 @@ mod tests {
             None,
             expected_mount_point_mappings.clone(),
             Ok((
-                fixtures::WORKLOAD_IDS[0].to_string(),
+                fixtures::WORKLOAD_IDS[0].into(),
                 Box::new(StubStateChecker::new()),
             )),
         )]);
@@ -2558,7 +2558,7 @@ mod tests {
                 Some(fixtures::PIPES_LOCATION.into()),
                 HashMap::default(),
                 Ok((
-                    fixtures::WORKLOAD_IDS[0].to_string(),
+                    fixtures::WORKLOAD_IDS[0].into(),
                     Box::new(StubStateChecker::new()),
                 )),
             ),

--- a/agent/src/workload/workload_control_loop.rs
+++ b/agent/src/workload/workload_control_loop.rs
@@ -28,7 +28,6 @@ use common::std_extensions::IllegalStateResult;
 use futures_util::Future;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::io_utils::filesystem_async;
@@ -42,10 +41,7 @@ use super::retry_manager::RetryToken;
 pub struct WorkloadControlLoop;
 
 impl WorkloadControlLoop {
-    pub async fn run<WorkloadId>(mut control_loop_state: ControlLoopState<WorkloadId>)
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    pub async fn run(mut control_loop_state: ControlLoopState) {
         loop {
             tokio::select! {
                 // [impl->swdd~workload-control-loop-receives-workload-states~1]
@@ -178,13 +174,10 @@ impl WorkloadControlLoop {
             .await;
     }
 
-    async fn restart_workload_on_runtime<WorkloadId>(
-        control_loop_state: ControlLoopState<WorkloadId>,
+    async fn restart_workload_on_runtime(
+        control_loop_state: ControlLoopState,
         execution_state: &ExecutionStateSpec,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> ControlLoopState {
         log::debug!(
             "Restart workload '{}' with restart policy '{:?}'",
             control_loop_state
@@ -235,15 +228,12 @@ impl WorkloadControlLoop {
         }
     }
 
-    async fn send_retry_for_workload<WorkloadId>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
+    async fn send_retry_for_workload(
+        mut control_loop_state: ControlLoopState,
         instance_name: WorkloadInstanceNameSpec,
         retry_token: RetryToken,
         error_msg: String,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> ControlLoopState {
         log::info!(
             "Retrying workload creation for: '{}'. Error: '{}'",
             instance_name.workload_name(),
@@ -269,21 +259,15 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-create~4]
-    async fn create_workload_on_runtime<WorkloadId, ErrorFunc, Fut>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
+    async fn create_workload_on_runtime<ErrorFunc, Fut>(
+        mut control_loop_state: ControlLoopState,
         retry_token: RetryToken,
         func_on_recoverable_error: ErrorFunc,
-    ) -> ControlLoopState<WorkloadId>
+    ) -> ControlLoopState
     where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        Fut: Future<Output = ControlLoopState<WorkloadId>> + 'static,
-        ErrorFunc: FnOnce(
-                ControlLoopState<WorkloadId>,
-                WorkloadInstanceNameSpec,
-                RetryToken,
-                String,
-            ) -> Fut
-            + 'static,
+        Fut: Future<Output = ControlLoopState> + 'static,
+        ErrorFunc:
+            FnOnce(ControlLoopState, WorkloadInstanceNameSpec, RetryToken, String) -> Fut + 'static,
     {
         let host_file_path_mount_point_mappings =
             match Self::handle_mount_point_creation(&control_loop_state).await {
@@ -363,12 +347,9 @@ impl WorkloadControlLoop {
         }
     }
 
-    async fn handle_mount_point_creation<WorkloadId>(
-        control_loop_state: &ControlLoopState<WorkloadId>,
-    ) -> Result<HashMap<PathBuf, PathBuf>, String>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    async fn handle_mount_point_creation(
+        control_loop_state: &ControlLoopState,
+    ) -> Result<HashMap<PathBuf, PathBuf>, String> {
         if !control_loop_state
             .workload_named
             .workload
@@ -416,12 +397,9 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-delete~3]
-    async fn delete_workload_on_runtime<WorkloadId>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
-    ) -> Option<ControlLoopState<WorkloadId>>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    async fn delete_workload_on_runtime(
+        mut control_loop_state: ControlLoopState,
+    ) -> Option<ControlLoopState> {
         Self::send_workload_state_to_agent(
             &control_loop_state.to_agent_workload_state_sender,
             control_loop_state.instance_name(),
@@ -477,14 +455,11 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-update~3]
-    async fn update_workload_on_runtime<WorkloadId>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
+    async fn update_workload_on_runtime(
+        mut control_loop_state: ControlLoopState,
         new_workload_named: Option<Box<WorkloadNamed>>,
         control_interface_path: Option<ControlInterfacePath>,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> ControlLoopState {
         Self::send_workload_state_to_agent(
             &control_loop_state.to_agent_workload_state_sender,
             control_loop_state.instance_name(),
@@ -578,14 +553,11 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~workload-control-loop-reuses-bundle-on-successful-restart~1]
-    async fn restart_workload_with_bundle_reuse<WorkloadId>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
+    async fn restart_workload_with_bundle_reuse(
+        mut control_loop_state: ControlLoopState,
         new_workload_named: Option<Box<WorkloadNamed>>,
         control_interface_path: Option<ControlInterfacePath>,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> ControlLoopState {
         log::debug!(
             "Reusing bundle and workload files for workload '{}' due to restart policy",
             control_loop_state.instance_name().workload_name()
@@ -632,13 +604,10 @@ impl WorkloadControlLoop {
         control_loop_state
     }
 
-    async fn retry_create_workload_on_runtime<WorkloadId>(
-        control_loop_state: ControlLoopState<WorkloadId>,
+    async fn retry_create_workload_on_runtime(
+        control_loop_state: ControlLoopState,
         retry_token: RetryToken,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> ControlLoopState {
         if retry_token.is_valid() {
             Self::create_workload_on_runtime(
                 control_loop_state,
@@ -653,12 +622,9 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-resume~1]
-    async fn resume_workload_on_runtime<WorkloadId>(
-        mut control_loop_state: ControlLoopState<WorkloadId>,
-    ) -> ControlLoopState<WorkloadId>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    async fn resume_workload_on_runtime(
+        mut control_loop_state: ControlLoopState,
+    ) -> ControlLoopState {
         let workload_name = control_loop_state.instance_name().workload_name();
         let workload_id = control_loop_state
             .runtime
@@ -707,13 +673,10 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-creates-log-fetcher~1]
-    fn create_log_fetcher<WorkloadId>(
-        control_loop_state: &ControlLoopState<WorkloadId>,
+    fn create_log_fetcher(
+        control_loop_state: &ControlLoopState,
         log_request_options: &LogRequestOptions,
-    ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError>
-    where
-        WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-    {
+    ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
         let Some(workload_id) = &control_loop_state.workload_id else {
             return Err(RuntimeError::CollectLog(
                 "Could not start collecting logs for as it has no workload ID yet.".into(),
@@ -737,11 +700,9 @@ impl WorkloadControlLoop {
 #[cfg(test)]
 mockall::mock! {
     pub WorkloadControlLoop {
-        pub async fn run<WorkloadId>(
-            control_loop_state: ControlLoopState<WorkloadId>,
-        )
-        where
-            WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static;
+        pub async fn run(
+            control_loop_state: ControlLoopState,
+        );
     }
 }
 
@@ -874,7 +835,7 @@ mod tests {
             .expect_new_token()
             .return_once(|| mock_retry_token);
 
-        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
+        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.into());
         control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
@@ -965,7 +926,7 @@ mod tests {
             .expect_new_token()
             .return_once(|| mock_retry_token);
 
-        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
+        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.into());
         control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
@@ -1084,7 +1045,7 @@ mod tests {
             .expect_new_token()
             .return_once(|| mock_retry_token);
 
-        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
+        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.into());
         control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
@@ -1359,7 +1320,7 @@ mod tests {
             .once()
             .return_const(());
 
-        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
+        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.into());
         control_loop_state.state_checker = Some(Box::new(mock_state_checker));
 
         assert!(
@@ -2543,7 +2504,7 @@ mod tests {
             .times(2)
             .return_const(());
 
-        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
+        control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.into());
         control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         control_loop_state

--- a/agent/src/workload/workload_control_loop.rs
+++ b/agent/src/workload/workload_control_loop.rs
@@ -15,7 +15,7 @@
 use crate::control_interface::ControlInterfacePath;
 use crate::io_utils::FileSystemError;
 use crate::runtime_connectors::log_fetcher::LogFetcher;
-use crate::runtime_connectors::{LogRequestOptions, RuntimeError, StateChecker};
+use crate::runtime_connectors::{LogRequestOptions, RuntimeError};
 use crate::workload::{ControlLoopState, WorkloadCommand};
 use crate::workload_files::WorkloadFilesBasePath;
 use crate::workload_state::{WorkloadStateSender, WorkloadStateSenderInterface};
@@ -42,11 +42,9 @@ use super::retry_manager::RetryToken;
 pub struct WorkloadControlLoop;
 
 impl WorkloadControlLoop {
-    pub async fn run<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
-    ) where
+    pub async fn run<WorkloadId>(mut control_loop_state: ControlLoopState<WorkloadId>)
+    where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         loop {
             tokio::select! {
@@ -180,13 +178,12 @@ impl WorkloadControlLoop {
             .await;
     }
 
-    async fn restart_workload_on_runtime<WorkloadId, StChecker>(
-        control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn restart_workload_on_runtime<WorkloadId>(
+        control_loop_state: ControlLoopState<WorkloadId>,
         execution_state: &ExecutionStateSpec,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         log::debug!(
             "Restart workload '{}' with restart policy '{:?}'",
@@ -238,15 +235,14 @@ impl WorkloadControlLoop {
         }
     }
 
-    async fn send_retry_for_workload<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn send_retry_for_workload<WorkloadId>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
         instance_name: WorkloadInstanceNameSpec,
         retry_token: RetryToken,
         error_msg: String,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         log::info!(
             "Retrying workload creation for: '{}'. Error: '{}'",
@@ -273,17 +269,16 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-create~4]
-    async fn create_workload_on_runtime<WorkloadId, StChecker, ErrorFunc, Fut>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn create_workload_on_runtime<WorkloadId, ErrorFunc, Fut>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
         retry_token: RetryToken,
         func_on_recoverable_error: ErrorFunc,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
-        Fut: Future<Output = ControlLoopState<WorkloadId, StChecker>> + 'static,
+        Fut: Future<Output = ControlLoopState<WorkloadId>> + 'static,
         ErrorFunc: FnOnce(
-                ControlLoopState<WorkloadId, StChecker>,
+                ControlLoopState<WorkloadId>,
                 WorkloadInstanceNameSpec,
                 RetryToken,
                 String,
@@ -368,12 +363,11 @@ impl WorkloadControlLoop {
         }
     }
 
-    async fn handle_mount_point_creation<WorkloadId, StChecker>(
-        control_loop_state: &ControlLoopState<WorkloadId, StChecker>,
+    async fn handle_mount_point_creation<WorkloadId>(
+        control_loop_state: &ControlLoopState<WorkloadId>,
     ) -> Result<HashMap<PathBuf, PathBuf>, String>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         if !control_loop_state
             .workload_named
@@ -422,12 +416,11 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-delete~3]
-    async fn delete_workload_on_runtime<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
-    ) -> Option<ControlLoopState<WorkloadId, StChecker>>
+    async fn delete_workload_on_runtime<WorkloadId>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
+    ) -> Option<ControlLoopState<WorkloadId>>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         Self::send_workload_state_to_agent(
             &control_loop_state.to_agent_workload_state_sender,
@@ -484,14 +477,13 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-update~3]
-    async fn update_workload_on_runtime<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn update_workload_on_runtime<WorkloadId>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
         new_workload_named: Option<Box<WorkloadNamed>>,
         control_interface_path: Option<ControlInterfacePath>,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         Self::send_workload_state_to_agent(
             &control_loop_state.to_agent_workload_state_sender,
@@ -586,14 +578,13 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~workload-control-loop-reuses-bundle-on-successful-restart~1]
-    async fn restart_workload_with_bundle_reuse<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn restart_workload_with_bundle_reuse<WorkloadId>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
         new_workload_named: Option<Box<WorkloadNamed>>,
         control_interface_path: Option<ControlInterfacePath>,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         log::debug!(
             "Reusing bundle and workload files for workload '{}' due to restart policy",
@@ -641,13 +632,12 @@ impl WorkloadControlLoop {
         control_loop_state
     }
 
-    async fn retry_create_workload_on_runtime<WorkloadId, StChecker>(
-        control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+    async fn retry_create_workload_on_runtime<WorkloadId>(
+        control_loop_state: ControlLoopState<WorkloadId>,
         retry_token: RetryToken,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         if retry_token.is_valid() {
             Self::create_workload_on_runtime(
@@ -663,12 +653,11 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-executes-resume~1]
-    async fn resume_workload_on_runtime<WorkloadId, StChecker>(
-        mut control_loop_state: ControlLoopState<WorkloadId, StChecker>,
-    ) -> ControlLoopState<WorkloadId, StChecker>
+    async fn resume_workload_on_runtime<WorkloadId>(
+        mut control_loop_state: ControlLoopState<WorkloadId>,
+    ) -> ControlLoopState<WorkloadId>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         let workload_name = control_loop_state.instance_name().workload_name();
         let workload_id = control_loop_state
@@ -676,7 +665,7 @@ impl WorkloadControlLoop {
             .get_workload_id(&control_loop_state.workload_named.instance_name)
             .await;
 
-        let state_checker: Option<StChecker> = match workload_id.as_ref() {
+        let state_checker = match workload_id.as_ref() {
             Ok(wl_id) => control_loop_state
                 .runtime
                 .start_checker(
@@ -718,13 +707,12 @@ impl WorkloadControlLoop {
     }
 
     // [impl->swdd~agent-workload-control-loop-creates-log-fetcher~1]
-    fn create_log_fetcher<WorkloadId, StChecker>(
-        control_loop_state: &ControlLoopState<WorkloadId, StChecker>,
+    fn create_log_fetcher<WorkloadId>(
+        control_loop_state: &ControlLoopState<WorkloadId>,
         log_request_options: &LogRequestOptions,
     ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError>
     where
         WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-        StChecker: StateChecker<WorkloadId> + Send + Sync + 'static,
     {
         let Some(workload_id) = &control_loop_state.workload_id else {
             return Err(RuntimeError::CollectLog(
@@ -749,12 +737,11 @@ impl WorkloadControlLoop {
 #[cfg(test)]
 mockall::mock! {
     pub WorkloadControlLoop {
-        pub async fn run<WorkloadId, StChecker>(
-            control_loop_state: ControlLoopState<WorkloadId, StChecker>,
+        pub async fn run<WorkloadId>(
+            control_loop_state: ControlLoopState<WorkloadId>,
         )
         where
-            WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static,
-            StChecker: StateChecker<WorkloadId> + Send + Sync + 'static;
+            WorkloadId: ToString + FromStr + Clone + Send + Sync + 'static;
     }
 }
 
@@ -839,7 +826,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             // Since we also send a delete command to exit the control loop properly, the new workload
@@ -888,7 +875,7 @@ mod tests {
             .return_once(|| mock_retry_token);
 
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
             timeout(
@@ -979,7 +966,7 @@ mod tests {
             .return_once(|| mock_retry_token);
 
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
             timeout(
@@ -1044,7 +1031,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             // Delete the new updated workload to exit the infinite loop
@@ -1098,7 +1085,7 @@ mod tests {
             .return_once(|| mock_retry_token);
 
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         assert!(
             timeout(
@@ -1160,7 +1147,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             // Since we also send a delete command to exit the control loop properly, the new workload
@@ -1373,7 +1360,7 @@ mod tests {
             .return_const(());
 
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
-        control_loop_state.state_checker = Some(mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(mock_state_checker));
 
         assert!(
             timeout(
@@ -1477,7 +1464,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             // Since we also send a delete command to exit the control loop properly, the new workload
@@ -1563,7 +1550,7 @@ mod tests {
                 fixtures::WORKLOAD_IDS[0].to_string(),
                 workload.clone(),
                 state_checker_workload_state_sender.clone(),
-                Ok(new_mock_state_checker),
+                Ok(Box::new(new_mock_state_checker)),
             ),
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),
         ]);
@@ -1633,7 +1620,7 @@ mod tests {
                 fixtures::WORKLOAD_IDS[0].to_string(),
                 workload.clone(),
                 state_checker_workload_state_sender.clone(),
-                Ok(StubStateChecker::new()),
+                Ok(Box::new(StubStateChecker::new())),
             ),
         ]);
 
@@ -1887,7 +1874,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[1].to_string(), // new workload id after restart
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[1].to_string(), Ok(())),
@@ -1913,7 +1900,7 @@ mod tests {
             .unwrap();
 
         control_loop_state.workload_id = Some(fixtures::WORKLOAD_IDS[0].into());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         control_loop_state
             .retry_manager
@@ -1994,7 +1981,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    new_mock_state_checker,
+                    Box::new(new_mock_state_checker),
                 )),
             ),
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),
@@ -2020,7 +2007,7 @@ mod tests {
             .unwrap();
 
         control_loop_state.workload_id = Some(fixtures::WORKLOAD_IDS[0].into());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         control_loop_state
             .retry_manager
@@ -2205,7 +2192,7 @@ mod tests {
             expected_mount_point_mappings.clone(),
             Ok((
                 fixtures::WORKLOAD_IDS[0].to_string(),
-                StubStateChecker::new(),
+                Box::new(StubStateChecker::new()),
             )),
         )]);
 
@@ -2557,7 +2544,7 @@ mod tests {
             .return_const(());
 
         control_loop_state.workload_id = Some(OLD_WORKLOAD_ID.to_string());
-        control_loop_state.state_checker = Some(old_mock_state_checker);
+        control_loop_state.state_checker = Some(Box::new(old_mock_state_checker));
 
         control_loop_state
             .retry_manager
@@ -2611,7 +2598,7 @@ mod tests {
                 HashMap::default(),
                 Ok((
                     fixtures::WORKLOAD_IDS[0].to_string(),
-                    StubStateChecker::new(),
+                    Box::new(StubStateChecker::new()),
                 )),
             ),
             RuntimeCall::DeleteWorkload(fixtures::WORKLOAD_IDS[0].to_string(), Ok(())),


### PR DESCRIPTION
Remove generics from runtime interface.
This should show that it is possible to move runtimes to shard objects plugins.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
