### PR TITLE
Split sonarcloud workflow to allow forks access to the SONAR_TOKEN for the scan

### DIFF
--- a/.github/workflows/sonarcloud-pr-scan.yml
+++ b/.github/workflows/sonarcloud-pr-scan.yml
@@ -1,0 +1,75 @@
+# Copyright (c) 2026 Elektrobit Automotive GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs the actual SonarCloud upload for pull requests. Split out from
+# sonarcloud.yml because fork PRs never receive SONAR_TOKEN. workflow_run runs
+# in the trusted base branch context and only downloads already-built reports
+# - it never builds or executes PR code.
+name: SonarCloud PR Scan
+
+on:
+  workflow_run:
+    workflows: ["SonarCloud Analysis"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: "sonarcloud-pr-scan-${{ github.event.workflow_run.id }}"
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download analysis reports
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sonar-reports
+          path: target/sonar
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          {
+            echo "number=$(jq -r .number target/sonar/pr.json)"
+            echo "head_sha=$(jq -r .headSha target/sonar/pr.json)"
+            echo "head_ref=$(jq -r .headRef target/sonar/pr.json)"
+            echo "base_ref=$(jq -r .baseRef target/sonar/pr.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.pullrequest.key=${{ steps.pr.outputs.number }}
+            -Dsonar.pullrequest.branch=${{ steps.pr.outputs.head_ref }}
+            -Dsonar.pullrequest.base=${{ steps.pr.outputs.base_ref }}
+            -Dsonar.pullrequest.provider=github
+            -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.scm.revision=${{ steps.pr.outputs.head_sha }}
+            -Dsonar.qualitygate.wait=true

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -96,7 +96,35 @@ jobs:
           lcov_to_sonar(sys.argv[1], sys.argv[2])
           PYEOF
 
+      # Secrets are withheld from pull_request runs opened by Dependabot or from forks,
+      # so the scan itself can't happen here. Persist the reports + PR metadata as an
+      # artifact and let the trusted sonarcloud-pr-scan.yml (workflow_run) do the upload.
+      - name: Save PR metadata
+        if: github.event_name == 'pull_request'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          jq -n \
+            --arg number "$PR_NUMBER" \
+            --arg headSha "$PR_HEAD_SHA" \
+            --arg headRef "$PR_HEAD_REF" \
+            --arg baseRef "$PR_BASE_REF" \
+            '{number: $number, headSha: $headSha, headRef: $headRef, baseRef: $baseRef}' \
+            > target/sonar/pr.json
+
+      - name: Upload sonar reports
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: sonar-reports
+          path: target/sonar
+          retention-days: 1
+
       - name: SonarCloud Scan
+        if: github.event_name == 'push'
         uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -107,13 +107,15 @@ jobs:
           PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
           PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          jq -n \
-            --arg number "$PR_NUMBER" \
-            --arg headSha "$PR_HEAD_SHA" \
-            --arg headRef "$PR_HEAD_REF" \
-            --arg baseRef "$PR_BASE_REF" \
-            '{number: $number, headSha: $headSha, headRef: $headRef, baseRef: $baseRef}' \
-            > target/sonar/pr.json
+          python3 -c "
+          import json, os
+          json.dump({
+              'number': os.environ['PR_NUMBER'],
+              'headSha': os.environ['PR_HEAD_SHA'],
+              'headRef': os.environ['PR_HEAD_REF'],
+              'baseRef': os.environ['PR_BASE_REF'],
+          }, open('target/sonar/pr.json', 'w'))
+          "
 
       - name: Upload sonar reports
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Issues: https://github.com/eclipse-ankaios/ank-sdk-rust/issues/78

Same issue as in the Rust SDK. The solution is identical.

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
