### PR TITLE
Add message size check for Control Interface input

### DIFF
--- a/agent/doc/swdesign/README.md
+++ b/agent/doc/swdesign/README.md
@@ -3686,6 +3686,26 @@ Needs:
 - impl
 - utest
 
+#### Agent rejects oversized Control Interface messages
+`swdd~agent-rejects-oversized-control-interface-messages~1`
+
+Status: approved
+
+The Ankaios Agent shall reject Control Interface messages with a declared protobuf payload size greater than 4 MiB minus 256 bytes before allocating the payload buffer.
+
+Comment:
+The 256-byte reserve accounts for the message-dependent protobuf envelope and request ID prefixes added when forwarding a Control Interface request via gRPC, whose default receive limit is 4 MiB.
+
+Rationale:
+The payload size is supplied by a workload and must not cause unbounded memory allocation in the Ankaios Agent.
+
+Tags:
+- ControlInterface
+
+Needs:
+- impl
+- utest
+
 #### Agent listens for Control Interface requests from the output pipe
 `swdd~agent-listens-for-requests-from-pipe~1`
 

--- a/agent/src/control_interface/control_interface_task.rs
+++ b/agent/src/control_interface/control_interface_task.rs
@@ -82,8 +82,7 @@ impl ControlInterfaceTask {
     async fn check_initial_hello(&mut self) -> Result<(), String> {
         let to_ankaios =
             decode_to_server(self.input_stream.read_protobuf_data().await).map_err(|err| {
-                log::debug!("{PROTOBUF_DECODE_ERROR_MSG}: '{err:?}'");
-                PROTOBUF_DECODE_ERROR_MSG.to_string()
+                format!("{PROTOBUF_DECODE_ERROR_MSG}: '{err:?}'")
             })?;
         match to_ankaios.try_into() {
             Ok(ToAnkaios::Hello(Hello { protocol_version })) => {
@@ -139,47 +138,50 @@ impl ControlInterfaceTask {
                 }
                 // [impl->swdd~agent-listens-for-requests-from-pipe~1]
                 to_ankaios_binary = self.input_stream.read_protobuf_data() => {
-                    if let Ok(to_ankaios) = decode_to_server(to_ankaios_binary) {
-                        // [impl->swdd~agent-converts-control-interface-message-to-ankaios-object~1]
-                        match to_ankaios.try_into() {
-                            Ok(ToAnkaios::Request(mut request)) => {
-                                // [impl->swdd~agent-checks-request-for-authorization~1]
-                                if self.authorizer.authorize(&request) {
-                                    // [impl->swdd~agent-forward-request-from-control-interface-pipe-to-server~2]
-                                    log::debug!("Allowing request '{:?}' from authorizer '{:?}'", request, self.authorizer);
-                                    request.prefix_request_id(&self.request_id_prefix);
-                                    let _ = self.to_server_sender.send(ToServer::Request(request)).await;
-                                } else {
-                                    log::info!("Denying request '{:?}' from authorizer '{:?}'", request, self.authorizer);
-                                    // [impl->swdd~agent-responses-to-denied-request-from-control-interface~1]
-                                    // [impl->swdd~agent-responses-to-denied-request-from-control-interface-contains-request-id~1]
-                                    let error = ank_base::Response {
-                                        request_id: request.request_id,
-                                        response_content: Some(ank_base::response::ResponseContent::Error(ank_base::Error {
-                                            message: "Access denied".into(),
-                                        })),
-                                    };
-                                    let _ = self.forward_from_server(error).await;
+                    match decode_to_server(to_ankaios_binary) {
+                        Ok(to_ankaios) => {
+                            // [impl->swdd~agent-converts-control-interface-message-to-ankaios-object~1]
+                            match to_ankaios.try_into() {
+                                Ok(ToAnkaios::Request(mut request)) => {
+                                    // [impl->swdd~agent-checks-request-for-authorization~1]
+                                    if self.authorizer.authorize(&request) {
+                                        // [impl->swdd~agent-forward-request-from-control-interface-pipe-to-server~2]
+                                        log::debug!("Allowing request '{:?}' from authorizer '{:?}'", request, self.authorizer);
+                                        request.prefix_request_id(&self.request_id_prefix);
+                                        let _ = self.to_server_sender.send(ToServer::Request(request)).await;
+                                    } else {
+                                        log::info!("Denying request '{:?}' from authorizer '{:?}'", request, self.authorizer);
+                                        // [impl->swdd~agent-responses-to-denied-request-from-control-interface~1]
+                                        // [impl->swdd~agent-responses-to-denied-request-from-control-interface-contains-request-id~1]
+                                        let error = ank_base::Response {
+                                            request_id: request.request_id,
+                                            response_content: Some(ank_base::response::ResponseContent::Error(ank_base::Error {
+                                                message: "Access denied".into(),
+                                            })),
+                                        };
+                                        let _ = self.forward_from_server(error).await;
+                                    }
+                                },
+                                Ok(ToAnkaios::Hello(Hello{protocol_version})) => {
+                                    log::warn!("Received yet another Hello with protocol version '{protocol_version}'");
+                                    if let Err(message) = check_version_compatibility(protocol_version) {
+                                        log::warn!("{message}");
+                                        let _ = self.send_connection_closed(message).await;
+                                        return;
+                                    }
                                 }
-                            },
-                            Ok(ToAnkaios::Hello(Hello{protocol_version})) => {
-                                log::warn!("Received yet another Hello with protocol version '{protocol_version}'");
-                                if let Err(message) = check_version_compatibility(protocol_version) {
-                                    log::warn!("{message}");
-                                    let _ = self.send_connection_closed(message).await;
-                                    return;
+                                Err(error) => {
+                                    log::warn!("Could not convert protobuf in internal data structure: '{error}'");
                                 }
-                            }
-                            Err(error) => {
-                                log::warn!("Could not convert protobuf in internal data structure: '{error}'");
                             }
                         }
-                    } else {
-                        log::warn!("Could not decode to Ankaios data.");
-                        // Beware! There be dragons! This part is needed to test the workloop of the control interface.
-                        // There is no other (proper) possibility to get out of the loop as mockall does not work properly with tasks.
-                        #[cfg(test)]
-                        return;
+                        Err(error) => {
+                            log::warn!("Could not decode to Ankaios data: '{error}'");
+                            // Beware! There be dragons! This part is needed to test the workloop of the control interface.
+                            // There is no other (proper) possibility to get out of the loop as mockall does not work properly with tasks.
+                            #[cfg(test)]
+                            return;
+                        }
                     }
                 }
             }

--- a/agent/src/control_interface/input_pipe.rs
+++ b/agent/src/control_interface/input_pipe.rs
@@ -22,6 +22,9 @@ use tokio::{
     net::unix::pipe::{OpenOptions, Receiver},
 };
 
+/// Maximum allowed size for a control interface message towards the agent.
+pub const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024 - 256;
+
 #[derive(Debug)]
 pub struct InputPipe {
     path: PathBuf,
@@ -60,10 +63,22 @@ impl InputPipe {
         let varint_data = Self::try_read_varint_data(file).await?;
         let mut varint_data = Box::new(&varint_data[..]);
 
-        let size = prost::encoding::decode_varint(&mut varint_data)? as usize;
+        let size = prost::encoding::decode_varint(&mut varint_data)?;
 
-        let mut buf = vec![0; size];
+        // [impl->swdd~agent-rejects-oversized-control-interface-messages~1]
+        if size > MAX_MESSAGE_SIZE as u64 {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "Control Interface message size {size} exceeds the maximum of {} bytes",
+                    MAX_MESSAGE_SIZE
+                ),
+            ));
+        }
+
+        let mut buf = vec![0; size as usize];
         file.read_exact(&mut buf[..]).await?;
+
         Ok(buf)
     }
 
@@ -246,6 +261,47 @@ mod tests {
         }
 
         reading_task.await.unwrap();
+    }
+
+    // [utest->swdd~agent-rejects-oversized-control-interface-messages~1]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_rejects_oversized_message_before_reading_payload() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let fifo = tmpdir.path().join("fifo");
+        mkfifo(&fifo, Mode::S_IRWXU).unwrap();
+        let mut reading_side = super::InputPipe::open(&fifo);
+
+        let reading_task = tokio::spawn(async move { reading_side.read_protobuf_data().await });
+
+        let mut writing_side = super::OpenOptions::new().open_sender(&fifo).unwrap();
+        let mut varint = Vec::new();
+        prost::encoding::encode_varint(super::MAX_MESSAGE_SIZE as u64 + 1, &mut varint);
+        writing_side.write_all(&varint).await.unwrap();
+        writing_side.flush().await.unwrap();
+
+        let error = reading_task.await.unwrap().unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+
+    // [utest->swdd~agent-rejects-oversized-control-interface-messages~1]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_reads_message_at_maximum_size() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let fifo = tmpdir.path().join("fifo");
+        mkfifo(&fifo, Mode::S_IRWXU).unwrap();
+        let mut reading_side = super::InputPipe::open(&fifo);
+
+        let reading_task = tokio::spawn(async move { reading_side.read_protobuf_data().await });
+
+        let mut writing_side = super::OpenOptions::new().open_sender(&fifo).unwrap();
+        let payload = vec![17; super::MAX_MESSAGE_SIZE];
+        let mut data = Vec::new();
+        prost::encoding::encode_varint(super::MAX_MESSAGE_SIZE as u64, &mut data);
+        data.extend_from_slice(&payload);
+        writing_side.write_all(&data).await.unwrap();
+        writing_side.flush().await.unwrap();
+
+        assert_eq!(reading_task.await.unwrap().unwrap(), payload);
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This prevents unbound allocation in the agent that can lead to aborting the agent process by an workload with Control Interface access. Additionally improved the error tracing in case of Control Interface message reading errors.

<!--  Description of the change in case no issue is mentioned -->

# Definition of Done

The PR shall be merged only if all items mentioned in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been followed. In case an item is not applicable as described, please provide a short explanation in the description.

- [x] All steps in [CONTRIBUTING.md](https://github.com/eclipse-ankaios/ankaios/blob/main/CONTRIBUTING.md#how-to-contribute) have been handled
