### PR TITLE
Add warning for insecure installation methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ __pycache__
 
 # ignore nohup file for postStartCommand
 nohup.out
+
+# Claude local config
+.claude/settings.local.json
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -796,7 +796,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1010,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2247,7 +2247,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2490,7 +2490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2606,7 +2606,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/doc/docs/usage/installation.md
+++ b/doc/docs/usage/installation.md
@@ -158,9 +158,14 @@ The `ankaios` meta-package installs all components. Individual packages can be i
 | `ank-agent` | Ankaios agent |
 | `ank` | Ankaios CLI |
 
-!!! note
+!!! Warning
 
-    The `ank-server` and `ank-agent` systemd services are started automatically after installation.
+    The APT package installation does not enable any authentication for access to
+    the Ankaios server (see [Setting up Ankaios with mTLS](mtls-setup.md)).
+    Since the  `ank-server` and `ank-agent` systemd services are started
+    automatically after installation, any client that can reach the `ank-server`
+    could start workloads with root privileges. For this reason, only use this
+    setup for development purposes.
 
 The packages are compatible with Ubuntu 22.04+, Debian 12+ and other distributions based on glibc 2.35 or later.
 

--- a/doc/docs/usage/installation.md
+++ b/doc/docs/usage/installation.md
@@ -14,6 +14,14 @@ Ankaios works with most Linux distributions and has been tested with Ubuntu 22.0
 
 Detailed installation steps, including instructions on setting up container runtimes, choosing an installation method, and installing specific Ankaios versions, are provided below.
 
+!!! Warning
+
+    The express installation does not enable any authentication for access to
+    the Ankaios server (see [Setting up Ankaios with mTLS](mtls-setup.md)).
+    Since the server is typically run as root (e.g. via `sudo systemctl`),
+    any client that can reach it could start workloads with root privileges.
+    For this reason, only use this setup for development purposes.
+
 ## System requirements
 
 Ankaios currently requires a Linux OS and is available for x86_64 and arm64

--- a/doc/docs/usage/installation.md
+++ b/doc/docs/usage/installation.md
@@ -230,6 +230,14 @@ You can also install:
 
     `sudo systemctl enable --now ank-server ank-agent`
 
+!!! Warning
+
+    The AUR package installation does not enable any authentication for access to the Ankaios server
+    (see [Setting up Ankaios with mTLS](mtls-setup.md)).
+    After starting the `ank-server` and `ank-agent` systemd services,
+    any client that can reach the `ank-server` could start workloads with root privileges.
+    For this reason, only use this setup for development purposes.
+
 #### Uninstall
 
 ```shell

--- a/doc/docs/usage/mtls-setup.md
+++ b/doc/docs/usage/mtls-setup.md
@@ -231,3 +231,6 @@ Alternatively, you can pass the mTLS certificates as command line arguments:
 ```shell
 ank --ca_pem=/etc/ankaios/certs/ca.pem --crt_pem="${XDG_CONFIG_HOME:-$HOME/.config}/ankaios/ank.pem" --key_pem="${XDG_CONFIG_HOME:-$HOME/.config}/ankaios/ank-key.pem" get workloads
 ```
+
+Or you can also configure the mTLS certificates in the CLI configuration file `~/.config/ankaios/ank.conf`.
+In any case you should set `insecure = false` in there to prevent a warning when mTLS certificates are provided.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -275,4 +275,32 @@ EOF
 ${BIN_SUDO} chmod +x "${BIN_DESTINATION}/${BASEFILE_ANK_UNINSTALL}"
 echo "Created uninstall script ${BIN_DESTINATION}/${BASEFILE_ANK_UNINSTALL}."
 
+
+if [ -t 1 ]; then
+    WARN_COLOR="$(printf '\033[1;33m')"
+    RESET_COLOR="$(printf '\033[0m')"
+else
+    WARN_COLOR=""
+    RESET_COLOR=""
+fi
+
+cat << EOF
+
+${WARN_COLOR}!!!!!!!!!!!!!!!!!!!!!!!!!!!! SECURITY WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  The install script does NOT enable any authentication for access to the
+  Ankaios server.
+
+  Since the server is typically run as root (e.g. via "sudo systemctl"), any
+  client that can reach it could start workloads with root privileges.
+
+  To secure your setup, see "Setting up Ankaios with mTLS" in the docs:
+  https://eclipse-ankaios.github.io/ankaios/latest/usage/mtls-setup/
+
+  ==> Only use this setup for development purposes. <==
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${RESET_COLOR}
+
+EOF
+
 echo "Installation has finished."


### PR DESCRIPTION
Currently there is no warning in the documentation that priviledge escaltion might occur with express installation. This PR adds one.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [ ] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
