### PR TITLE
Add systemd runtime support for managing existing services

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -52,7 +52,7 @@ use common::{
 
 use runtime_connectors::{
     GenericRuntimeFacade, RuntimeFacade, SUPPORTED_RUNTIMES, containerd::ContainerdRuntime,
-    podman::PodmanRuntime, podman_kube::PodmanKubeRuntime,
+    podman::PodmanRuntime, podman_kube::PodmanKubeRuntime, systemd::SystemdRuntime,
 };
 
 use grpc::client::GRPCCommunicationsClient;
@@ -163,7 +163,8 @@ async fn main() {
         Box::new(PodmanKubeRuntime::default()),
         // [impl->swdd~agent-supports-containerd~1]
         Box::new(ContainerdRuntime {}),
-    ] as [Box<dyn OwnableRuntime>; 3])
+        Box::new(SystemdRuntime {}),
+    ] as [Box<dyn OwnableRuntime>; 4])
         .into_iter()
         .map(|r| {
             (

--- a/agent/src/runtime_connectors/mod.rs
+++ b/agent/src/runtime_connectors/mod.rs
@@ -22,6 +22,8 @@ pub(crate) mod podman_kube;
 
 pub(crate) mod containerd;
 
+pub(crate) mod systemd;
+
 pub(crate) mod unsupported;
 
 mod runtime_connector;
@@ -50,4 +52,9 @@ pub use state_checker::MockRuntimeStateGetter;
 mod log_fetching;
 pub use log_fetching::{generic_log_fetcher, log_channel, log_fetcher, log_fetching_runner};
 
-pub const SUPPORTED_RUNTIMES: &[&str] = &[podman::NAME, containerd::NAME, podman_kube::NAME];
+pub const SUPPORTED_RUNTIMES: &[&str] = &[
+    podman::NAME,
+    containerd::NAME,
+    podman_kube::NAME,
+    systemd::NAME,
+];

--- a/agent/src/runtime_connectors/systemd/mod.rs
+++ b/agent/src/runtime_connectors/systemd/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod systemd_log_fetcher;
+mod systemd_cli;
+mod systemd_runtime;
+mod systemd_runtime_config;
+pub use systemd_runtime::{SystemdRuntime, SYSTEMD_RUNTIME_NAME as NAME};

--- a/agent/src/runtime_connectors/systemd/mod.rs
+++ b/agent/src/runtime_connectors/systemd/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Red Hat LLC
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub(crate) mod systemd_log_fetcher;
+mod systemd_cli;
+mod systemd_runtime;
+mod systemd_runtime_config;
+pub use systemd_runtime::{SystemdRuntime, SYSTEMD_RUNTIME_NAME as NAME};

--- a/agent/src/runtime_connectors/systemd/systemd_cli.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_cli.rs
@@ -1,0 +1,209 @@
+// Copyright (c) 2024 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg_attr(test, mockall_double::double)]
+use crate::runtime_connectors::cli_command::CliCommand;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemdUnitState {
+    pub active_state: String,
+    pub sub_state: String,
+    pub exit_code: Option<i32>,
+}
+
+pub struct SystemdCli {}
+
+#[cfg_attr(test, automock)]
+#[allow(dead_code)]
+impl SystemdCli {
+    const SYSTEMCTL_CMD: &str = "systemctl";
+    /// Start a systemd unit
+    pub async fn start_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Starting systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["start", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Stop a systemd unit
+    pub async fn stop_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Stopping systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["stop", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Restart a systemd unit
+    pub async fn restart_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Restarting systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["restart", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Get the state of a systemd unit
+    pub async fn get_unit_state(unit_name: &str) -> Result<SystemdUnitState, String> {
+        log::trace!("Getting state for systemd unit: {}", unit_name);
+
+        let output = CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&[
+                "show",
+                unit_name,
+                "--property=ActiveState,SubState,ExecMainStatus",
+            ])
+            .exec()
+            .await?;
+
+        Self::parse_unit_state(&output)
+    }
+
+    /// Get the uptime of a systemd unit in seconds
+    /// Returns None if the service is not active or timestamp cannot be parsed
+    pub async fn get_unit_uptime_seconds(unit_name: &str) -> Result<Option<u64>, String> {
+        log::trace!("Getting uptime for systemd unit: {}", unit_name);
+
+        let systemctl_output = CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&[
+                "show",
+                unit_name,
+                "--property=ActiveEnterTimestampMonotonic,ActiveState",
+            ])
+            .exec()
+            .await?;
+
+        // Parse systemctl output
+        let mut active_enter_monotonic: Option<u64> = None;
+        let mut is_active = false;
+
+        for line in systemctl_output.lines() {
+            let line = line.trim();
+            if let Some(value) = line.strip_prefix("ActiveEnterTimestampMonotonic=") {
+                // Monotonic timestamp is in microseconds
+                active_enter_monotonic = value.parse().ok();
+            } else if let Some(value) = line.strip_prefix("ActiveState=") {
+                is_active = value == "active";
+            }
+        }
+
+        if !is_active || active_enter_monotonic == Some(0) {
+            return Ok(None);
+        }
+
+        if let Some(enter_us) = active_enter_monotonic {
+            let uptime_output = tokio::fs::read_to_string("/proc/uptime")
+                .await
+                .map_err(|e| format!("Failed to read /proc/uptime: {}", e))?;
+
+            // /proc/uptime gives system uptime in seconds (first field)
+            let uptime_str = uptime_output.split_whitespace().next()
+                .ok_or_else(|| "Failed to parse /proc/uptime".to_string())?;
+            let system_uptime_secs: f64 = uptime_str.parse()
+                .map_err(|_| "Invalid uptime format".to_string())?;
+            let system_uptime_us = (system_uptime_secs * 1_000_000.0) as u64;
+
+            // Calculate service uptime
+            let service_uptime_us = system_uptime_us.saturating_sub(enter_us);
+            let service_uptime_secs = service_uptime_us / 1_000_000;
+
+            Ok(Some(service_uptime_secs))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Parse systemctl show output into SystemdUnitState
+    fn parse_unit_state(output: &str) -> Result<SystemdUnitState, String> {
+        let mut active_state = None;
+        let mut sub_state = None;
+        let mut exit_code = None;
+
+        for line in output.lines() {
+            let line = line.trim();
+            if let Some(value) = line.strip_prefix("ActiveState=") {
+                active_state = Some(value.to_string());
+            } else if let Some(value) = line.strip_prefix("SubState=") {
+                sub_state = Some(value.to_string());
+            } else if let Some(value) = line.strip_prefix("ExecMainStatus=") {
+                exit_code = value.parse().ok();
+            }
+        }
+
+        Ok(SystemdUnitState {
+            active_state: active_state.ok_or_else(|| "Missing ActiveState".to_string())?,
+            sub_state: sub_state.ok_or_else(|| "Missing SubState".to_string())?,
+            exit_code,
+        })
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_unit_state_running() {
+        let output = "ActiveState=active\nSubState=running\nExecMainStatus=0\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "active");
+        assert_eq!(state.sub_state, "running");
+        assert_eq!(state.exit_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_unit_state_failed() {
+        let output = "ActiveState=failed\nSubState=failed\nExecMainStatus=1\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "failed");
+        assert_eq!(state.sub_state, "failed");
+        assert_eq!(state.exit_code, Some(1));
+    }
+
+    #[test]
+    fn test_parse_unit_state_inactive() {
+        let output = "ActiveState=inactive\nSubState=dead\nExecMainStatus=0\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "inactive");
+        assert_eq!(state.sub_state, "dead");
+        assert_eq!(state.exit_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_unit_state_missing_field() {
+        let output = "ActiveState=active\n";
+        let result = SystemdCli::parse_unit_state(output);
+
+        assert!(result.is_err());
+    }
+
+}

--- a/agent/src/runtime_connectors/systemd/systemd_cli.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_cli.rs
@@ -31,33 +31,43 @@ pub struct SystemdCli {}
 #[allow(dead_code)]
 impl SystemdCli {
     const SYSTEMCTL_CMD: &str = "systemctl";
+    /// Global systemctl options applied to every invocation.
+    /// `--no-ask-password` disables interactive authentication prompts so that
+    /// privileged operations fail with an error instead of blocking on a prompt.
+    /// `--no-pager` prevents systemctl from piping output through a pager.
+    const SYSTEMCTL_GLOBAL_ARGS: &[&str] = &["--no-ask-password", "--no-pager"];
+
+    /// Add explicit lifetime as automock prevents the compiler from inferring it.
+    async fn exec_systemctl<'a>(args: &'a[&'a str]) -> Result<String, String> {
+        let full_args: Vec<&str> = Self::SYSTEMCTL_GLOBAL_ARGS
+            .iter()
+            .copied()
+            .chain(args.iter().copied())
+            .collect();
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&full_args)
+            .exec()
+            .await
+    }
+
     /// Start a systemd unit
     pub async fn start_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Starting systemd unit: {}", unit_name);
-        CliCommand::new(Self::SYSTEMCTL_CMD)
-            .args(&["start", unit_name])
-            .exec()
-            .await?;
+        Self::exec_systemctl(&["start", unit_name]).await?;
         Ok(())
     }
 
     /// Stop a systemd unit
     pub async fn stop_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Stopping systemd unit: {}", unit_name);
-        CliCommand::new(Self::SYSTEMCTL_CMD)
-            .args(&["stop", unit_name])
-            .exec()
-            .await?;
+        Self::exec_systemctl(&["stop", unit_name]).await?;
         Ok(())
     }
 
     /// Restart a systemd unit
     pub async fn restart_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Restarting systemd unit: {}", unit_name);
-        CliCommand::new(Self::SYSTEMCTL_CMD)
-            .args(&["restart", unit_name])
-            .exec()
-            .await?;
+        Self::exec_systemctl(&["restart", unit_name]).await?;
         Ok(())
     }
 
@@ -65,14 +75,12 @@ impl SystemdCli {
     pub async fn get_unit_state(unit_name: &str) -> Result<SystemdUnitState, String> {
         log::trace!("Getting state for systemd unit: {}", unit_name);
 
-        let output = CliCommand::new(Self::SYSTEMCTL_CMD)
-            .args(&[
-                "show",
-                unit_name,
-                "--property=ActiveState,SubState,ExecMainStatus",
-            ])
-            .exec()
-            .await?;
+        let output = Self::exec_systemctl(&[
+            "show",
+            unit_name,
+            "--property=ActiveState,SubState,ExecMainStatus",
+        ])
+        .await?;
 
         Self::parse_unit_state(&output)
     }
@@ -82,14 +90,12 @@ impl SystemdCli {
     pub async fn get_unit_uptime_seconds(unit_name: &str) -> Result<Option<u64>, String> {
         log::trace!("Getting uptime for systemd unit: {}", unit_name);
 
-        let systemctl_output = CliCommand::new(Self::SYSTEMCTL_CMD)
-            .args(&[
-                "show",
-                unit_name,
-                "--property=ActiveEnterTimestampMonotonic,ActiveState",
-            ])
-            .exec()
-            .await?;
+        let systemctl_output = Self::exec_systemctl(&[
+            "show",
+            unit_name,
+            "--property=ActiveEnterTimestampMonotonic,ActiveState",
+        ])
+        .await?;
 
         // Parse systemctl output
         let mut active_enter_monotonic: Option<u64> = None;
@@ -115,9 +121,12 @@ impl SystemdCli {
                 .map_err(|e| format!("Failed to read /proc/uptime: {}", e))?;
 
             // /proc/uptime gives system uptime in seconds (first field)
-            let uptime_str = uptime_output.split_whitespace().next()
+            let uptime_str = uptime_output
+                .split_whitespace()
+                .next()
                 .ok_or_else(|| "Failed to parse /proc/uptime".to_string())?;
-            let system_uptime_secs: f64 = uptime_str.parse()
+            let system_uptime_secs: f64 = uptime_str
+                .parse()
                 .map_err(|_| "Invalid uptime format".to_string())?;
             let system_uptime_us = (system_uptime_secs * 1_000_000.0) as u64;
 
@@ -205,5 +214,4 @@ mod tests {
 
         assert!(result.is_err());
     }
-
 }

--- a/agent/src/runtime_connectors/systemd/systemd_cli.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_cli.rs
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 Red Hat LLC
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg_attr(test, mockall_double::double)]
+use crate::runtime_connectors::cli_command::CliCommand;
+
+#[cfg(test)]
+use mockall::automock;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SystemdUnitState {
+    pub active_state: String,
+    pub sub_state: String,
+    pub exit_code: Option<i32>,
+}
+
+pub struct SystemdCli {}
+
+#[cfg_attr(test, automock)]
+#[allow(dead_code)]
+impl SystemdCli {
+    const SYSTEMCTL_CMD: &str = "systemctl";
+    /// Start a systemd unit
+    pub async fn start_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Starting systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["start", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Stop a systemd unit
+    pub async fn stop_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Stopping systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["stop", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Restart a systemd unit
+    pub async fn restart_unit(unit_name: &str) -> Result<(), String> {
+        log::debug!("Restarting systemd unit: {}", unit_name);
+        CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&["restart", unit_name])
+            .exec()
+            .await?;
+        Ok(())
+    }
+
+    /// Get the state of a systemd unit
+    pub async fn get_unit_state(unit_name: &str) -> Result<SystemdUnitState, String> {
+        log::trace!("Getting state for systemd unit: {}", unit_name);
+
+        let output = CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&[
+                "show",
+                unit_name,
+                "--property=ActiveState,SubState,ExecMainStatus",
+            ])
+            .exec()
+            .await?;
+
+        Self::parse_unit_state(&output)
+    }
+
+    /// Get the uptime of a systemd unit in seconds
+    /// Returns None if the service is not active or timestamp cannot be parsed
+    pub async fn get_unit_uptime_seconds(unit_name: &str) -> Result<Option<u64>, String> {
+        log::trace!("Getting uptime for systemd unit: {}", unit_name);
+
+        let systemctl_output = CliCommand::new(Self::SYSTEMCTL_CMD)
+            .args(&[
+                "show",
+                unit_name,
+                "--property=ActiveEnterTimestampMonotonic,ActiveState",
+            ])
+            .exec()
+            .await?;
+
+        // Parse systemctl output
+        let mut active_enter_monotonic: Option<u64> = None;
+        let mut is_active = false;
+
+        for line in systemctl_output.lines() {
+            let line = line.trim();
+            if let Some(value) = line.strip_prefix("ActiveEnterTimestampMonotonic=") {
+                // Monotonic timestamp is in microseconds
+                active_enter_monotonic = value.parse().ok();
+            } else if let Some(value) = line.strip_prefix("ActiveState=") {
+                is_active = value == "active";
+            }
+        }
+
+        if !is_active || active_enter_monotonic == Some(0) {
+            return Ok(None);
+        }
+
+        if let Some(enter_us) = active_enter_monotonic {
+            let uptime_output = tokio::fs::read_to_string("/proc/uptime")
+                .await
+                .map_err(|e| format!("Failed to read /proc/uptime: {}", e))?;
+
+            // /proc/uptime gives system uptime in seconds (first field)
+            let uptime_str = uptime_output.split_whitespace().next()
+                .ok_or_else(|| "Failed to parse /proc/uptime".to_string())?;
+            let system_uptime_secs: f64 = uptime_str.parse()
+                .map_err(|_| "Invalid uptime format".to_string())?;
+            let system_uptime_us = (system_uptime_secs * 1_000_000.0) as u64;
+
+            // Calculate service uptime
+            let service_uptime_us = system_uptime_us.saturating_sub(enter_us);
+            let service_uptime_secs = service_uptime_us / 1_000_000;
+
+            Ok(Some(service_uptime_secs))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Parse systemctl show output into SystemdUnitState
+    fn parse_unit_state(output: &str) -> Result<SystemdUnitState, String> {
+        let mut active_state = None;
+        let mut sub_state = None;
+        let mut exit_code = None;
+
+        for line in output.lines() {
+            let line = line.trim();
+            if let Some(value) = line.strip_prefix("ActiveState=") {
+                active_state = Some(value.to_string());
+            } else if let Some(value) = line.strip_prefix("SubState=") {
+                sub_state = Some(value.to_string());
+            } else if let Some(value) = line.strip_prefix("ExecMainStatus=") {
+                exit_code = value.parse().ok();
+            }
+        }
+
+        Ok(SystemdUnitState {
+            active_state: active_state.ok_or_else(|| "Missing ActiveState".to_string())?,
+            sub_state: sub_state.ok_or_else(|| "Missing SubState".to_string())?,
+            exit_code,
+        })
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_unit_state_running() {
+        let output = "ActiveState=active\nSubState=running\nExecMainStatus=0\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "active");
+        assert_eq!(state.sub_state, "running");
+        assert_eq!(state.exit_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_unit_state_failed() {
+        let output = "ActiveState=failed\nSubState=failed\nExecMainStatus=1\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "failed");
+        assert_eq!(state.sub_state, "failed");
+        assert_eq!(state.exit_code, Some(1));
+    }
+
+    #[test]
+    fn test_parse_unit_state_inactive() {
+        let output = "ActiveState=inactive\nSubState=dead\nExecMainStatus=0\n";
+        let state = SystemdCli::parse_unit_state(output).unwrap();
+
+        assert_eq!(state.active_state, "inactive");
+        assert_eq!(state.sub_state, "dead");
+        assert_eq!(state.exit_code, Some(0));
+    }
+
+    #[test]
+    fn test_parse_unit_state_missing_field() {
+        let output = "ActiveState=active\n";
+        let result = SystemdCli::parse_unit_state(output);
+
+        assert!(result.is_err());
+    }
+
+}

--- a/agent/src/runtime_connectors/systemd/systemd_cli.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_cli.rs
@@ -38,7 +38,7 @@ impl SystemdCli {
     const SYSTEMCTL_GLOBAL_ARGS: &[&str] = &["--no-ask-password", "--no-pager"];
 
     /// Add explicit lifetime as automock prevents the compiler from inferring it.
-    async fn exec_systemctl<'a>(args: &'a[&'a str]) -> Result<String, String> {
+    async fn exec_systemctl<'a>(args: &'a [&'a str]) -> Result<String, String> {
         let full_args: Vec<&str> = Self::SYSTEMCTL_GLOBAL_ARGS
             .iter()
             .copied()

--- a/agent/src/runtime_connectors/systemd/systemd_cli.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_cli.rs
@@ -50,28 +50,24 @@ impl SystemdCli {
             .await
     }
 
-    /// Start a systemd unit
     pub async fn start_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Starting systemd unit: {}", unit_name);
         Self::exec_systemctl(&["start", unit_name]).await?;
         Ok(())
     }
 
-    /// Stop a systemd unit
     pub async fn stop_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Stopping systemd unit: {}", unit_name);
         Self::exec_systemctl(&["stop", unit_name]).await?;
         Ok(())
     }
 
-    /// Restart a systemd unit
     pub async fn restart_unit(unit_name: &str) -> Result<(), String> {
         log::debug!("Restarting systemd unit: {}", unit_name);
         Self::exec_systemctl(&["restart", unit_name]).await?;
         Ok(())
     }
 
-    /// Get the state of a systemd unit
     pub async fn get_unit_state(unit_name: &str) -> Result<SystemdUnitState, String> {
         log::trace!("Getting state for systemd unit: {}", unit_name);
 
@@ -85,8 +81,6 @@ impl SystemdCli {
         Self::parse_unit_state(&output)
     }
 
-    /// Get the uptime of a systemd unit in seconds
-    /// Returns None if the service is not active or timestamp cannot be parsed
     pub async fn get_unit_uptime_seconds(unit_name: &str) -> Result<Option<u64>, String> {
         log::trace!("Getting uptime for systemd unit: {}", unit_name);
 
@@ -97,14 +91,12 @@ impl SystemdCli {
         ])
         .await?;
 
-        // Parse systemctl output
         let mut active_enter_monotonic: Option<u64> = None;
         let mut is_active = false;
 
         for line in systemctl_output.lines() {
             let line = line.trim();
             if let Some(value) = line.strip_prefix("ActiveEnterTimestampMonotonic=") {
-                // Monotonic timestamp is in microseconds
                 active_enter_monotonic = value.parse().ok();
             } else if let Some(value) = line.strip_prefix("ActiveState=") {
                 is_active = value == "active";
@@ -115,32 +107,29 @@ impl SystemdCli {
             return Ok(None);
         }
 
-        if let Some(enter_us) = active_enter_monotonic {
-            let uptime_output = tokio::fs::read_to_string("/proc/uptime")
-                .await
-                .map_err(|e| format!("Failed to read /proc/uptime: {}", e))?;
-
-            // /proc/uptime gives system uptime in seconds (first field)
-            let uptime_str = uptime_output
-                .split_whitespace()
-                .next()
-                .ok_or_else(|| "Failed to parse /proc/uptime".to_string())?;
-            let system_uptime_secs: f64 = uptime_str
-                .parse()
-                .map_err(|_| "Invalid uptime format".to_string())?;
-            let system_uptime_us = (system_uptime_secs * 1_000_000.0) as u64;
-
-            // Calculate service uptime
-            let service_uptime_us = system_uptime_us.saturating_sub(enter_us);
-            let service_uptime_secs = service_uptime_us / 1_000_000;
-
+        if let Some(enter_monotonic_us) = active_enter_monotonic {
+            let system_uptime_secs = Self::get_system_uptime_secs().await?;
+            let enter_secs = enter_monotonic_us / 1_000_000;
+            let service_uptime_secs = system_uptime_secs.saturating_sub(enter_secs);
             Ok(Some(service_uptime_secs))
         } else {
             Ok(None)
         }
     }
 
-    /// Parse systemctl show output into SystemdUnitState
+    async fn get_system_uptime_secs() -> Result<u64, String> {
+        let content = tokio::fs::read_to_string("/proc/uptime")
+            .await
+            .map_err(|e| format!("Failed to read /proc/uptime: {}", e))?;
+        let secs: f64 = content
+            .split_whitespace()
+            .next()
+            .ok_or_else(|| "Failed to parse /proc/uptime".to_string())?
+            .parse()
+            .map_err(|_| "Invalid uptime format".to_string())?;
+        Ok(secs as u64)
+    }
+
     fn parse_unit_state(output: &str) -> Result<SystemdUnitState, String> {
         let mut active_state = None;
         let mut sub_state = None;

--- a/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
@@ -1,0 +1,336 @@
+// Copyright (c) 2024 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::log_fetcher::{GetOutputStreams, StreamTrait};
+use crate::runtime_connectors::{runtime_connector::LogRequestOptions, RuntimeError, RuntimeWorkloadId};
+
+use std::process::Stdio;
+#[cfg(test)]
+use tests::{MockChild as Child, MockCommand as Command};
+#[cfg(not(test))]
+use tokio::process::{Child, Command};
+
+#[derive(Debug)]
+pub struct SystemdLogFetcher {
+    child: Option<Child>,
+    #[cfg(test)]
+    pub stdout: Option<Box<dyn StreamTrait>>,
+    #[cfg(test)]
+    pub stderr: Option<Box<dyn StreamTrait>>,
+}
+
+impl SystemdLogFetcher {
+    pub fn new(
+        workload_id: &RuntimeWorkloadId,
+        options: &LogRequestOptions,
+    ) -> Result<Self, RuntimeError> {
+        let unit_name = workload_id.as_ref();
+        let mut args = Vec::with_capacity(9);
+        args.push("-u");
+        args.push(unit_name);
+
+        if options.follow {
+            args.push("-f");
+        }
+        if let Some(since) = &options.since {
+            args.push("--since");
+            args.push(since);
+        }
+        if let Some(until) = &options.until {
+            args.push("--until");
+            args.push(until);
+        }
+        let tail_string;
+        if let Some(tail) = options.tail {
+            tail_string = tail.to_string();
+            args.push("-n");
+            args.push(&tail_string);
+        }
+
+        let cmd = Command::new("journalctl")
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+
+        let cmd = match cmd {
+            Ok(cmd) => Some(cmd),
+            Err(err) => {
+                log::warn!("Cannot collect logs for '{}': '{}'", workload_id, err);
+                return Err(RuntimeError::CollectLog(format!(
+                    "Failed to spawn journalctl: {}",
+                    err
+                )));
+            }
+        };
+
+        #[cfg(not(test))]
+        return Ok(Self { child: cmd });
+        #[cfg(test)]
+        Ok(Self {
+            child: cmd,
+            stdout: None,
+            stderr: None,
+        })
+    }
+
+}
+
+impl Drop for SystemdLogFetcher {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.child
+            && let Err(err) = child.start_kill()
+        {
+            log::warn!("Could not stop log collection: '{}'", err);
+        }
+    }
+}
+
+impl GetOutputStreams for SystemdLogFetcher {
+    type OutputStream = Box<dyn StreamTrait>;
+    type ErrStream = Box<dyn StreamTrait>;
+
+    fn get_output_streams(&mut self) -> (Option<Self::OutputStream>, Option<Self::ErrStream>) {
+        #[cfg(not(test))]
+        {
+            if let Some(child) = &mut self.child {
+                return (
+                    child
+                        .stdout
+                        .take()
+                        .map(|stdout| Box::new(stdout) as Box<dyn StreamTrait>),
+                    child
+                        .stderr
+                        .take()
+                        .map(|stderr| Box::new(stderr) as Box<dyn StreamTrait>),
+                );
+            }
+            (None, None)
+        }
+        #[cfg(test)]
+        return (self.stdout.take(), self.stderr.take());
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::SystemdLogFetcher;
+    use crate::runtime_connectors::{
+        log_fetcher::GetOutputStreams, LogRequestOptions, RuntimeWorkloadId,
+    };
+
+    use std::{process::Stdio, sync::Mutex};
+    use tokio::io::Empty;
+
+    static CAN_SPAWN: Mutex<bool> = Mutex::new(true);
+    static CAN_KILL: Mutex<bool> = Mutex::new(true);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static WAS_KILLED: Mutex<bool> = Mutex::new(false);
+
+    #[derive(Debug)]
+    pub struct MockChild {
+        pub _stdout: Option<Empty>,
+        cmd: String,
+        args: Vec<String>,
+        stdout_option: Option<Stdio>,
+        stderr_option: Option<Stdio>,
+    }
+    impl MockChild {
+        pub(crate) fn start_kill(&self) -> Result<(), String> {
+            *WAS_KILLED.lock().unwrap() = true;
+            if *CAN_KILL.lock().unwrap() {
+                Ok(())
+            } else {
+                Err("MockChild: Could not kill child".to_string())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MockCommand {
+        cmd: String,
+        args: Vec<String>,
+        stdout: Option<Stdio>,
+        stderr: Option<Stdio>,
+    }
+
+    impl MockCommand {
+        pub fn new(cmd: &str) -> Self {
+            Self {
+                cmd: cmd.to_owned(),
+                ..Default::default()
+            }
+        }
+
+        pub(crate) fn args(&mut self, args: Vec<&str>) -> &mut Self {
+            self.args = args.into_iter().map(ToOwned::to_owned).collect();
+            self
+        }
+
+        pub(crate) fn stdout(&mut self, piped: Stdio) -> &mut Self {
+            self.stdout = Some(piped);
+            self
+        }
+
+        pub(crate) fn stderr(&mut self, piped: Stdio) -> &mut Self {
+            self.stderr = Some(piped);
+            self
+        }
+
+        pub(crate) fn spawn(&mut self) -> Result<MockChild, String> {
+            if *CAN_SPAWN.lock().unwrap() {
+                Ok(MockChild {
+                    _stdout: None,
+                    cmd: self.cmd.clone(),
+                    args: self.args.clone(),
+                    stdout_option: self.stdout.take(),
+                    stderr_option: self.stderr.take(),
+                })
+            } else {
+                Err("MockCommand: Could not spawn child".to_string())
+            }
+        }
+    }
+
+    #[test]
+    fn utest_new_with_no_parameters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = true;
+        let mut log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: false,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            &log_fetcher.child,
+            Some(MockChild {
+                _stdout: _,
+                cmd,
+                args,
+                stdout_option: Some(_),
+                stderr_option: Some(_)
+
+            }) if cmd == "journalctl" && *args == vec!["-u".to_string(), "test.service".to_string()]
+        ));
+        let (child_stdout, child_stderr) = log_fetcher.get_output_streams();
+        assert!(child_stdout.is_none());
+        assert!(child_stderr.is_none());
+    }
+
+    #[test]
+    fn utest_new_with_with_parameters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = true;
+        let mut log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("nginx.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: Some(10),
+                since: Some("since".to_string()),
+                until: Some("until".to_string()),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            &log_fetcher.child,
+            Some(MockChild {
+                _stdout: _,
+                cmd,
+                args,
+                stdout_option: Some(_),
+                stderr_option: Some(_),
+            }) if cmd == "journalctl" && *args == vec!["-u".to_string(), "nginx.service".to_string(), "-f".to_string(), "--since".to_string(), "since".to_string(), "--until".to_string(), "until".to_string(), "-n".to_string(), "10".to_string()]
+        ));
+        let (child_stdout, child_stderr) = log_fetcher.get_output_streams();
+        assert!(child_stdout.is_none());
+        assert!(child_stderr.is_none());
+    }
+
+    #[test]
+    fn utest_new_spawn_fails() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = false;
+        let result = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: false,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn utest_dropped_child_kills_cmd() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *WAS_KILLED.lock().unwrap() = false;
+        *CAN_SPAWN.lock().unwrap() = true;
+
+        *CAN_KILL.lock().unwrap() = true;
+        let log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(!*WAS_KILLED.lock().unwrap());
+        drop(log_fetcher);
+        assert!(*WAS_KILLED.lock().unwrap());
+    }
+
+    #[test]
+    fn utest_dropped_child_handles_kills_error() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *WAS_KILLED.lock().unwrap() = false;
+        *CAN_SPAWN.lock().unwrap() = true;
+        *CAN_KILL.lock().unwrap() = false;
+        let log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(!*WAS_KILLED.lock().unwrap());
+        drop(log_fetcher);
+        assert!(*WAS_KILLED.lock().unwrap());
+    }
+}

--- a/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 Red Hat LLC
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::log_fetcher::{GetOutputStreams, StreamTrait};
+use crate::runtime_connectors::{runtime_connector::LogRequestOptions, RuntimeError, RuntimeWorkloadId};
+
+use std::process::Stdio;
+#[cfg(test)]
+use tests::{MockChild as Child, MockCommand as Command};
+#[cfg(not(test))]
+use tokio::process::{Child, Command};
+
+#[derive(Debug)]
+pub struct SystemdLogFetcher {
+    child: Option<Child>,
+    #[cfg(test)]
+    pub stdout: Option<Box<dyn StreamTrait>>,
+    #[cfg(test)]
+    pub stderr: Option<Box<dyn StreamTrait>>,
+}
+
+impl SystemdLogFetcher {
+    pub fn new(
+        workload_id: &RuntimeWorkloadId,
+        options: &LogRequestOptions,
+    ) -> Result<Self, RuntimeError> {
+        let unit_name = workload_id.as_ref();
+        let mut args = Vec::with_capacity(9);
+        args.push("-u");
+        args.push(unit_name);
+
+        if options.follow {
+            args.push("-f");
+        }
+        if let Some(since) = &options.since {
+            args.push("--since");
+            args.push(since);
+        }
+        if let Some(until) = &options.until {
+            args.push("--until");
+            args.push(until);
+        }
+        let tail_string;
+        if let Some(tail) = options.tail {
+            tail_string = tail.to_string();
+            args.push("-n");
+            args.push(&tail_string);
+        }
+
+        let cmd = Command::new("journalctl")
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn();
+
+        let cmd = match cmd {
+            Ok(cmd) => Some(cmd),
+            Err(err) => {
+                log::warn!("Cannot collect logs for '{}': '{}'", workload_id, err);
+                return Err(RuntimeError::CollectLog(format!(
+                    "Failed to spawn journalctl: {}",
+                    err
+                )));
+            }
+        };
+
+        #[cfg(not(test))]
+        return Ok(Self { child: cmd });
+        #[cfg(test)]
+        Ok(Self {
+            child: cmd,
+            stdout: None,
+            stderr: None,
+        })
+    }
+
+}
+
+impl Drop for SystemdLogFetcher {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.child
+            && let Err(err) = child.start_kill()
+        {
+            log::warn!("Could not stop log collection: '{}'", err);
+        }
+    }
+}
+
+impl GetOutputStreams for SystemdLogFetcher {
+    type OutputStream = Box<dyn StreamTrait>;
+    type ErrStream = Box<dyn StreamTrait>;
+
+    fn get_output_streams(&mut self) -> (Option<Self::OutputStream>, Option<Self::ErrStream>) {
+        #[cfg(not(test))]
+        {
+            if let Some(child) = &mut self.child {
+                return (
+                    child
+                        .stdout
+                        .take()
+                        .map(|stdout| Box::new(stdout) as Box<dyn StreamTrait>),
+                    child
+                        .stderr
+                        .take()
+                        .map(|stderr| Box::new(stderr) as Box<dyn StreamTrait>),
+                );
+            }
+            (None, None)
+        }
+        #[cfg(test)]
+        return (self.stdout.take(), self.stderr.take());
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::SystemdLogFetcher;
+    use crate::runtime_connectors::{
+        log_fetcher::GetOutputStreams, LogRequestOptions, RuntimeWorkloadId,
+    };
+
+    use std::{process::Stdio, sync::Mutex};
+    use tokio::io::Empty;
+
+    static CAN_SPAWN: Mutex<bool> = Mutex::new(true);
+    static CAN_KILL: Mutex<bool> = Mutex::new(true);
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static WAS_KILLED: Mutex<bool> = Mutex::new(false);
+
+    #[derive(Debug)]
+    pub struct MockChild {
+        pub _stdout: Option<Empty>,
+        cmd: String,
+        args: Vec<String>,
+        stdout_option: Option<Stdio>,
+        stderr_option: Option<Stdio>,
+    }
+    impl MockChild {
+        pub(crate) fn start_kill(&self) -> Result<(), String> {
+            *WAS_KILLED.lock().unwrap() = true;
+            if *CAN_KILL.lock().unwrap() {
+                Ok(())
+            } else {
+                Err("MockChild: Could not kill child".to_string())
+            }
+        }
+    }
+
+    #[derive(Default)]
+    pub struct MockCommand {
+        cmd: String,
+        args: Vec<String>,
+        stdout: Option<Stdio>,
+        stderr: Option<Stdio>,
+    }
+
+    impl MockCommand {
+        pub fn new(cmd: &str) -> Self {
+            Self {
+                cmd: cmd.to_owned(),
+                ..Default::default()
+            }
+        }
+
+        pub(crate) fn args(&mut self, args: Vec<&str>) -> &mut Self {
+            self.args = args.into_iter().map(ToOwned::to_owned).collect();
+            self
+        }
+
+        pub(crate) fn stdout(&mut self, piped: Stdio) -> &mut Self {
+            self.stdout = Some(piped);
+            self
+        }
+
+        pub(crate) fn stderr(&mut self, piped: Stdio) -> &mut Self {
+            self.stderr = Some(piped);
+            self
+        }
+
+        pub(crate) fn spawn(&mut self) -> Result<MockChild, String> {
+            if *CAN_SPAWN.lock().unwrap() {
+                Ok(MockChild {
+                    _stdout: None,
+                    cmd: self.cmd.clone(),
+                    args: self.args.clone(),
+                    stdout_option: self.stdout.take(),
+                    stderr_option: self.stderr.take(),
+                })
+            } else {
+                Err("MockCommand: Could not spawn child".to_string())
+            }
+        }
+    }
+
+    #[test]
+    fn utest_new_with_no_parameters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = true;
+        let mut log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: false,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            &log_fetcher.child,
+            Some(MockChild {
+                _stdout: _,
+                cmd,
+                args,
+                stdout_option: Some(_),
+                stderr_option: Some(_)
+
+            }) if cmd == "journalctl" && *args == vec!["-u".to_string(), "test.service".to_string()]
+        ));
+        let (child_stdout, child_stderr) = log_fetcher.get_output_streams();
+        assert!(child_stdout.is_none());
+        assert!(child_stderr.is_none());
+    }
+
+    #[test]
+    fn utest_new_with_with_parameters() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = true;
+        let mut log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("nginx.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: Some(10),
+                since: Some("since".to_string()),
+                until: Some("until".to_string()),
+            },
+        )
+        .unwrap();
+
+        assert!(matches!(
+            &log_fetcher.child,
+            Some(MockChild {
+                _stdout: _,
+                cmd,
+                args,
+                stdout_option: Some(_),
+                stderr_option: Some(_),
+            }) if cmd == "journalctl" && *args == vec!["-u".to_string(), "nginx.service".to_string(), "-f".to_string(), "--since".to_string(), "since".to_string(), "--until".to_string(), "until".to_string(), "-n".to_string(), "10".to_string()]
+        ));
+        let (child_stdout, child_stderr) = log_fetcher.get_output_streams();
+        assert!(child_stdout.is_none());
+        assert!(child_stderr.is_none());
+    }
+
+    #[test]
+    fn utest_new_spawn_fails() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *CAN_SPAWN.lock().unwrap() = false;
+        let result = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: false,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn utest_dropped_child_kills_cmd() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *WAS_KILLED.lock().unwrap() = false;
+        *CAN_SPAWN.lock().unwrap() = true;
+
+        *CAN_KILL.lock().unwrap() = true;
+        let log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(!*WAS_KILLED.lock().unwrap());
+        drop(log_fetcher);
+        assert!(*WAS_KILLED.lock().unwrap());
+    }
+
+    #[test]
+    fn utest_dropped_child_handles_kills_error() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        *WAS_KILLED.lock().unwrap() = false;
+        *CAN_SPAWN.lock().unwrap() = true;
+        *CAN_KILL.lock().unwrap() = false;
+        let log_fetcher = SystemdLogFetcher::new(
+            &RuntimeWorkloadId::from("test.service"),
+            &LogRequestOptions {
+                follow: true,
+                tail: None,
+                since: None,
+                until: None,
+            },
+        )
+        .unwrap();
+
+        assert!(!*WAS_KILLED.lock().unwrap());
+        drop(log_fetcher);
+        assert!(*WAS_KILLED.lock().unwrap());
+    }
+}

--- a/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_log_fetcher.rs
@@ -24,10 +24,6 @@ use tokio::process::{Child, Command};
 #[derive(Debug)]
 pub struct SystemdLogFetcher {
     child: Option<Child>,
-    #[cfg(test)]
-    pub stdout: Option<Box<dyn StreamTrait>>,
-    #[cfg(test)]
-    pub stderr: Option<Box<dyn StreamTrait>>,
 }
 
 impl SystemdLogFetcher {
@@ -58,33 +54,20 @@ impl SystemdLogFetcher {
             args.push(&tail_string);
         }
 
-        let cmd = Command::new("journalctl")
-            .args(args)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn();
+        let child = Some(
+            Command::new("journalctl")
+                .args(args)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .map_err(|err| {
+                    log::warn!("Cannot collect logs for '{}': '{}'", workload_id, err);
+                    RuntimeError::CollectLog(format!("Failed to spawn journalctl: {}", err))
+                })?,
+        );
 
-        let cmd = match cmd {
-            Ok(cmd) => Some(cmd),
-            Err(err) => {
-                log::warn!("Cannot collect logs for '{}': '{}'", workload_id, err);
-                return Err(RuntimeError::CollectLog(format!(
-                    "Failed to spawn journalctl: {}",
-                    err
-                )));
-            }
-        };
-
-        #[cfg(not(test))]
-        return Ok(Self { child: cmd });
-        #[cfg(test)]
-        Ok(Self {
-            child: cmd,
-            stdout: None,
-            stderr: None,
-        })
+        Ok(Self { child })
     }
-
 }
 
 impl Drop for SystemdLogFetcher {
@@ -116,10 +99,8 @@ impl GetOutputStreams for SystemdLogFetcher {
                         .map(|stderr| Box::new(stderr) as Box<dyn StreamTrait>),
                 );
             }
-            (None, None)
         }
-        #[cfg(test)]
-        return (self.stdout.take(), self.stderr.take());
+        (None, None)
     }
 }
 
@@ -139,7 +120,6 @@ mod tests {
     };
 
     use std::{process::Stdio, sync::Mutex};
-    use tokio::io::Empty;
 
     static CAN_SPAWN: Mutex<bool> = Mutex::new(true);
     static CAN_KILL: Mutex<bool> = Mutex::new(true);
@@ -148,7 +128,6 @@ mod tests {
 
     #[derive(Debug)]
     pub struct MockChild {
-        pub _stdout: Option<Empty>,
         cmd: String,
         args: Vec<String>,
         stdout_option: Option<Stdio>,
@@ -199,7 +178,6 @@ mod tests {
         pub(crate) fn spawn(&mut self) -> Result<MockChild, String> {
             if *CAN_SPAWN.lock().unwrap() {
                 Ok(MockChild {
-                    _stdout: None,
                     cmd: self.cmd.clone(),
                     args: self.args.clone(),
                     stdout_option: self.stdout.take(),
@@ -229,12 +207,10 @@ mod tests {
         assert!(matches!(
             &log_fetcher.child,
             Some(MockChild {
-                _stdout: _,
                 cmd,
                 args,
                 stdout_option: Some(_),
-                stderr_option: Some(_)
-
+                stderr_option: Some(_),
             }) if cmd == "journalctl" && *args == vec!["-u".to_string(), "test.service".to_string()]
         ));
         let (child_stdout, child_stderr) = log_fetcher.get_output_streams();
@@ -260,7 +236,6 @@ mod tests {
         assert!(matches!(
             &log_fetcher.child,
             Some(MockChild {
-                _stdout: _,
                 cmd,
                 args,
                 stdout_option: Some(_),

--- a/agent/src/runtime_connectors/systemd/systemd_runtime.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_runtime.rs
@@ -1,0 +1,529 @@
+// Copyright (c) 2024 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::systemd_runtime_config::{ServiceState, SystemdRuntimeConfig};
+#[cfg_attr(test, double)]
+use crate::runtime_connectors::systemd::systemd_cli::SystemdCli;
+use crate::{
+    generic_polling_state_checker::GenericPollingStateChecker,
+    runtime_connectors::{
+        generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
+        runtime_connector::LogRequestOptions, ReusableWorkloadState, RuntimeConnector,
+        RuntimeError, RuntimeStateGetter, RuntimeWorkloadId, StateCheckerHandle,
+    },
+    workload_state::WorkloadStateSender,
+};
+
+use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec, WorkloadNamed};
+use common::objects::AgentName;
+
+use async_trait::async_trait;
+#[cfg(test)]
+use mockall_double::double;
+use std::{collections::HashMap, path::PathBuf};
+
+pub const SYSTEMD_RUNTIME_NAME: &str = "systemd";
+
+// Guards against duplicate restart when the agent itself is restarted by systemd
+const RECENT_RESTART_THRESHOLD_SECS: u64 = 3;
+
+#[derive(Debug, Clone)]
+pub struct SystemdRuntime {}
+
+#[derive(Debug, Clone)]
+pub struct SystemdStateGetter {}
+
+#[async_trait]
+impl RuntimeStateGetter for SystemdStateGetter {
+    async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
+        let unit_name = workload_id.as_ref();
+        log::trace!("Getting the state for systemd unit '{}'", unit_name);
+
+        let exec_state = match SystemdCli::get_unit_state(unit_name).await {
+            Ok(state) => map_systemd_state_to_execution_state(state),
+            Err(err) => {
+                log::warn!(
+                    "Could not get state of unit '{}': '{}'. Returning unknown.",
+                    unit_name,
+                    err
+                );
+                ExecutionStateSpec::unknown("Error getting state from systemd.")
+            }
+        };
+
+        log::trace!(
+            "Returning the state '{}' for systemd unit '{}'",
+            exec_state,
+            unit_name
+        );
+        exec_state
+    }
+}
+
+/// Map systemd unit state to Ankaios execution state
+fn map_systemd_state_to_execution_state(
+    state: crate::runtime_connectors::systemd::systemd_cli::SystemdUnitState,
+) -> ExecutionStateSpec {
+    match state.active_state.as_str() {
+        "active" if state.sub_state == "running" => ExecutionStateSpec::running(),
+        "inactive" if state.sub_state == "dead" => {
+            // Check exit code to determine success or failure
+            match state.exit_code {
+                Some(0) => ExecutionStateSpec::succeeded(),
+                Some(code) => ExecutionStateSpec::failed(format!("Exit code: {}", code)),
+                None => ExecutionStateSpec::succeeded(), // Treat no exit code as success for inactive services
+            }
+        }
+        "failed" => ExecutionStateSpec::failed(format!("Service failed: {}", state.sub_state)),
+        "activating" => ExecutionStateSpec::starting(state.sub_state),
+        "deactivating" => ExecutionStateSpec::stopping(state.sub_state),
+        _ => ExecutionStateSpec::unknown(state.active_state),
+    }
+}
+
+#[async_trait]
+impl RuntimeConnector for SystemdRuntime {
+    fn name(&self) -> String {
+        SYSTEMD_RUNTIME_NAME.to_string()
+    }
+
+    async fn get_reusable_workloads(
+        &self,
+        _agent_name: &AgentName,
+    ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
+        Ok(Vec::new())
+    }
+
+    async fn create_workload(
+        &self,
+        workload_named: WorkloadNamed,
+        _reusable_workload_id: Option<RuntimeWorkloadId>,
+        _control_interface_path: Option<PathBuf>,
+        update_state_tx: WorkloadStateSender,
+        _workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
+        let config = SystemdRuntimeConfig::try_from(&workload_named.workload)
+            .map_err(RuntimeError::Unsupported)?;
+
+        log::debug!(
+            "Processing systemd workload '{}' for service '{}'",
+            workload_named.instance_name,
+            config.service_name
+        );
+
+        let result = match config.desired_state {
+            ServiceState::Running => {
+                log::debug!("Starting systemd unit: {}", config.service_name);
+                SystemdCli::start_unit(&config.service_name).await
+            }
+            ServiceState::Stopped => {
+                log::debug!("Stopping systemd unit: {}", config.service_name);
+                SystemdCli::stop_unit(&config.service_name).await
+            }
+            ServiceState::Restarted => {
+                match SystemdCli::get_unit_uptime_seconds(&config.service_name).await {
+                    Ok(Some(uptime_secs)) if uptime_secs <= RECENT_RESTART_THRESHOLD_SECS => {
+                        log::info!(
+                            "Service '{}' was restarted {}s ago, skipping restart to avoid duplicate action",
+                            config.service_name,
+                            uptime_secs
+                        );
+                        Ok(())
+                    }
+                    _ => {
+                        log::debug!("Restarting systemd unit: {}", config.service_name);
+                        SystemdCli::restart_unit(&config.service_name).await
+                    }
+                }
+            }
+        };
+
+        match result {
+            Ok(()) => {
+                let workload_id = RuntimeWorkloadId::from(config.service_name);
+
+                log::debug!(
+                    "The systemd workload '{}' has been reconciled to desired state",
+                    workload_named.instance_name
+                );
+
+                let state_checker = self
+                    .start_checker(&workload_id, workload_named, update_state_tx)
+                    .await?;
+
+                Ok((workload_id, state_checker))
+            }
+            Err(err) => {
+                log::debug!("Systemd operation failed. Error: '{}'", err);
+                Err(RuntimeError::Create(err))
+            }
+        }
+    }
+
+    async fn get_workload_id(
+        &self,
+        _instance_name: &WorkloadInstanceNameSpec,
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
+        Err(RuntimeError::List(
+            "Systemd runtime does not support reusability".to_string(),
+        ))
+    }
+
+    async fn start_checker(
+        &self,
+        workload_id: &RuntimeWorkloadId,
+        workload_named: WorkloadNamed,
+        update_state_tx: WorkloadStateSender,
+    ) -> Result<StateCheckerHandle, RuntimeError> {
+        log::debug!(
+            "Starting the checker for systemd unit '{}'",
+            workload_id
+        );
+        let checker = GenericPollingStateChecker::start_checker(
+            &workload_named,
+            workload_id.clone(),
+            update_state_tx,
+            SystemdStateGetter {},
+        );
+        Ok(Box::new(checker))
+    }
+
+    fn get_log_fetcher(
+        &self,
+        workload_id: RuntimeWorkloadId,
+        options: &LogRequestOptions,
+    ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
+        let systemd_log_fetcher =
+            super::systemd_log_fetcher::SystemdLogFetcher::new(&workload_id, options)?;
+        let log_fetcher = GenericLogFetcher::new(systemd_log_fetcher);
+        Ok(Box::new(log_fetcher))
+    }
+
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
+        let unit_name = workload_id.as_ref();
+        log::debug!("Stopping systemd unit '{}'", unit_name);
+        SystemdCli::stop_unit(unit_name)
+            .await
+            .map_err(|err| RuntimeError::Delete(err.to_string()))
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_systemd_state_to_execution_state, SystemdCli, SystemdRuntime, SystemdStateGetter,
+        SYSTEMD_RUNTIME_NAME,
+    };
+    use crate::runtime_connectors::{
+        RuntimeConnector, RuntimeError, RuntimeStateGetter, RuntimeWorkloadId,
+    };
+    use crate::runtime_connectors::systemd::systemd_cli::SystemdUnitState;
+    use crate::test_helper::MOCKALL_CONTEXT_SYNC;
+
+    use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadNamed};
+    use ankaios_api::test_utils::{fixtures, generate_test_workload_named_with_params};
+    use common::objects::AgentName;
+
+    use std::collections::HashMap;
+
+    fn generate_test_systemd_workload() -> WorkloadNamed {
+        let mut workload = generate_test_workload_named_with_params(
+            fixtures::WORKLOAD_NAMES[0],
+            fixtures::AGENT_NAMES[0],
+            SYSTEMD_RUNTIME_NAME,
+        );
+        workload.workload.runtime_config = "serviceName: test.service\n".to_string();
+        workload
+    }
+
+    #[test]
+    fn utest_name_systemd() {
+        let systemd_runtime = SystemdRuntime {};
+        assert_eq!(systemd_runtime.name(), "systemd".to_string());
+    }
+
+    #[tokio::test]
+    async fn utest_get_reusable_workloads_always_empty() {
+        let systemd_runtime = SystemdRuntime {};
+        let agent_name = AgentName::from(fixtures::AGENT_NAMES[0]);
+        let result = systemd_runtime.get_reusable_workloads(&agent_name).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_running() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context.expect().return_const(Ok(SystemdUnitState {
+            active_state: "active".to_string(),
+            sub_state: "running".to_string(),
+            exit_code: Some(0),
+        }));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::running());
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_failed() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context.expect().return_const(Ok(SystemdUnitState {
+            active_state: "failed".to_string(),
+            sub_state: "failed".to_string(),
+            exit_code: Some(1),
+        }));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::failed("Service failed: failed"));
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_starts_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let start_unit_context = SystemdCli::start_unit_context();
+        start_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let workload = generate_test_systemd_workload();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+        let (workload_id, _checker) = result.unwrap();
+        assert_eq!(workload_id.to_string(), "test.service");
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_stops_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: stopped\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_restarts_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        // Mock uptime check to return old uptime (service not recently restarted)
+        let get_uptime_context = SystemdCli::get_unit_uptime_seconds_context();
+        get_uptime_context.expect().return_const(Ok(Some(100)));  // 100 seconds uptime
+
+        let restart_unit_context = SystemdCli::restart_unit_context();
+        restart_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_skips_recent_restart() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        // Mock uptime check to return recent restart (2 seconds ago)
+        let get_uptime_context = SystemdCli::get_unit_uptime_seconds_context();
+        get_uptime_context.expect().return_const(Ok(Some(2)));  // Recently restarted
+
+        // restart_unit should NOT be called
+        let restart_unit_context = SystemdCli::restart_unit_context();
+        restart_unit_context.expect().times(0);
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        // Should still succeed even though restart was skipped
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_delete_workload_stops_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+
+        let result = runtime.delete_workload(&workload_id).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_start_fails() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let start_unit_context = SystemdCli::start_unit_context();
+        start_unit_context
+            .expect()
+            .return_const(Err("unit not found".to_string()));
+
+        let runtime = SystemdRuntime {};
+        let workload = generate_test_systemd_workload();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(matches!(result, Err(RuntimeError::Create(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_delete_workload_fails() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context
+            .expect()
+            .return_const(Err("permission denied".to_string()));
+
+        let runtime = SystemdRuntime {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+
+        let result = runtime.delete_workload(&workload_id).await;
+        assert!(matches!(result, Err(RuntimeError::Delete(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_unknown_on_error() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context
+            .expect()
+            .return_const(Err("dbus error".to_string()));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::unknown("Error getting state from systemd."));
+    }
+
+    #[test]
+    fn utest_map_state_activating() {
+        let state = SystemdUnitState {
+            active_state: "activating".to_string(),
+            sub_state: "start".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::starting("start")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_deactivating() {
+        let state = SystemdUnitState {
+            active_state: "deactivating".to_string(),
+            sub_state: "stop-sigterm".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::stopping("stop-sigterm")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_inactive_success() {
+        let state = SystemdUnitState {
+            active_state: "inactive".to_string(),
+            sub_state: "dead".to_string(),
+            exit_code: Some(0),
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::succeeded()
+        );
+    }
+
+    #[test]
+    fn utest_map_state_inactive_failed() {
+        let state = SystemdUnitState {
+            active_state: "inactive".to_string(),
+            sub_state: "dead".to_string(),
+            exit_code: Some(1),
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::failed("Exit code: 1")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_unknown() {
+        let state = SystemdUnitState {
+            active_state: "reloading".to_string(),
+            sub_state: "reload".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::unknown("reloading")
+        );
+    }
+}

--- a/agent/src/runtime_connectors/systemd/systemd_runtime.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_runtime.rs
@@ -77,6 +77,8 @@ fn map_systemd_state_to_execution_state(
 ) -> ExecutionStateSpec {
     match state.active_state.as_str() {
         "active" if state.sub_state == "running" => ExecutionStateSpec::running(),
+        "active" if state.sub_state == "exited" => ExecutionStateSpec::succeeded(),
+        "active" => ExecutionStateSpec::running(),
         "inactive" if state.sub_state == "dead" => {
             // Check exit code to determine success or failure
             match state.exit_code {
@@ -511,6 +513,32 @@ mod tests {
         assert_eq!(
             map_systemd_state_to_execution_state(state),
             ExecutionStateSpec::failed("Exit code: 1")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_active_exited() {
+        let state = SystemdUnitState {
+            active_state: "active".to_string(),
+            sub_state: "exited".to_string(),
+            exit_code: Some(0),
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::succeeded()
+        );
+    }
+
+    #[test]
+    fn utest_map_state_active_other_substate() {
+        let state = SystemdUnitState {
+            active_state: "active".to_string(),
+            sub_state: "waiting".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::running()
         );
     }
 

--- a/agent/src/runtime_connectors/systemd/systemd_runtime.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_runtime.rs
@@ -1,0 +1,529 @@
+// Copyright (c) 2026 Red Hat LLC
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::systemd_runtime_config::{ServiceState, SystemdRuntimeConfig};
+#[cfg_attr(test, double)]
+use crate::runtime_connectors::systemd::systemd_cli::SystemdCli;
+use crate::{
+    generic_polling_state_checker::GenericPollingStateChecker,
+    runtime_connectors::{
+        generic_log_fetcher::GenericLogFetcher, log_fetcher::LogFetcher,
+        runtime_connector::LogRequestOptions, ReusableWorkloadState, RuntimeConnector,
+        RuntimeError, RuntimeStateGetter, RuntimeWorkloadId, StateCheckerHandle,
+    },
+    workload_state::WorkloadStateSender,
+};
+
+use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadInstanceNameSpec, WorkloadNamed};
+use common::objects::AgentName;
+
+use async_trait::async_trait;
+#[cfg(test)]
+use mockall_double::double;
+use std::{collections::HashMap, path::PathBuf};
+
+pub const SYSTEMD_RUNTIME_NAME: &str = "systemd";
+
+// Guards against duplicate restart when the agent itself is restarted by systemd
+const RECENT_RESTART_THRESHOLD_SECS: u64 = 3;
+
+#[derive(Debug, Clone)]
+pub struct SystemdRuntime {}
+
+#[derive(Debug, Clone)]
+pub struct SystemdStateGetter {}
+
+#[async_trait]
+impl RuntimeStateGetter for SystemdStateGetter {
+    async fn get_state(&self, workload_id: &RuntimeWorkloadId) -> ExecutionStateSpec {
+        let unit_name = workload_id.as_ref();
+        log::trace!("Getting the state for systemd unit '{}'", unit_name);
+
+        let exec_state = match SystemdCli::get_unit_state(unit_name).await {
+            Ok(state) => map_systemd_state_to_execution_state(state),
+            Err(err) => {
+                log::warn!(
+                    "Could not get state of unit '{}': '{}'. Returning unknown.",
+                    unit_name,
+                    err
+                );
+                ExecutionStateSpec::unknown("Error getting state from systemd.")
+            }
+        };
+
+        log::trace!(
+            "Returning the state '{}' for systemd unit '{}'",
+            exec_state,
+            unit_name
+        );
+        exec_state
+    }
+}
+
+/// Map systemd unit state to Ankaios execution state
+fn map_systemd_state_to_execution_state(
+    state: crate::runtime_connectors::systemd::systemd_cli::SystemdUnitState,
+) -> ExecutionStateSpec {
+    match state.active_state.as_str() {
+        "active" if state.sub_state == "running" => ExecutionStateSpec::running(),
+        "inactive" if state.sub_state == "dead" => {
+            // Check exit code to determine success or failure
+            match state.exit_code {
+                Some(0) => ExecutionStateSpec::succeeded(),
+                Some(code) => ExecutionStateSpec::failed(format!("Exit code: {}", code)),
+                None => ExecutionStateSpec::succeeded(), // Treat no exit code as success for inactive services
+            }
+        }
+        "failed" => ExecutionStateSpec::failed(format!("Service failed: {}", state.sub_state)),
+        "activating" => ExecutionStateSpec::starting(state.sub_state),
+        "deactivating" => ExecutionStateSpec::stopping(state.sub_state),
+        _ => ExecutionStateSpec::unknown(state.active_state),
+    }
+}
+
+#[async_trait]
+impl RuntimeConnector for SystemdRuntime {
+    fn name(&self) -> String {
+        SYSTEMD_RUNTIME_NAME.to_string()
+    }
+
+    async fn get_reusable_workloads(
+        &self,
+        _agent_name: &AgentName,
+    ) -> Result<Vec<ReusableWorkloadState>, RuntimeError> {
+        Ok(Vec::new())
+    }
+
+    async fn create_workload(
+        &self,
+        workload_named: WorkloadNamed,
+        _reusable_workload_id: Option<RuntimeWorkloadId>,
+        _control_interface_path: Option<PathBuf>,
+        update_state_tx: WorkloadStateSender,
+        _workload_file_path_mappings: HashMap<PathBuf, PathBuf>,
+    ) -> Result<(RuntimeWorkloadId, StateCheckerHandle), RuntimeError> {
+        let config = SystemdRuntimeConfig::try_from(&workload_named.workload)
+            .map_err(RuntimeError::Unsupported)?;
+
+        log::debug!(
+            "Processing systemd workload '{}' for service '{}'",
+            workload_named.instance_name,
+            config.service_name
+        );
+
+        let result = match config.desired_state {
+            ServiceState::Running => {
+                log::debug!("Starting systemd unit: {}", config.service_name);
+                SystemdCli::start_unit(&config.service_name).await
+            }
+            ServiceState::Stopped => {
+                log::debug!("Stopping systemd unit: {}", config.service_name);
+                SystemdCli::stop_unit(&config.service_name).await
+            }
+            ServiceState::Restarted => {
+                match SystemdCli::get_unit_uptime_seconds(&config.service_name).await {
+                    Ok(Some(uptime_secs)) if uptime_secs <= RECENT_RESTART_THRESHOLD_SECS => {
+                        log::info!(
+                            "Service '{}' was restarted {}s ago, skipping restart to avoid duplicate action",
+                            config.service_name,
+                            uptime_secs
+                        );
+                        Ok(())
+                    }
+                    _ => {
+                        log::debug!("Restarting systemd unit: {}", config.service_name);
+                        SystemdCli::restart_unit(&config.service_name).await
+                    }
+                }
+            }
+        };
+
+        match result {
+            Ok(()) => {
+                let workload_id = RuntimeWorkloadId::from(config.service_name);
+
+                log::debug!(
+                    "The systemd workload '{}' has been reconciled to desired state",
+                    workload_named.instance_name
+                );
+
+                let state_checker = self
+                    .start_checker(&workload_id, workload_named, update_state_tx)
+                    .await?;
+
+                Ok((workload_id, state_checker))
+            }
+            Err(err) => {
+                log::debug!("Systemd operation failed. Error: '{}'", err);
+                Err(RuntimeError::Create(err))
+            }
+        }
+    }
+
+    async fn get_workload_id(
+        &self,
+        _instance_name: &WorkloadInstanceNameSpec,
+    ) -> Result<RuntimeWorkloadId, RuntimeError> {
+        Err(RuntimeError::List(
+            "Systemd runtime does not support reusability".to_string(),
+        ))
+    }
+
+    async fn start_checker(
+        &self,
+        workload_id: &RuntimeWorkloadId,
+        workload_named: WorkloadNamed,
+        update_state_tx: WorkloadStateSender,
+    ) -> Result<StateCheckerHandle, RuntimeError> {
+        log::debug!(
+            "Starting the checker for systemd unit '{}'",
+            workload_id
+        );
+        let checker = GenericPollingStateChecker::start_checker(
+            &workload_named,
+            workload_id.clone(),
+            update_state_tx,
+            SystemdStateGetter {},
+        );
+        Ok(Box::new(checker))
+    }
+
+    fn get_log_fetcher(
+        &self,
+        workload_id: RuntimeWorkloadId,
+        options: &LogRequestOptions,
+    ) -> Result<Box<dyn LogFetcher + Send>, RuntimeError> {
+        let systemd_log_fetcher =
+            super::systemd_log_fetcher::SystemdLogFetcher::new(&workload_id, options)?;
+        let log_fetcher = GenericLogFetcher::new(systemd_log_fetcher);
+        Ok(Box::new(log_fetcher))
+    }
+
+    async fn delete_workload(&self, workload_id: &RuntimeWorkloadId) -> Result<(), RuntimeError> {
+        let unit_name = workload_id.as_ref();
+        log::debug!("Stopping systemd unit '{}'", unit_name);
+        SystemdCli::stop_unit(unit_name)
+            .await
+            .map_err(|err| RuntimeError::Delete(err.to_string()))
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_systemd_state_to_execution_state, SystemdCli, SystemdRuntime, SystemdStateGetter,
+        SYSTEMD_RUNTIME_NAME,
+    };
+    use crate::runtime_connectors::{
+        RuntimeConnector, RuntimeError, RuntimeStateGetter, RuntimeWorkloadId,
+    };
+    use crate::runtime_connectors::systemd::systemd_cli::SystemdUnitState;
+    use crate::test_helper::MOCKALL_CONTEXT_SYNC;
+
+    use ankaios_api::ank_base::{ExecutionStateSpec, WorkloadNamed};
+    use ankaios_api::test_utils::{fixtures, generate_test_workload_named_with_params};
+    use common::objects::AgentName;
+
+    use std::collections::HashMap;
+
+    fn generate_test_systemd_workload() -> WorkloadNamed {
+        let mut workload = generate_test_workload_named_with_params(
+            fixtures::WORKLOAD_NAMES[0],
+            fixtures::AGENT_NAMES[0],
+            SYSTEMD_RUNTIME_NAME,
+        );
+        workload.workload.runtime_config = "serviceName: test.service\n".to_string();
+        workload
+    }
+
+    #[test]
+    fn utest_name_systemd() {
+        let systemd_runtime = SystemdRuntime {};
+        assert_eq!(systemd_runtime.name(), "systemd".to_string());
+    }
+
+    #[tokio::test]
+    async fn utest_get_reusable_workloads_always_empty() {
+        let systemd_runtime = SystemdRuntime {};
+        let agent_name = AgentName::from(fixtures::AGENT_NAMES[0]);
+        let result = systemd_runtime.get_reusable_workloads(&agent_name).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_running() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context.expect().return_const(Ok(SystemdUnitState {
+            active_state: "active".to_string(),
+            sub_state: "running".to_string(),
+            exit_code: Some(0),
+        }));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::running());
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_failed() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context.expect().return_const(Ok(SystemdUnitState {
+            active_state: "failed".to_string(),
+            sub_state: "failed".to_string(),
+            exit_code: Some(1),
+        }));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::failed("Service failed: failed"));
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_starts_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let start_unit_context = SystemdCli::start_unit_context();
+        start_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let workload = generate_test_systemd_workload();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+        let (workload_id, _checker) = result.unwrap();
+        assert_eq!(workload_id.to_string(), "test.service");
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_stops_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: stopped\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_restarts_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        // Mock uptime check to return old uptime (service not recently restarted)
+        let get_uptime_context = SystemdCli::get_unit_uptime_seconds_context();
+        get_uptime_context.expect().return_const(Ok(Some(100)));  // 100 seconds uptime
+
+        let restart_unit_context = SystemdCli::restart_unit_context();
+        restart_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_skips_recent_restart() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        // Mock uptime check to return recent restart (2 seconds ago)
+        let get_uptime_context = SystemdCli::get_unit_uptime_seconds_context();
+        get_uptime_context.expect().return_const(Ok(Some(2)));  // Recently restarted
+
+        // restart_unit should NOT be called
+        let restart_unit_context = SystemdCli::restart_unit_context();
+        restart_unit_context.expect().times(0);
+
+        let runtime = SystemdRuntime {};
+        let mut workload = generate_test_systemd_workload();
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        // Should still succeed even though restart was skipped
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_delete_workload_stops_service() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context.expect().return_const(Ok(()));
+
+        let runtime = SystemdRuntime {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+
+        let result = runtime.delete_workload(&workload_id).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn utest_create_workload_start_fails() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let start_unit_context = SystemdCli::start_unit_context();
+        start_unit_context
+            .expect()
+            .return_const(Err("unit not found".to_string()));
+
+        let runtime = SystemdRuntime {};
+        let workload = generate_test_systemd_workload();
+        let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+
+        let result = runtime
+            .create_workload(workload, None, None, sender, HashMap::new())
+            .await;
+
+        assert!(matches!(result, Err(RuntimeError::Create(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_delete_workload_fails() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let stop_unit_context = SystemdCli::stop_unit_context();
+        stop_unit_context
+            .expect()
+            .return_const(Err("permission denied".to_string()));
+
+        let runtime = SystemdRuntime {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+
+        let result = runtime.delete_workload(&workload_id).await;
+        assert!(matches!(result, Err(RuntimeError::Delete(_))));
+    }
+
+    #[tokio::test]
+    async fn utest_state_getter_returns_unknown_on_error() {
+        let _guard = MOCKALL_CONTEXT_SYNC.get_lock_async().await;
+
+        let get_unit_state_context = SystemdCli::get_unit_state_context();
+        get_unit_state_context
+            .expect()
+            .return_const(Err("dbus error".to_string()));
+
+        let state_getter = SystemdStateGetter {};
+        let workload_id = RuntimeWorkloadId::from("test.service");
+        let state = state_getter.get_state(&workload_id).await;
+
+        assert_eq!(state, ExecutionStateSpec::unknown("Error getting state from systemd."));
+    }
+
+    #[test]
+    fn utest_map_state_activating() {
+        let state = SystemdUnitState {
+            active_state: "activating".to_string(),
+            sub_state: "start".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::starting("start")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_deactivating() {
+        let state = SystemdUnitState {
+            active_state: "deactivating".to_string(),
+            sub_state: "stop-sigterm".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::stopping("stop-sigterm")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_inactive_success() {
+        let state = SystemdUnitState {
+            active_state: "inactive".to_string(),
+            sub_state: "dead".to_string(),
+            exit_code: Some(0),
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::succeeded()
+        );
+    }
+
+    #[test]
+    fn utest_map_state_inactive_failed() {
+        let state = SystemdUnitState {
+            active_state: "inactive".to_string(),
+            sub_state: "dead".to_string(),
+            exit_code: Some(1),
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::failed("Exit code: 1")
+        );
+    }
+
+    #[test]
+    fn utest_map_state_unknown() {
+        let state = SystemdUnitState {
+            active_state: "reloading".to_string(),
+            sub_state: "reload".to_string(),
+            exit_code: None,
+        };
+        assert_eq!(
+            map_systemd_state_to_execution_state(state),
+            ExecutionStateSpec::unknown("reloading")
+        );
+    }
+}

--- a/agent/src/runtime_connectors/systemd/systemd_runtime_config.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_runtime_config.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2024 Elektrobit Automotive GmbH
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::systemd_runtime::SYSTEMD_RUNTIME_NAME;
+use ankaios_api::ank_base::WorkloadSpec;
+
+#[derive(Debug, serde::Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemdRuntimeConfig {
+    pub service_name: String,
+    #[serde(default = "default_desired_state")]
+    pub desired_state: ServiceState,
+}
+
+fn default_desired_state() -> ServiceState {
+    ServiceState::Running
+}
+
+#[derive(Debug, serde::Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceState {
+    Running,
+    Stopped,
+    Restarted,
+}
+
+const VALID_UNIT_SUFFIXES: &[&str] = &[
+    ".service", ".timer", ".socket", ".mount", ".target", ".path", ".scope", ".slice", ".swap",
+    ".automount", ".device",
+];
+
+fn validate_service_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("service_name must not be empty".to_string());
+    }
+
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || "@_:.-".contains(c)) {
+        return Err(format!(
+            "service_name '{}' contains invalid characters (only alphanumeric, @, _, :, ., - allowed)",
+            name
+        ));
+    }
+
+    if !VALID_UNIT_SUFFIXES.iter().any(|suffix| name.ends_with(suffix)) {
+        return Err(format!(
+            "service_name '{}' must end with a valid systemd unit suffix (e.g. .service, .timer)",
+            name
+        ));
+    }
+
+    Ok(())
+}
+
+impl TryFrom<&WorkloadSpec> for SystemdRuntimeConfig {
+    type Error = String;
+    fn try_from(workload_spec: &WorkloadSpec) -> Result<Self, Self::Error> {
+        if SYSTEMD_RUNTIME_NAME != workload_spec.runtime {
+            return Err(format!(
+                "Received a workload for the wrong runtime: '{}'",
+                workload_spec.runtime
+            ));
+        }
+        let config: Self =
+            serde_yaml::from_str(&workload_spec.runtime_config).map_err(|e| e.to_string())?;
+        validate_service_name(&config.service_name)?;
+        Ok(config)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ankaios_api::test_utils::generate_test_workload_with_params;
+
+    const DIFFERENT_RUNTIME_NAME: &str = "different-runtime-name";
+
+    #[test]
+    fn utest_systemd_config_failure_missing_service_name() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "something: without_service_name".to_string();
+
+        assert!(SystemdRuntimeConfig::try_from(&workload).is_err());
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_wrong_runtime() {
+        let workload = generate_test_workload_with_params("agent_A", DIFFERENT_RUNTIME_NAME);
+
+        assert!(SystemdRuntimeConfig::try_from(&workload).is_err());
+    }
+
+    #[test]
+    fn utest_systemd_config_success_minimal() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: nginx.service\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Running); // default
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_running() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: nginx.service\ndesiredState: running\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Running);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_stopped() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: cups.service\ndesiredState: stopped\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "cups.service");
+        assert_eq!(config.desired_state, ServiceState::Stopped);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_restarted() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: nginx.service\ndesiredState: restarted\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Restarted);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_template_unit() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: foo@bar.service\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "foo@bar.service");
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_timer_unit() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: backup.timer\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "backup.timer");
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_empty_service_name() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: ''\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must not be empty"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_shell_metacharacters() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: \"test;rm -rf /.service\"\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid characters"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_no_unit_suffix() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: nginx\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("valid systemd unit suffix"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_path_traversal() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: \"../etc/passwd.service\"\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid characters"));
+    }
+}

--- a/agent/src/runtime_connectors/systemd/systemd_runtime_config.rs
+++ b/agent/src/runtime_connectors/systemd/systemd_runtime_config.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 Red Hat LLC
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License, Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use super::systemd_runtime::SYSTEMD_RUNTIME_NAME;
+use ankaios_api::ank_base::WorkloadSpec;
+
+#[derive(Debug, serde::Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SystemdRuntimeConfig {
+    pub service_name: String,
+    #[serde(default = "default_desired_state")]
+    pub desired_state: ServiceState,
+}
+
+fn default_desired_state() -> ServiceState {
+    ServiceState::Running
+}
+
+#[derive(Debug, serde::Deserialize, Eq, PartialEq, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceState {
+    Running,
+    Stopped,
+    Restarted,
+}
+
+const VALID_UNIT_SUFFIXES: &[&str] = &[
+    ".service", ".timer", ".socket", ".mount", ".target", ".path", ".scope", ".slice", ".swap",
+    ".automount", ".device",
+];
+
+fn validate_service_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("service_name must not be empty".to_string());
+    }
+
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || "@_:.-".contains(c)) {
+        return Err(format!(
+            "service_name '{}' contains invalid characters (only alphanumeric, @, _, :, ., - allowed)",
+            name
+        ));
+    }
+
+    if !VALID_UNIT_SUFFIXES.iter().any(|suffix| name.ends_with(suffix)) {
+        return Err(format!(
+            "service_name '{}' must end with a valid systemd unit suffix (e.g. .service, .timer)",
+            name
+        ));
+    }
+
+    Ok(())
+}
+
+impl TryFrom<&WorkloadSpec> for SystemdRuntimeConfig {
+    type Error = String;
+    fn try_from(workload_spec: &WorkloadSpec) -> Result<Self, Self::Error> {
+        if SYSTEMD_RUNTIME_NAME != workload_spec.runtime {
+            return Err(format!(
+                "Received a workload for the wrong runtime: '{}'",
+                workload_spec.runtime
+            ));
+        }
+        let config: Self =
+            serde_yaml::from_str(&workload_spec.runtime_config).map_err(|e| e.to_string())?;
+        validate_service_name(&config.service_name)?;
+        Ok(config)
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//                 ########  #######    #########  #########                //
+//                    ##     ##        ##             ##                    //
+//                    ##     #####     #########      ##                    //
+//                    ##     ##                ##     ##                    //
+//                    ##     #######   #########      ##                    //
+//////////////////////////////////////////////////////////////////////////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ankaios_api::test_utils::generate_test_workload_with_params;
+
+    const DIFFERENT_RUNTIME_NAME: &str = "different-runtime-name";
+
+    #[test]
+    fn utest_systemd_config_failure_missing_service_name() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "something: without_service_name".to_string();
+
+        assert!(SystemdRuntimeConfig::try_from(&workload).is_err());
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_wrong_runtime() {
+        let workload = generate_test_workload_with_params("agent_A", DIFFERENT_RUNTIME_NAME);
+
+        assert!(SystemdRuntimeConfig::try_from(&workload).is_err());
+    }
+
+    #[test]
+    fn utest_systemd_config_success_minimal() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: nginx.service\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Running); // default
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_running() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: nginx.service\ndesiredState: running\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Running);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_stopped() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: cups.service\ndesiredState: stopped\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "cups.service");
+        assert_eq!(config.desired_state, ServiceState::Stopped);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_desired_state_restarted() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config =
+            "serviceName: nginx.service\ndesiredState: restarted\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "nginx.service");
+        assert_eq!(config.desired_state, ServiceState::Restarted);
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_template_unit() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: foo@bar.service\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "foo@bar.service");
+    }
+
+    #[test]
+    fn utest_systemd_config_success_with_timer_unit() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: backup.timer\n".to_string();
+
+        let config = SystemdRuntimeConfig::try_from(&workload).unwrap();
+        assert_eq!(config.service_name, "backup.timer");
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_empty_service_name() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: ''\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must not be empty"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_shell_metacharacters() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: \"test;rm -rf /.service\"\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid characters"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_no_unit_suffix() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: nginx\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("valid systemd unit suffix"));
+    }
+
+    #[test]
+    fn utest_systemd_config_failure_path_traversal() {
+        let mut workload = generate_test_workload_with_params("agent_A", SYSTEMD_RUNTIME_NAME);
+        workload.runtime_config = "serviceName: \"../etc/passwd.service\"\n".to_string();
+
+        let result = SystemdRuntimeConfig::try_from(&workload);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid characters"));
+    }
+}

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -43,6 +43,16 @@ pub struct StateGenerationResult {
     pub new_agent_map: AgentMapSpec,
 }
 
+fn is_transient_restart_workload(workload: &WorkloadNamed) -> bool {
+    if workload.workload.runtime != "systemd" {
+        return false;
+    }
+    serde_yaml::from_str::<serde_yaml::Value>(&workload.workload.runtime_config)
+        .ok()
+        .and_then(|v| v.get("desiredState").and_then(|s| s.as_str()).map(|s| s == "restarted"))
+        .unwrap_or(false)
+}
+
 fn extract_added_and_deleted_workloads(
     current_workloads: &RenderedWorkloads,
     new_workloads: &RenderedWorkloads,
@@ -54,7 +64,8 @@ fn extract_added_and_deleted_workloads(
     current_workloads.iter().for_each(|(wl_name, wls)| {
         if let Some(new_wls) = new_workloads.get(wl_name) {
             // The new workload is identical with existing or updated. Lets check if it is an update.
-            if wls != new_wls {
+            // Restart workloads are ALWAYS treated as updates, even if identical
+            if wls != new_wls || is_transient_restart_workload(new_wls) {
                 // [impl->swdd~server-detects-changed-workload~1]
                 added_workloads.push(new_wls.clone());
                 deleted_workloads.push(DeletedWorkload {
@@ -370,6 +381,19 @@ impl ServerState {
 
             self.set_desired_state(new_desired_state);
             self.pre_hook_rendered_workloads = pre_hook_rendered_workloads;
+
+            // Filter out transient restart workloads — they are one-time actions, not persistent state
+            new_rendered_workloads.retain(|_, workload| {
+                let transient = is_transient_restart_workload(workload);
+                if transient {
+                    log::debug!(
+                        "Removing transient restart workload '{}' from rendered_workloads",
+                        workload.instance_name.workload_name()
+                    );
+                }
+                !transient
+            });
+
             self.rendered_workloads = new_rendered_workloads;
             Ok(Some(added_deleted_workloads))
         } else {
@@ -1971,5 +1995,118 @@ mod tests {
         w4.workload.dependencies.dependencies.clear();
 
         generate_test_complete_state(vec![w1, w3, w4])
+    }
+
+    #[test]
+    fn utest_extract_forces_update_for_restart_workload() {
+        let mut workload = generate_test_workload_named_with_params(
+            fixtures::WORKLOAD_NAMES[0],
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+
+        let rendered = RenderedWorkloads::from([(
+            fixtures::WORKLOAD_NAMES[0].to_string(),
+            workload.clone(),
+        )]);
+
+        let result = extract_added_and_deleted_workloads(&rendered, &rendered);
+        assert!(result.is_some());
+
+        let AddedDeletedWorkloads {
+            added_workloads,
+            deleted_workloads,
+        } = result.unwrap();
+        assert_eq!(added_workloads.len(), 1);
+        assert_eq!(deleted_workloads.len(), 1);
+        assert_eq!(
+            added_workloads[0].instance_name.workload_name(),
+            fixtures::WORKLOAD_NAMES[0]
+        );
+    }
+
+    #[test]
+    fn utest_extract_no_update_for_identical_non_restart_workload() {
+        let mut workload = generate_test_workload_named_with_params(
+            fixtures::WORKLOAD_NAMES[0],
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: running\n".to_string();
+
+        let rendered = RenderedWorkloads::from([(
+            fixtures::WORKLOAD_NAMES[0].to_string(),
+            workload.clone(),
+        )]);
+
+        let result = extract_added_and_deleted_workloads(&rendered, &rendered);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn utest_update_filters_transient_restart_workload() {
+        let mut restart_workload = generate_test_workload_named_with_params(
+            "restart_wl",
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        restart_workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        restart_workload.workload.dependencies.dependencies.clear();
+
+        let mut normal_workload = generate_test_workload_named_with_params(
+            "normal_wl",
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        normal_workload.workload.runtime_config =
+            "serviceName: other.service\ndesiredState: running\n".to_string();
+        normal_workload.workload.dependencies.dependencies.clear();
+
+        let new_rendered = RenderedWorkloads::from([
+            ("restart_wl".to_string(), restart_workload.clone()),
+            ("normal_wl".to_string(), normal_workload.clone()),
+        ]);
+
+        let new_state = generate_test_state_from_workloads(vec![
+            restart_workload.clone(),
+            normal_workload.clone(),
+        ]);
+
+        let mut mock_config_renderer = MockConfigRenderer::default();
+        mock_config_renderer
+            .expect_render_workloads()
+            .once()
+            .return_once(move |_, _| Ok(new_rendered));
+
+        let mut mock_delete_graph = MockDeleteGraph::default();
+        mock_delete_graph.expect_insert().return_const(());
+        mock_delete_graph
+            .expect_apply_delete_conditions_to()
+            .return_const(());
+
+        let mut server_state = ServerState {
+            state: CompleteStateSpec::default(),
+            rendered_workloads: RenderedWorkloads::default(),
+            pre_hook_rendered_workloads: RenderedWorkloads::default(),
+            delete_graph: mock_delete_graph,
+            config_renderer: mock_config_renderer,
+        };
+
+        let hooks_registry = HooksRegistry::default();
+        let result = server_state.update(new_state, &hooks_registry);
+        assert!(result.is_ok());
+
+        assert!(
+            !server_state.rendered_workloads.contains_key("restart_wl"),
+            "Transient restart workload should be filtered from rendered_workloads"
+        );
+        assert!(
+            server_state.rendered_workloads.contains_key("normal_wl"),
+            "Non-restart workload should be kept in rendered_workloads"
+        );
     }
 }

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -290,6 +290,11 @@ impl ServerState {
         self.rendered_workloads
             .iter()
             .filter(|(_, workload)| workload.instance_name.agent_name().eq(agent_name))
+            // Transient restart workloads are one-time actions and must not be (re-)sent to an
+            // agent when it connects. Otherwise the restart would be re-triggered on every
+            // reconnect, which could result in an infinite restart loop when the restart targets
+            // the agent itself.
+            .filter(|(_, workload)| !is_transient_restart_workload(workload))
             .map(|(_, workload)| workload.clone())
             .collect()
     }
@@ -381,18 +386,6 @@ impl ServerState {
 
             self.set_desired_state(new_desired_state);
             self.pre_hook_rendered_workloads = pre_hook_rendered_workloads;
-
-            // Filter out transient restart workloads — they are one-time actions, not persistent state
-            new_rendered_workloads.retain(|_, workload| {
-                let transient = is_transient_restart_workload(workload);
-                if transient {
-                    log::debug!(
-                        "Removing transient restart workload '{}' from rendered_workloads",
-                        workload.instance_name.workload_name()
-                    );
-                }
-                !transient
-            });
 
             self.rendered_workloads = new_rendered_workloads;
             Ok(Some(added_deleted_workloads))
@@ -2047,7 +2040,7 @@ mod tests {
     }
 
     #[test]
-    fn utest_update_filters_transient_restart_workload() {
+    fn utest_update_keeps_transient_restart_workload_in_rendered_workloads() {
         let mut restart_workload = generate_test_workload_named_with_params(
             "restart_wl",
             fixtures::AGENT_NAMES[0],
@@ -2100,13 +2093,62 @@ mod tests {
         let result = server_state.update(new_state, &hooks_registry);
         assert!(result.is_ok());
 
+        // The transient restart workload stays in the rendered workloads so that it remains
+        // part of the effective state, log requests and change detection.
         assert!(
-            !server_state.rendered_workloads.contains_key("restart_wl"),
-            "Transient restart workload should be filtered from rendered_workloads"
+            server_state.rendered_workloads.contains_key("restart_wl"),
+            "Transient restart workload should be kept in rendered_workloads"
         );
         assert!(
             server_state.rendered_workloads.contains_key("normal_wl"),
             "Non-restart workload should be kept in rendered_workloads"
+        );
+    }
+
+    // [utest->swdd~agent-from-agent-field~1]
+    #[test]
+    fn utest_get_workloads_for_agent_filters_transient_restart_workload() {
+        let mut restart_workload = generate_test_workload_named_with_params(
+            "restart_wl",
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        restart_workload.workload.runtime_config =
+            "serviceName: test.service\ndesiredState: restarted\n".to_string();
+        restart_workload.workload.dependencies.dependencies.clear();
+
+        let mut normal_workload = generate_test_workload_named_with_params(
+            "normal_wl",
+            fixtures::AGENT_NAMES[0],
+            "systemd",
+        );
+        normal_workload.workload.runtime_config =
+            "serviceName: other.service\ndesiredState: running\n".to_string();
+        normal_workload.workload.dependencies.dependencies.clear();
+
+        let rendered = RenderedWorkloads::from([
+            ("restart_wl".to_string(), restart_workload.clone()),
+            ("normal_wl".to_string(), normal_workload.clone()),
+        ]);
+
+        let server_state = ServerState {
+            rendered_workloads: rendered,
+            ..Default::default()
+        };
+
+        let workloads = server_state.get_workloads_for_agent(fixtures::AGENT_NAMES[0]);
+        let workload_names: Vec<&str> = workloads
+            .iter()
+            .map(|w| w.instance_name.workload_name())
+            .collect();
+
+        assert!(
+            !workload_names.contains(&"restart_wl"),
+            "Transient restart workload must not be sent to a (re)connecting agent"
+        );
+        assert!(
+            workload_names.contains(&"normal_wl"),
+            "Non-restart workload must be sent to a (re)connecting agent"
         );
     }
 }

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -43,8 +43,10 @@ pub struct StateGenerationResult {
     pub new_agent_map: AgentMapSpec,
 }
 
+const SYSTEMD_RUNTIME: &str = "systemd";
+
 fn is_transient_restart_workload(workload: &WorkloadNamed) -> bool {
-    if workload.workload.runtime != "systemd" {
+    if workload.workload.runtime != SYSTEMD_RUNTIME {
         return false;
     }
     serde_yaml::from_str::<serde_yaml::Value>(&workload.workload.runtime_config)


### PR DESCRIPTION
Add systemd runtime support for managing existing services

Implements a new systemd runtime connector that enables Ankaios to
manage existing systemd services alongside container workloads.
Uses the new non-generic RuntimeConnector/RuntimeStateGetter traits
with RuntimeWorkloadId and StateCheckerHandle, matching the simplified
pluggable runtime architecture.

Features:
- Start, stop, and restart existing systemd services
- Monitor service state via systemctl show
- Stream logs via journalctl integration
- Support for three desired states: running, stopped, restarted
- Smart restart handling: skips restart if service was restarted recently
- Transient restart workloads: always trigger even if manifest unchanged
- Input validation on service names (safe characters and unit suffix)
- Full test coverage (43 unit tests including error paths)

Architecture:
- SystemdCli: Wrapper for systemctl commands using CliCommand pattern
- SystemdRuntime: Implements RuntimeConnector trait
- SystemdStateGetter: Implements RuntimeStateGetter trait
- SystemdLogFetcher: Streams logs via journalctl with follow/tail/since/until
- SystemdRuntimeConfig: Parses YAML configuration with serviceName and desiredState
- Registered via Box<dyn OwnableRuntime> array (no macro)

Design decisions:
- No unit file creation/deletion (only manages existing services)
- No reusability tracking (always reconciles to desired state)
- No control interface support (can't inject env vars into existing services)
- No file mappings (no container abstraction)
- Polling-based state monitoring (500ms interval)
- Uptime-based restart deduplication for agent self-restart scenarios
- Server detects restart workloads via YAML parsing (not string matching)
- Server treats restart workloads as transient (always sends, even if identical)

Restart handling rationale:
When restarting the ank-agent service itself, the agent reconnects after
restart and receives the same restart workload again from the server.
Two mechanisms work together:
1. Agent-side: Check service uptime, skip if recent (prevents duplicate restart)
2. Server-side: Always send restart workloads, even if identical (allows repeated restarts)

This enables multiple restart attempts while preventing spurious restarts
during agent reconnection.

Example usage:
```
  workloads:
    nginx:
      runtime: systemd
      agent: agent_A
      runtimeConfig: |
        serviceName: nginx.service
        desiredState: running
```

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
