### PR TITLE
Fix hooks config typos in ank-server.conf

### DIFF
--- a/server/config/ank-server.conf
+++ b/server/config/ank-server.conf
@@ -46,11 +46,11 @@ insecure = true
 # as unstable and can change at any time.
 # Each hook has a name and a priority ('prio') that
 # determines the order in which hooks are executed (lower runs first).
-# [[mutating_hook]]
+# [[mutating_hooks]]
 # name = 'validate-resources'
 # prio = 10
 
-# [[mutating_hook]]
+# [[mutating_hooks]]
 # name = 'inject-defaults'
 # prio = 20
 # path = '/custom/hooks/path'


### PR DESCRIPTION
Fixes accidentially used singular form of the mutating_hooks config item in the ank-server.conf example.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
