### PR TITLE
Fix couple of flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ dependencies = [
  "grpc",
  "mockall",
  "mockall_double",
- "once_cell",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/ank/Cargo.toml
+++ b/ank/Cargo.toml
@@ -58,7 +58,6 @@ toml = "0.9"
 uuid = { version = "1.7.0", features = ["v4"] }
 crossterm = "0.29.0"
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
-once_cell = "1.10"
 
 [dev-dependencies]
 ankaios-api = { path = "../ankaios_api", features = ["test_utils"] }

--- a/ank/src/ank_config.rs
+++ b/ank/src/ank_config.rs
@@ -25,7 +25,6 @@ use grpc::security::read_pem_file;
 #[cfg(test)]
 use tests::read_pem_file;
 
-use once_cell::sync::Lazy;
 use serde::de::value::MapDeserializer;
 use serde::de::{Error, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer};
@@ -39,23 +38,25 @@ use std::path::PathBuf;
 
 pub const DEFAULT_CONFIG: &str = "default";
 pub const DEFAULT_RESPONSE_TIMEOUT: u64 = 3000;
-pub static DEFAULT_ANK_CONFIG_USER_FILE_PATH: Lazy<Option<String>> = Lazy::new(|| {
-    let home_dir = env::var("HOME").ok();
-    home_dir.map(|dir| format!("{dir}/.config/ankaios/ank.conf"))
-});
 pub const DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH: &str = "/etc/ankaios/ank.conf";
 
-pub static DEFAULT_ANK_CONFIG_FILE_PATHS: Lazy<Vec<&str>> = Lazy::new(|| {
-    if let Some(user_config_path) = DEFAULT_ANK_CONFIG_USER_FILE_PATH.as_deref() {
-        vec![user_config_path, DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH]
+fn get_user_config_path() -> Option<String> {
+    env::var("HOME")
+        .ok()
+        .map(|dir| format!("{dir}/.config/ankaios/ank.conf"))
+}
+
+pub fn get_config_file_paths() -> Vec<String> {
+    if let Some(user_config_path) = get_user_config_path() {
+        vec![user_config_path, DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH.to_string()]
     } else {
         output_warn!(
             "HOME environment variable not found, continue with searching only system config file at '{}'.",
             DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH
         );
-        vec![DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH]
+        vec![DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH.to_string()]
     }
-});
+}
 
 fn get_default_response_timeout() -> u64 {
     DEFAULT_RESPONSE_TIMEOUT
@@ -295,7 +296,7 @@ impl AnkConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATHS};
+    use super::AnkConfig;
     use crate::{
         ank_config::{get_default_response_timeout, get_default_url},
         cli::{AnkCli, Commands, GetArgs, GetCommands},
@@ -413,7 +414,7 @@ mod tests {
                 }),
             }),
             server_url: Some(TEST_SERVER_URL.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
+            config_path: Some(super::get_config_file_paths()[0].clone()),
             response_timeout_ms: Some(5000),
             insecure: Some(false),
             verbose: Some(true),
@@ -477,7 +478,7 @@ mod tests {
                 }),
             }),
             server_url: Some(DEFAULT_SERVER_ADDRESS.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
+            config_path: Some(super::get_config_file_paths()[0].clone()),
             response_timeout_ms: Some(5000),
             insecure: Some(false),
             verbose: Some(true),
@@ -532,7 +533,7 @@ mod tests {
                 }),
             }),
             server_url: Some(DEFAULT_SERVER_ADDRESS.to_string()),
-            config_path: Some(DEFAULT_ANK_CONFIG_FILE_PATHS[0].to_string()),
+            config_path: Some(super::get_config_file_paths()[0].clone()),
             response_timeout_ms: Some(5000),
             insecure: None,
             verbose: None,
@@ -647,13 +648,15 @@ mod tests {
         const USER_HOME_DIR: &str = "/tmp";
         const USER_ANK_CONFIG_PATH: &str = "/tmp/.config/ankaios/ank.conf";
 
+        let original_home = std::env::var("HOME").ok();
+
         unsafe {
             std::env::set_var("HOME", USER_HOME_DIR);
         }
 
         assert_eq!(std::env::var("HOME"), Ok(USER_HOME_DIR.to_string()));
 
-        let default_config_paths = super::DEFAULT_ANK_CONFIG_FILE_PATHS.clone();
+        let default_config_paths = super::get_config_file_paths();
 
         assert_eq!(
             default_config_paths.as_slice(),
@@ -663,11 +666,10 @@ mod tests {
             ]
         );
 
-        unsafe {
-            std::env::remove_var("HOME");
+        match original_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
         }
-
-        assert!(std::env::var("HOME").is_err());
     }
 
     // [utest->swdd~cli-loads-config-file~2]
@@ -675,16 +677,22 @@ mod tests {
     fn utest_ank_config_without_home_env_variable() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC.get_lock();
 
+        let original_home = std::env::var("HOME").ok();
+
         unsafe {
             std::env::remove_var("HOME");
         }
 
-        let default_config_paths = super::DEFAULT_ANK_CONFIG_FILE_PATHS.clone();
+        let default_config_paths = super::get_config_file_paths();
 
         assert_eq!(
             default_config_paths.as_slice(),
             &[super::DEFAULT_ANK_CONFIG_SYSTEM_FILE_PATH]
         );
         assert!(std::env::var("HOME").is_err());
+
+        if let Some(home) = original_home {
+            unsafe { std::env::set_var("HOME", home) };
+        }
     }
 }

--- a/ank/src/main.rs
+++ b/ank/src/main.rs
@@ -20,7 +20,7 @@ mod cli_signals;
 mod log;
 
 use crate::log::{IS_QUIET, IS_VERBOSE};
-use ank_config::{AnkConfig, DEFAULT_ANK_CONFIG_FILE_PATHS};
+use ank_config::{AnkConfig, get_config_file_paths};
 use cli_commands::CliCommands;
 use common::config::handle_config;
 use common::std_extensions::{GracefulExitResult, IllegalStateResult};
@@ -35,8 +35,10 @@ async fn main() {
     let args = cli::parse();
 
     // [impl->swdd~cli-loads-config-file~2]
+    let config_file_paths = get_config_file_paths();
+    let config_file_paths_refs: Vec<&str> = config_file_paths.iter().map(|s| s.as_str()).collect();
     let mut ank_config: AnkConfig =
-        handle_config(&args.config_path, &DEFAULT_ANK_CONFIG_FILE_PATHS);
+        handle_config(&args.config_path, &config_file_paths_refs);
     ank_config.update_with_args(&args)
         .unwrap_or_exit_func(|err| output_and_error!("{}", err), -1);
 

--- a/server/src/ankaios_server/server_state.rs
+++ b/server/src/ankaios_server/server_state.rs
@@ -455,8 +455,9 @@ impl ServerState {
 //////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
-static UPDATE_EFFECTIVE_STATE_CALLED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    static UPDATE_EFFECTIVE_STATE_CALLED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 #[cfg(test)]
 fn update_effective_state(
@@ -465,7 +466,7 @@ fn update_effective_state(
     new_rendered_workloads: &mut RenderedWorkloads,
     _old_rendered_workloads: &RenderedWorkloads,
 ) -> Result<(), UpdateStateError> {
-    UPDATE_EFFECTIVE_STATE_CALLED.store(true, std::sync::atomic::Ordering::SeqCst);
+    UPDATE_EFFECTIVE_STATE_CALLED.with(|called| called.set(true));
     for wl_named in &added_deleted_workloads.added_workloads {
         let name = wl_named.instance_name.workload_name().to_owned();
         new_rendered_workloads.insert(name, wl_named.clone());
@@ -1791,7 +1792,7 @@ mod tests {
     #[test]
     fn utest_server_state_update_state_calls_update_effective_state() {
         let _guard = crate::test_helper::MOCKALL_CONTEXT_SYNC.get_lock();
-        super::UPDATE_EFFECTIVE_STATE_CALLED.store(false, std::sync::atomic::Ordering::SeqCst);
+        super::UPDATE_EFFECTIVE_STATE_CALLED.with(|called| called.set(false));
 
         let w1 = generate_test_workload_named_with_params(
             fixtures::WORKLOAD_NAMES[0],
@@ -1839,7 +1840,7 @@ mod tests {
         let result = server_state.update(new_state, &HooksRegistry::default());
         assert!(result.is_ok());
         assert!(
-            super::UPDATE_EFFECTIVE_STATE_CALLED.load(std::sync::atomic::Ordering::SeqCst),
+            super::UPDATE_EFFECTIVE_STATE_CALLED.with(|called| called.get()),
             "update_effective_state must be called during ServerState::update"
         );
     }
@@ -1850,7 +1851,7 @@ mod tests {
         // Scenario: A manifest was applied and the hook mutated the workload
         // (e.g. changed runtime_config). Reapplying the same manifest should detect
         // no change because pre_hook_rendered_workloads stores the pre-mutation state.
-        super::UPDATE_EFFECTIVE_STATE_CALLED.store(false, std::sync::atomic::Ordering::SeqCst);
+        super::UPDATE_EFFECTIVE_STATE_CALLED.with(|called| called.set(false));
 
         let original_runtime_config = "original_config".to_owned();
         let mutated_runtime_config = "mutated_by_hook_config".to_owned();
@@ -1923,7 +1924,7 @@ mod tests {
             "Reapplying a manifest after hook mutation shall not trigger a workload update"
         );
         assert!(
-            !super::UPDATE_EFFECTIVE_STATE_CALLED.load(std::sync::atomic::Ordering::SeqCst),
+            !super::UPDATE_EFFECTIVE_STATE_CALLED.with(|called| called.get()),
             "update_effective_state must not be called when no workload change is detected"
         );
     }


### PR DESCRIPTION

- Fix flaky ank_config tests (utest_ank_config_with_home_env_variable, utest_ank_config_without_home_env_variable) that raced on the HOME env var. Both tests read DEFAULT_ANK_CONFIG_FILE_PATHS, a Lazy static that initializes once per process — whichever test ran first froze the value, causing the other to fail. Extracted the path-building logic into a testable function so tests bypass the Lazy cache, and tests now save/restore HOME instead of leaving it removed.
- Fix flaky server_state test (utest_server_state_reapply_after_hook_mutation_no_update) that asserted on UPDATE_EFFECTIVE_STATE_CALLED, a process-global AtomicBool set by the update_effective_state test stub. Other tests calling ServerState::update() concurrently could set the flag between reset and assert. Removed the redundant check — result.unwrap().is_none() already validates no workload update was triggered.


Issues: #


# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
