### PR TITLE
Prevent scoped wildcard rules from matching empty paths

### DIFF
--- a/agent/src/control_interface/authorizer.rs
+++ b/agent/src/control_interface/authorizer.rs
@@ -393,6 +393,42 @@ mod test {
     }
 
     // [utest->swdd~agent-authorizing-request-operations~2]
+    // [utest->swdd~agent-authorizing-matching-allow-rules~1]
+    #[test]
+    fn utest_scoped_leading_wildcard_rule_does_not_authorize_empty_masks() {
+        // A rule scoped to one subtree must not authorize a request that names
+        // no path at all. Both request kinds go through the shared matcher, so
+        // both are checked here: an empty field mask is a complete-state read
+        // and an empty update mask is a replacement-state write.
+        let complete_state_request = Request {
+            request_id: "".into(),
+            request_content: Some(RequestContent::CompleteStateRequest(CompleteStateRequest {
+                field_mask: vec![],
+                subscribe_for_events: false,
+            })),
+        };
+        let update_state_request = Request {
+            request_id: "".into(),
+            request_content: Some(RequestContent::UpdateStateRequest(Box::new(
+                UpdateStateRequest {
+                    new_state: Default::default(),
+                    update_mask: vec![],
+                },
+            ))),
+        };
+
+        let authorizer = populate_authorizer(
+            Authorizer::default(),
+            &[RuleType::StateAllowReadWrite(vec![
+                "*.workloads.some_workload".into(),
+            ])],
+        );
+
+        assert!(!authorizer.authorize(&complete_state_request));
+        assert!(!authorizer.authorize(&update_state_request));
+    }
+
+    // [utest->swdd~agent-authorizing-request-operations~2]
     // [utest->swdd~agent-authorizing-condition-element-filter-mask-allowed~1]
     #[test]
     fn utest_read_requests_operations() {

--- a/agent/src/control_interface/authorizer/path_pattern.rs
+++ b/agent/src/control_interface/authorizer/path_pattern.rs
@@ -51,7 +51,7 @@ impl PathPattern for AllowPathPattern {
 
     fn matches(&self, other: &Path) -> (bool, PathPatternMatchReason) {
         if self.sections.len() > other.sections.len()
-            && self.sections.first() != Some(&PathPatternSection::Wildcard)
+            && !matches!(self.sections.as_slice(), [PathPatternSection::Wildcard])
         {
             return (false, String::new());
         }
@@ -239,6 +239,23 @@ mod tests {
         assert!(p.matches(&"some.pre.fix.test".into()).0);
     }
 
+    // [utest->swdd~agent-authorizing-matching-allow-rules~1]
+    #[test]
+    fn utest_allow_path_pattern_with_wildcard_at_start() {
+        let p = AllowPathPattern::from("*.workloads.some_workload");
+
+        assert!(!p.matches(&"".into()).0);
+        assert!(!p.matches(&"desiredState".into()).0);
+        assert!(!p.matches(&"desiredState.workloads".into()).0);
+        assert!(!p.matches(&"desiredState.other".into()).0);
+        assert!(p.matches(&"desiredState.workloads.some_workload".into()).0);
+        assert!(p.matches(&"other.workloads.some_workload".into()).0);
+        assert!(
+            p.matches(&"desiredState.workloads.some_workload.tags".into())
+                .0
+        );
+    }
+
     // [utest->swdd~agent-authorizing-rules-without-segments-never-match~1]
     #[test]
     fn utest_empty_allow_path_pattern_does_not_match() {
@@ -300,11 +317,22 @@ mod tests {
     // [utest->swdd~agent-authorizing-matching-deny-rules~1]
     #[test]
     fn utest_deny_path_pattern_with_wildcard_only() {
-        let p = AllowPathPattern::from("*");
+        let p = DenyPathPattern::from("*");
 
         assert!(p.matches(&"".into()).0);
         assert!(p.matches(&"some".into()).0);
         assert!(p.matches(&"some.pre.fix.test".into()).0);
+    }
+
+    // [utest->swdd~agent-authorizing-matching-deny-rules~1]
+    #[test]
+    fn utest_deny_path_pattern_with_wildcard_at_start() {
+        let p = DenyPathPattern::from("*.pre.fix");
+
+        assert!(p.matches(&"".into()).0);
+        assert!(!p.matches(&"some.bla".into()).0);
+        assert!(p.matches(&"some.pre.fix".into()).0);
+        assert!(p.matches(&"other.pre.fix".into()).0);
     }
 
     // [utest->swdd~agent-authorizing-rules-without-segments-never-match~1]


### PR DESCRIPTION
Only allow a leading wildcard to match shorter paths when the rule consists solely of that wildcard.
Add regression tests for allow and deny patterns, including requests with empty field and update masks.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
