### PR TITLE
Fix to long  container name

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -2231,12 +2231,12 @@ Needs:
 - utest
 
 ##### Podman create workload sets optionally container name
-`swdd~podman-create-workload-sets-optionally-container-name~2`
+`swdd~podman-create-workload-sets-optionally-container-name~3`
 
 Status: approved
 
 When the podman runtime connector is called without an existing workload id to create a new workload and the workload name is not set in the runtime configuration,
-the podman runtime connector shall set the workload execution name as the workload name.
+the podman runtime connector shall set the shortened workload execution instance name as the workload name.
 
 Tags:
 - PodmanRuntimeConnector
@@ -2773,11 +2773,11 @@ Needs:
 - utest
 
 ##### Containerd create workload sets optionally container name
-`swdd~containerd-create-workload-sets-optionally-container-name~1`
+`swdd~containerd-create-workload-sets-optionally-container-name~2`
 
 Status: approved
 
-When the containerd runtime connector is called without an existing workload ID to create a new workload and the workload name is not set in the runtime configuration, the containerd runtime connector shall set the workload execution name as the workload name.
+When the containerd runtime connector is called without an existing workload ID to create a new workload and the workload name is not set in the runtime configuration, the containerd runtime connector shall set the shortened workload execution instance name as the workload name.
 
 Tags:
 - ContainerdRuntimeConnector

--- a/agent/src/runtime_connectors/containerd/containerd_runtime.rs
+++ b/agent/src/runtime_connectors/containerd/containerd_runtime.rs
@@ -170,14 +170,13 @@ impl RuntimeConnector<ContainerdWorkloadId, GenericPollingStateChecker> for Cont
                     general_options: workload_cfg.general_options,
                     container_id: workload_id.id,
                 };
-                NerdctlCli::nerdctl_start(start_config, &workload_named.instance_name.to_string())
+                NerdctlCli::nerdctl_start(start_config, &workload_named.instance_name)
                     .await
             }
             None => {
                 NerdctlCli::nerdctl_run(
                     workload_cfg.into(),
-                    &workload_named.instance_name.to_string(),
-                    workload_named.instance_name.agent_name(),
+                    &workload_named.instance_name,
                     control_interface_path,
                     workload_file_path_mappings,
                 )

--- a/agent/src/runtime_connectors/containerd/nerdctl_cli.rs
+++ b/agent/src/runtime_connectors/containerd/nerdctl_cli.rs
@@ -222,7 +222,7 @@ impl NerdctlCli {
         // We store workload name as a label (and use them from there).
         // Therefore we do insist on container names in particular format.
         //
-        // [impl->swdd~containerd-create-workload-sets-optionally-container-name~1]
+        // [impl->swdd~containerd-create-workload-sets-optionally-container-name~2]
         args.append(&mut vec![
             "--name".into(),
             instance_name.short_workload_name(),
@@ -644,7 +644,7 @@ mod tests {
     }
 
     // [utest->swdd~containerd-create-workload-creates-labels~1]
-    // [utest->swdd~containerd-create-workload-sets-optionally-container-name~1]
+    // [utest->swdd~containerd-create-workload-sets-optionally-container-name~2]
     // [utest->swdd~containerd-create-workload-mounts-fifo-files~1]
     // [utest->swdd~containerd-create-mounts-workload-files~1]
     #[tokio::test]
@@ -715,7 +715,7 @@ mod tests {
         assert!(matches!(res, Err(msg) if msg == SAMPLE_ERROR_MESSAGE));
     }
 
-    // [utest->swdd~containerd-create-workload-sets-optionally-container-name~1]
+    // [utest->swdd~containerd-create-workload-sets-optionally-container-name~2]
     // [utest->swdd~containerd-create-workload-mounts-fifo-files~1]
     // [utest->swdd~containerd-create-mounts-workload-files~1]
     #[tokio::test]

--- a/agent/src/runtime_connectors/containerd/nerdctl_cli.rs
+++ b/agent/src/runtime_connectors/containerd/nerdctl_cli.rs
@@ -12,7 +12,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use ankaios_api::ank_base::ExecutionStateSpec;
+use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec};
 #[cfg(test)]
 use mockall::automock;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -201,14 +201,13 @@ impl NerdctlCli {
 
     pub async fn nerdctl_run(
         mut run_config: NerdctlRunConfig,
-        workload_name: &str,
-        agent: &str,
+        instance_name: &WorkloadInstanceNameSpec,
         control_interface_path: Option<PathBuf>,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
     ) -> Result<String, String> {
         log::debug!(
             "Creating the workload '{}' with image '{}'",
-            workload_name,
+            instance_name,
             run_config.image
         );
 
@@ -224,7 +223,10 @@ impl NerdctlCli {
         // Therefore we do insist on container names in particular format.
         //
         // [impl->swdd~containerd-create-workload-sets-optionally-container-name~1]
-        args.append(&mut vec!["--name".into(), workload_name.to_string()]);
+        args.append(&mut vec![
+            "--name".into(),
+            instance_name.short_workload_name(),
+        ]);
 
         args.append(&mut run_config.command_options);
 
@@ -256,8 +258,8 @@ impl NerdctlCli {
         }
 
         // [impl->swdd~containerd-create-workload-creates-labels~1]
-        args.push(format!("--label=name={workload_name}"));
-        args.push(format!("--label=agent={agent}"));
+        args.push(format!("--label=name={instance_name}"));
+        args.push(format!("--label=agent={}", instance_name.agent_name()));
         args.push(run_config.image);
 
         args.append(&mut run_config.command_args);
@@ -274,11 +276,11 @@ impl NerdctlCli {
 
     pub async fn nerdctl_start(
         start_config: NerdctlStartConfig,
-        workload_name: &str,
+        instance_name: &WorkloadInstanceNameSpec,
     ) -> Result<String, String> {
         log::debug!(
             "Starting the workload '{}' with id '{}'",
-            workload_name,
+            instance_name,
             start_config.container_id
         );
 
@@ -452,7 +454,7 @@ where
 mod tests {
     use super::{NERDCTL_CMD, NerdctlCli, NerdctlPsCache};
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
-    use ankaios_api::ank_base::ExecutionStateSpec;
+    use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec};
     use ankaios_api::test_utils::fixtures;
 
     use serde::Serialize;
@@ -650,6 +652,9 @@ mod tests {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
         super::CliCommand::reset();
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         super::CliCommand::new_expect(
             NERDCTL_CMD,
             super::CliCommand::default()
@@ -657,8 +662,8 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
-                    "--label=name=test_workload_name",
+                    "test_workload.abcdefg.test_agent",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                 ])
@@ -671,14 +676,8 @@ mod tests {
             image: "alpine:latest".into(),
             command_args: Vec::new(),
         };
-        let res = NerdctlCli::nerdctl_run(
-            run_config,
-            "test_workload_name",
-            "test_agent",
-            None,
-            Default::default(),
-        )
-        .await;
+        let res =
+            NerdctlCli::nerdctl_run(run_config, &instance_name, None, Default::default()).await;
         assert_eq!(res, Ok(fixtures::WORKLOAD_IDS[0].to_owned()));
     }
 
@@ -687,6 +686,9 @@ mod tests {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
         super::CliCommand::reset();
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         super::CliCommand::new_expect(
             NERDCTL_CMD,
             super::CliCommand::default()
@@ -694,8 +696,8 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
-                    "--label=name=test_workload_name",
+                    "test_workload.abcdefg.test_agent",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                 ])
@@ -708,14 +710,8 @@ mod tests {
             image: "alpine:latest".into(),
             command_args: Vec::new(),
         };
-        let res = NerdctlCli::nerdctl_run(
-            run_config,
-            "test_workload_name",
-            "test_agent",
-            None,
-            Default::default(),
-        )
-        .await;
+        let res =
+            NerdctlCli::nerdctl_run(run_config, &instance_name, None, Default::default()).await;
         assert!(matches!(res, Err(msg) if msg == SAMPLE_ERROR_MESSAGE));
     }
 
@@ -730,6 +726,9 @@ mod tests {
         const HOST_WORKLOAD_FILE_PATH: &str = "/some/path/on/host/file/system/file.conf";
         const MOUNT_POINT_PATH: &str = "/mount/point/in/container/test.conf";
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         super::CliCommand::new_expect(
             NERDCTL_CMD,
             super::CliCommand::default()
@@ -738,13 +737,13 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
+                    "test_workload.abcdefg.test_agent",
                     "--network=host",
                     "--name",
                     "myCont",
                     "--mount=type=bind,source=/test/path,destination=/run/ankaios/control_interface",
                     &format!("--mount=type=bind,source={HOST_WORKLOAD_FILE_PATH},destination={MOUNT_POINT_PATH},readonly=true"),
-                    "--label=name=test_workload_name",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                     "sh",
@@ -760,8 +759,7 @@ mod tests {
         };
         let res = NerdctlCli::nerdctl_run(
             run_config,
-            "test_workload_name",
-            "test_agent",
+            &instance_name,
             Some("/test/path".into()),
             HashMap::from([(HOST_WORKLOAD_FILE_PATH.into(), MOUNT_POINT_PATH.into())]),
         )
@@ -781,11 +779,13 @@ mod tests {
                 .exec_returns(Ok(fixtures::WORKLOAD_IDS[0].to_owned())),
         );
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
         let start_config = super::NerdctlStartConfig {
             general_options: vec!["--remote".into()],
             container_id: fixtures::WORKLOAD_IDS[0].into(),
         };
-        let res = NerdctlCli::nerdctl_start(start_config, "test_workload_name").await;
+        let res = NerdctlCli::nerdctl_start(start_config, &instance_name).await;
         assert_eq!(res, Ok(fixtures::WORKLOAD_IDS[0].to_owned()));
     }
 
@@ -804,11 +804,13 @@ mod tests {
                 .exec_returns(Err(SAMPLE_ERROR_MESSAGE.into())),
         );
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
         let start_config = super::NerdctlStartConfig {
             general_options: Vec::default(),
             container_id: ID.into(),
         };
-        let res = NerdctlCli::nerdctl_start(start_config, "test_workload_name").await;
+        let res = NerdctlCli::nerdctl_start(start_config, &instance_name).await;
         assert_eq!(res, Err(SAMPLE_ERROR_MESSAGE.to_string()));
     }
 
@@ -1359,7 +1361,10 @@ mod tests {
             NERDCTL_CMD,
             super::CliCommand::default()
                 .expect_args(&["stop", fixtures::WORKLOAD_IDS[0]])
-                .exec_returns(Err(format!("1 errors:\nno such container: {}", fixtures::WORKLOAD_IDS[0]))),
+                .exec_returns(Err(format!(
+                    "1 errors:\nno such container: {}",
+                    fixtures::WORKLOAD_IDS[0]
+                ))),
         );
 
         super::CliCommand::new_expect(
@@ -1420,7 +1425,10 @@ mod tests {
             NERDCTL_CMD,
             super::CliCommand::default()
                 .expect_args(&["rm", fixtures::WORKLOAD_IDS[0]])
-                .exec_returns(Err(format!("1 errors:\nno such container: {}", fixtures::WORKLOAD_IDS[0]))),
+                .exec_returns(Err(format!(
+                    "1 errors:\nno such container: {}",
+                    fixtures::WORKLOAD_IDS[0]
+                ))),
         );
 
         assert!(

--- a/agent/src/runtime_connectors/podman/podman_runtime.rs
+++ b/agent/src/runtime_connectors/podman/podman_runtime.rs
@@ -169,14 +169,13 @@ impl RuntimeConnector<PodmanWorkloadId, GenericPollingStateChecker> for PodmanRu
                     general_options: workload_cfg.general_options,
                     container_id: workload_id.id,
                 };
-                PodmanCli::podman_start(start_config, &workload_named.instance_name.to_string())
+                PodmanCli::podman_start(start_config, &workload_named.instance_name)
                     .await
             }
             None => {
                 PodmanCli::podman_run(
                     workload_cfg.into(),
-                    &workload_named.instance_name.to_string(),
-                    workload_named.instance_name.agent_name(),
+                    &workload_named.instance_name,
                     control_interface_path,
                     workload_file_path_mappings,
                 )

--- a/agent/src/runtime_connectors/podman_cli.rs
+++ b/agent/src/runtime_connectors/podman_cli.rs
@@ -14,7 +14,7 @@
 
 #[cfg_attr(test, mockall_double::double)]
 use crate::runtime_connectors::cli_command::CliCommand;
-use ankaios_api::ank_base::ExecutionStateSpec;
+use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec};
 
 use base64::Engine;
 #[cfg(test)]
@@ -305,14 +305,13 @@ impl PodmanCli {
 
     pub async fn podman_run(
         mut run_config: PodmanRunConfig,
-        workload_name: &str,
-        agent: &str,
+        instance_name: &WorkloadInstanceNameSpec,
         control_interface_path: Option<PathBuf>,
         workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
     ) -> Result<String, String> {
         log::debug!(
             "Creating the workload '{}' with image '{}'",
-            workload_name,
+            instance_name,
             run_config.image
         );
 
@@ -328,7 +327,7 @@ impl PodmanCli {
         // Therefore we do insist on container names in particular format.
         //
         // [impl->swdd~podman-create-workload-sets-optionally-container-name~2]
-        args.append(&mut vec!["--name".into(), workload_name.to_string()]);
+        args.append(&mut vec!["--name".into(), instance_name.short_workload_name()]);
 
         args.append(&mut run_config.command_options);
 
@@ -360,8 +359,8 @@ impl PodmanCli {
         }
 
         // [impl->swdd~podman-create-workload-creates-labels~2]
-        args.push(format!("--label=name={workload_name}"));
-        args.push(format!("--label=agent={agent}"));
+        args.push(format!("--label=name={instance_name}"));
+        args.push(format!("--label=agent={}", instance_name.agent_name()));
         args.push(run_config.image);
 
         args.append(&mut run_config.command_args);
@@ -378,11 +377,11 @@ impl PodmanCli {
 
     pub async fn podman_start(
         start_config: PodmanStartConfig,
-        workload_name: &str,
+        instance_name: &WorkloadInstanceNameSpec,
     ) -> Result<String, String> {
         log::debug!(
             "Starting the workload '{}' with id '{}'",
-            workload_name,
+            instance_name,
             start_config.container_id
         );
 
@@ -564,7 +563,7 @@ mod tests {
     use super::{CliCommand, ContainerState, PodmanCli, PodmanContainerInfo, PodmanPsCache};
     use crate::test_helper::MOCKALL_CONTEXT_SYNC;
 
-    use ankaios_api::ank_base::ExecutionStateSpec;
+    use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec};
     use common::test_utils::serialize_as_map;
 
     use serde::Serialize;
@@ -1026,6 +1025,9 @@ mod tests {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
         CliCommand::reset();
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         CliCommand::new_expect(
             "podman",
             CliCommand::default()
@@ -1033,8 +1035,8 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
-                    "--label=name=test_workload_name",
+                    "test_workload.abcdefg.test_agent",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                 ])
@@ -1049,8 +1051,7 @@ mod tests {
         };
         let res = PodmanCli::podman_run(
             run_config,
-            "test_workload_name",
-            "test_agent",
+            &instance_name,
             None,
             Default::default(),
         )
@@ -1063,6 +1064,9 @@ mod tests {
         let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
         CliCommand::reset();
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         CliCommand::new_expect(
             "podman",
             CliCommand::default()
@@ -1070,8 +1074,8 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
-                    "--label=name=test_workload_name",
+                    "test_workload.abcdefg.test_agent",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                 ])
@@ -1086,8 +1090,7 @@ mod tests {
         };
         let res = PodmanCli::podman_run(
             run_config,
-            "test_workload_name",
-            "test_agent",
+            &instance_name,
             None,
             Default::default(),
         )
@@ -1106,6 +1109,9 @@ mod tests {
         const HOST_WORKLOAD_FILE_PATH: &str = "/some/path/on/host/file/system/file.conf";
         const MOUNT_POINT_PATH: &str = "/mount/point/in/container/test.conf";
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
+
         CliCommand::new_expect(
             "podman",
             CliCommand::default()
@@ -1114,13 +1120,13 @@ mod tests {
                     "run",
                     "--detach",
                     "--name",
-                    "test_workload_name",
+                    "test_workload.abcdefg.test_agent",
                     "--network=host",
                     "--name",
                     "myCont",
                     "--mount=type=bind,source=/test/path,destination=/run/ankaios/control_interface",
                     &format!("--mount=type=bind,source={HOST_WORKLOAD_FILE_PATH},destination={MOUNT_POINT_PATH},readonly=true"),
-                    "--label=name=test_workload_name",
+                    "--label=name=test_workload.abcdefghijklmnop.test_agent",
                     "--label=agent=test_agent",
                     "alpine:latest",
                     "sh",
@@ -1136,8 +1142,7 @@ mod tests {
         };
         let res = PodmanCli::podman_run(
             run_config,
-            "test_workload_name",
-            "test_agent",
+            &instance_name,
             Some("/test/path".into()),
             HashMap::from([(HOST_WORKLOAD_FILE_PATH.into(), MOUNT_POINT_PATH.into())]),
         )
@@ -1160,11 +1165,13 @@ mod tests {
                 .exec_returns(Ok(ID.to_string())),
         );
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
         let start_config = super::PodmanStartConfig {
             general_options: vec!["--remote".into()],
             container_id: ID.into(),
         };
-        let res = PodmanCli::podman_start(start_config, "test_workload_name").await;
+        let res = PodmanCli::podman_start(start_config, &instance_name).await;
         assert_eq!(res, Ok(ID.to_string()));
     }
 
@@ -1183,11 +1190,13 @@ mod tests {
                 .exec_returns(Err(SAMPLE_ERROR_MESSAGE.into())),
         );
 
+        let instance_name =
+            WorkloadInstanceNameSpec::new("test_agent", "test_workload", "abcdefghijklmnop");
         let start_config = super::PodmanStartConfig {
             general_options: vec![],
             container_id: ID.into(),
         };
-        let res = PodmanCli::podman_start(start_config, "test_workload_name").await;
+        let res = PodmanCli::podman_start(start_config, &instance_name).await;
         assert_eq!(res, Err(SAMPLE_ERROR_MESSAGE.to_string()));
     }
 

--- a/agent/src/runtime_connectors/podman_cli.rs
+++ b/agent/src/runtime_connectors/podman_cli.rs
@@ -326,7 +326,7 @@ impl PodmanCli {
         // We store workload name as a label (and use them from there).
         // Therefore we do insist on container names in particular format.
         //
-        // [impl->swdd~podman-create-workload-sets-optionally-container-name~2]
+        // [impl->swdd~podman-create-workload-sets-optionally-container-name~3]
         args.append(&mut vec!["--name".into(), instance_name.short_workload_name()]);
 
         args.append(&mut run_config.command_options);
@@ -1017,7 +1017,7 @@ mod tests {
     }
 
     // [utest->swdd~podman-create-workload-creates-labels~2]
-    // [utest->swdd~podman-create-workload-sets-optionally-container-name~2]
+    // [utest->swdd~podman-create-workload-sets-optionally-container-name~3]
     // [utest->swdd~podman-create-workload-mounts-fifo-files~1]
     // [utest->swdd~podman-create-mounts-workload-files~1]
     #[tokio::test]
@@ -1098,7 +1098,7 @@ mod tests {
         assert!(matches!(res, Err(msg) if msg == SAMPLE_ERROR_MESSAGE));
     }
 
-    // [utest->swdd~podman-create-workload-sets-optionally-container-name~2]
+    // [utest->swdd~podman-create-workload-sets-optionally-container-name~3]
     // [utest->swdd~podman-create-workload-mounts-fifo-files~1]
     // [utest->swdd~podman-create-mounts-workload-files~1]
     #[tokio::test]

--- a/ankaios_api/doc/swdesign/README.md
+++ b/ankaios_api/doc/swdesign/README.md
@@ -348,6 +348,30 @@ Needs:
 - impl
 - utest
 
+#### Shortened workload execution instance name
+`swdd~api-short-workload-execution-instance-naming~1`
+
+Status: approved
+
+Ankaios shall provide functionality for retrieving the shortened Workload execution instance name of the workload in the following naming schema:
+
+    <Workload name>.<short runtime config hash>.<Agent name>
+
+Where the short runtime config hash is built from the first 7 characters of the full runtime config hash.
+
+Comment:
+The shortened Workload execution instance name is used as default container name for runtime connectors such as Podman and Containerd.
+
+Rationale:
+Using a shortened runtime config hash keeps the container name deterministic and reproducible while reducing its length.
+
+Tags:
+- SpecObjects
+
+Needs:
+- impl
+- utest
+
 #### Control Interface convention for workload names in logs access rules
 `swdd~api-access-rules-logs-workload-names-convention~1`
 

--- a/ankaios_api/src/ank_base/workload_instance_name.rs
+++ b/ankaios_api/src/ank_base/workload_instance_name.rs
@@ -79,6 +79,7 @@ impl WorkloadInstanceNameSpec {
         ))
     }
 
+    // [impl->swdd~api-short-workload-execution-instance-naming~1]
     pub fn short_workload_name(&self) -> String {
         let short_id = &self.id[..7.min(self.id.len())];
         format!(
@@ -199,12 +200,14 @@ mod tests {
         )
     }
 
+    // [utest->swdd~api-short-workload-execution-instance-naming~1]
     #[test]
     fn utest_short_workload_name_truncates_hash_to_7_chars() {
         let name = WorkloadInstanceNameSpec::new("my_agent", "my_workload", "abcdefghijklmnop");
         assert_eq!(name.short_workload_name(), "my_workload.abcdefg.my_agent");
     }
 
+    // [utest->swdd~api-short-workload-execution-instance-naming~1]
     #[test]
     fn utest_short_workload_name_hash_shorter_than_7_chars() {
         let name = WorkloadInstanceNameSpec::new("my_agent", "my_workload", "abc");

--- a/ankaios_api/src/ank_base/workload_instance_name.rs
+++ b/ankaios_api/src/ank_base/workload_instance_name.rs
@@ -79,6 +79,18 @@ impl WorkloadInstanceNameSpec {
         ))
     }
 
+    pub fn short_workload_name(&self) -> String {
+        let short_id = &self.id[..7.min(self.id.len())];
+        format!(
+            "{}{}{}{}{}",
+            self.workload_name,
+            INSTANCE_NAME_SEPARATOR,
+            short_id,
+            INSTANCE_NAME_SEPARATOR,
+            self.agent_name
+        )
+    }
+
     pub fn builder() -> WorkloadInstanceNameBuilder {
         WorkloadInstanceNameBuilder::default()
     }
@@ -185,5 +197,17 @@ mod tests {
             name.to_string(),
             format!("{workload_name}.{expected_hash}.{agent_name}")
         )
+    }
+
+    #[test]
+    fn utest_short_workload_name_truncates_hash_to_7_chars() {
+        let name = WorkloadInstanceNameSpec::new("my_agent", "my_workload", "abcdefghijklmnop");
+        assert_eq!(name.short_workload_name(), "my_workload.abcdefg.my_agent");
+    }
+
+    #[test]
+    fn utest_short_workload_name_hash_shorter_than_7_chars() {
+        let name = WorkloadInstanceNameSpec::new("my_agent", "my_workload", "abc");
+        assert_eq!(name.short_workload_name(), "my_workload.abc.my_agent");
     }
 }

--- a/tests/stests/workloads/create_workload_containerd.robot
+++ b/tests/stests/workloads/create_workload_containerd.robot
@@ -46,7 +46,7 @@ Test Ankaios containerd create workloads
     [Teardown]    Clean up Ankaios
 
 # [stest->swdd~agent-supports-containerd~1]
-# [stest->swdd~containerd-create-workload-sets-optionally-container-name~1]
+# [stest->swdd~containerd-create-workload-sets-optionally-container-name~2]
 Test Ankaios containerd create a container with custom name
     [Setup]    Run Keywords    Setup Ankaios
 

--- a/tests/stests/workloads/create_workload_podman.robot
+++ b/tests/stests/workloads/create_workload_podman.robot
@@ -48,7 +48,7 @@ Test Ankaios Podman create workloads
     [Teardown]    Clean up Ankaios
 
 # [stest->swdd~agent-supports-podman~2]
-# [stest->swdd~podman-create-workload-sets-optionally-container-name~2]
+# [stest->swdd~podman-create-workload-sets-optionally-container-name~3]
 Test Ankaios Podman create a container with custom name
     [Setup]    Run Keywords    Setup Ankaios
 


### PR DESCRIPTION
# Fix container names for old versions of nerdctl

For older versions of nerdctl, the container name can not exceed 76 characters. This leads to only extream short workload and agents names being allowed. To fix this, the PR shortens the hash part of the container name. The hash used internally in the WorkloadIntanceId is not shortend.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
